### PR TITLE
No path folding at high HTL

### DIFF
--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1707,8 +1707,10 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         		return false;
         	}
         	
-            if(!node.canWriteDatastoreRequest(origHTL))
+            if(!node.canWriteDatastoreRequest(origHTL)) {
                 ackOpennet(next);
+                return false;
+            }
         	
 			if(node.addNewOpennetNode(ref, ConnectionType.PATH_FOLDING) == null) {
 				if(logMINOR) Logger.minor(this, "Don't want noderef on "+this);

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1716,7 +1716,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 				// RequestHandler will send a noderef back up, eventually, and will unlockHandler() after that point.
 				// But if this is a local request, we need to send the ack now.
 				// Serious race condition not possible here as we set it.
-				if(source == null)
+				if(!node.canWriteDatastoreRequest(origHTL))
 					ackOpennet(next);
 				else if(origTag.shouldStop()) {
 					// Can't pass it on.

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1708,6 +1708,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         	}
         	
             if(!node.canWriteDatastoreRequest(origHTL)) {
+                // Do not path fold at all at high HTL.
                 ackOpennet(next);
                 return false;
             }

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1720,8 +1720,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 					opennetNoderef = noderef;
 				}
 				// RequestHandler will send a noderef back up, eventually, and will unlockHandler() after that point.
-				// But if this is a local request, we need to send the ack now.
-				// Serious race condition not possible here as we set it.
+				assert(source != null);
 				if(origTag.shouldStop()) {
 					// Can't pass it on.
 					origTag.finishedWaitingForOpennet(next);

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1707,6 +1707,9 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         		return false;
         	}
         	
+            if(!node.canWriteDatastoreRequest(origHTL))
+                ackOpennet(next);
+        	
 			if(node.addNewOpennetNode(ref, ConnectionType.PATH_FOLDING) == null) {
 				if(logMINOR) Logger.minor(this, "Don't want noderef on "+this);
 				// If we don't want it let somebody else have it
@@ -1716,9 +1719,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 				// RequestHandler will send a noderef back up, eventually, and will unlockHandler() after that point.
 				// But if this is a local request, we need to send the ack now.
 				// Serious race condition not possible here as we set it.
-				if(!node.canWriteDatastoreRequest(origHTL))
-					ackOpennet(next);
-				else if(origTag.shouldStop()) {
+				if(origTag.shouldStop()) {
 					// Can't pass it on.
 					origTag.finishedWaitingForOpennet(next);
 				}


### PR DESCRIPTION
For consideration. This would improve security (e.g. no possibility of attacker data source getting directly connected to request originator just by path folding), but it may have negative performance impacts, especially on new nodes who mostly get their peers from doing local requests.
