### PR TITLE
Improve tests in the `freenet.client` package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'maven-publish'
 repositories {
     flatDir { dirs uri("${projectDir}/lib") }
     maven { url 'https://mvn.freenetproject.org' }
-    jcenter()
+    mavenCentral()
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ dependencies {
     compile "org.unbescape:unbescape:1.1.6.RELEASE"
     compile "org.slf4j:slf4j-api:1.7.25"
 
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
     testCompile "org.mockito:mockito-core:1.9.5"
     testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile "org.hamcrest:hamcrest-core:1.3"
@@ -257,7 +257,7 @@ dependencyVerification {
         'net.java.dev.jna:jna-platform:f1d00c167d8921c6e23c626ef9f1c3ae0be473c95c68ffa012bc7ae55a87e2d6',
         'net.java.dev.jna:jna:0c8eb7acf67261656d79005191debaba3b6bf5dd60a43735a245429381dbecff',
         'org.freenetproject:freenet-ext:32f2b3d6beedf54137ea2f9a3ebef67666d769f0966b08cd17fd7db59ba4d79f',
-        'junit:junit:59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a',
+        'junit:junit:8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3',
         'org.mockito:mockito-core:f97483ba0944b9fa133aa29638764ddbeadb51ec3dbc02074c58fa2caecd07fa',
         'org.hamcrest:hamcrest-library:711d64522f9ec410983bd310934296da134be4254a125080a0416ec178dfad1c',
         'org.hamcrest:hamcrest-core:66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9',

--- a/test/freenet/client/CodeTest.java
+++ b/test/freenet/client/CodeTest.java
@@ -15,133 +15,137 @@ import com.onionnetworks.util.Util;
 
 public class CodeTest {
 
-	public static FECMath fecMath = new FECMath(8);
+    public static FECMath fecMath = new FECMath(8);
 
-	public static final int KK = 192;
-	public static final int PACKET_SIZE = 4096;
+    public static final int KK = 192;
+    public static final int PACKET_SIZE = 4096;
 
-	/**
-	 * Creates k packets of size sz of random data, encodes them, and tries to decode. Index
-	 * contains the permutation entry.
-	 */
-	private static final void encodeDecode(FECCode encode, FECCode decode, int index[]) {
-		byte[] src = new byte[KK * PACKET_SIZE];
-		Util.rand.nextBytes(src);
-		Buffer[] srcBufs = new Buffer[KK];
-		for (int i = 0; i < srcBufs.length; i++)
-			srcBufs[i] = new Buffer(src, i * PACKET_SIZE, PACKET_SIZE);
+    /**
+     * Creates k packets of size sz of random data, encodes them, and tries to decode. Index
+     * contains the permutation entry.
+     */
+    private static void encodeDecode(FECCode encode, FECCode decode, int[] index) {
+        byte[] src = new byte[KK * PACKET_SIZE];
+        Util.rand.nextBytes(src);
+        Buffer[] srcBufs = createBuffers(src);
 
-		byte[] repair = new byte[KK * PACKET_SIZE];
-		Buffer[] repairBufs = new Buffer[KK];
-		for (int i = 0; i < repairBufs.length; i++) {
-			repairBufs[i] = new Buffer(repair, i * PACKET_SIZE, PACKET_SIZE);
-		}
+        byte[] repair = new byte[KK * PACKET_SIZE];
+        Buffer[] repairBufs = createBuffers(repair);
 
-		encode.encode(srcBufs, repairBufs, index);
-		decode.decode(repairBufs, index);
+        encode.encode(srcBufs, repairBufs, index);
+        decode.decode(repairBufs, index);
 
-		for (int i = 0; i < src.length; i++)
-			assertEquals(src[i], repair[i]);
-	}
+        assertArrayEquals(src, repair);
+    }
 
-	@Test
-	public void testBenchmark() {
-		if(!TestProperty.BENCHMARK) return;
+    @Test
+    public void testBenchmark() {
+        if (!TestProperty.BENCHMARK) {
+            return;
+        }
 
-		int lim = fecMath.gfSize + 1;
-		FECCode maybeNative = FECCodeFactory.getDefault().createFECCode(KK, lim);
-		FECCode pureCode = new PureCode(KK, lim);
-		int[] index = new int[KK];
+        int lim = fecMath.gfSize + 1;
+        FECCode maybeNative = FECCodeFactory.getDefault().createFECCode(KK, lim);
+        FECCode pureCode = new PureCode(KK, lim);
+        int[] index = new int[KK];
 
-		for (int i = 0; i < KK; i++)
-			index[i] = lim - i - 1;
+        for (int i = 0; i < KK; i++) {
+            index[i] = lim - i - 1;
+        }
 
-		byte[] src = new byte[KK * PACKET_SIZE];
-		Util.rand.nextBytes(src);
-		Buffer[] srcBufs = new Buffer[KK];
-		for (int i = 0; i < srcBufs.length; i++)
-			srcBufs[i] = new Buffer(src, i * PACKET_SIZE, PACKET_SIZE);
+        byte[] src = new byte[KK * PACKET_SIZE];
+        Util.rand.nextBytes(src);
+        Buffer[] srcBufs = createBuffers(src);
 
-		byte[] repair = new byte[KK * PACKET_SIZE];
-		Buffer[] repairBufs = new Buffer[KK];
-		for (int i = 0; i < repairBufs.length; i++) {
-			repairBufs[i] = new Buffer(repair, i * PACKET_SIZE, PACKET_SIZE);
-		}
+        byte[] repair = new byte[KK * PACKET_SIZE];
+        Buffer[] repairBufs = createBuffers(repair);
 
-		int[] indexBackup = new int[index.length];
-		System.arraycopy(index,0,indexBackup,0,index.length);
+        int[] indexBackup = new int[index.length];
+        System.arraycopy(index, 0, indexBackup, 0, index.length);
 
-		System.out.println("Getting ready for benchmarking encode()");
-		long t1 = System.currentTimeMillis();
-		maybeNative.encode(srcBufs, repairBufs, index);
-		long t2 = System.currentTimeMillis();
-		pureCode.encode(srcBufs, repairBufs, indexBackup);
-		long t3 = System.currentTimeMillis();
+        System.out.println("Getting ready for benchmarking encode()");
+        long t1 = System.currentTimeMillis();
+        maybeNative.encode(srcBufs, repairBufs, index);
+        long t2 = System.currentTimeMillis();
+        pureCode.encode(srcBufs, repairBufs, indexBackup);
+        long t3 = System.currentTimeMillis();
 
-		float dNativeEncode = t2 - t1;
-		float dPureEncode = t3 - t2;
+        float dNativeEncode = t2 - t1;
+        float dPureEncode = t3 - t2;
 
-		Buffer[] repairBufs2 = repairBufs.clone();
-		System.arraycopy(repairBufs, 0, repairBufs2, 0, repairBufs.length);
-		System.out.println("Getting ready for benchmarking decode()");
-		t1 = System.currentTimeMillis();
-		maybeNative.decode(repairBufs, index);
-		t2 = System.currentTimeMillis();
-		pureCode.decode(repairBufs2, indexBackup);
-		t3 = System.currentTimeMillis();
+        Buffer[] repairBufs2 = repairBufs.clone();
+        System.arraycopy(repairBufs, 0, repairBufs2, 0, repairBufs.length);
+        System.out.println("Getting ready for benchmarking decode()");
+        t1 = System.currentTimeMillis();
+        maybeNative.decode(repairBufs, index);
+        t2 = System.currentTimeMillis();
+        pureCode.decode(repairBufs2, indexBackup);
+        t3 = System.currentTimeMillis();
 
-		float dNativeDecode = t2 - t1;
-		float dPureDecode = t3 - t2;
+        float dNativeDecode = t2 - t1;
+        float dPureDecode = t3 - t2;
 
-		System.out.println(maybeNative);
-		System.out.println(pureCode);
-		System.out.println("Native code took "+dNativeEncode+"ms whereas java's code took "+dPureEncode+"ms to encode()");
-		System.out.println("Native code took "+dNativeDecode+"ms whereas java's code took "+dPureDecode+"ms to decode()");
-	}
+        System.out.println(maybeNative);
+        System.out.println(pureCode);
+        System.out.println("Native code took " + dNativeEncode + "ms whereas java's code took " + dPureEncode + "ms to encode()");
+        System.out.println("Native code took " + dNativeDecode + "ms whereas java's code took " + dPureDecode + "ms to decode()");
+    }
 
-	@Test
-	public void testSimpleRev() {
-		int lim = fecMath.gfSize + 1;
-		FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
-		FECCode code2 = new PureCode(KK, lim);
-		int[] index = new int[KK];
+    @Test
+    public void testSimpleRev() {
+        int lim = fecMath.gfSize + 1;
+        FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
+        FECCode code2 = new PureCode(KK, lim);
+        int[] index = new int[KK];
 
-		for (int i = 0; i < KK; i++)
-			index[i] = lim - i - 1;
+        for (int i = 0; i < KK; i++) {
+            index[i] = lim - i - 1;
+        }
 
-		encodeDecode(code, code2, index);
-		encodeDecode(code2, code, index);
-	}
+        encodeDecode(code, code2, index);
+        encodeDecode(code2, code, index);
+    }
 
-	@Test
-	public void testSimple() {
-		int lim = fecMath.gfSize + 1;
-		FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
-		FECCode code2 = new PureCode(KK, lim);
-		int[] index = new int[KK];
+    @Test
+    public void testSimple() {
+        int lim = fecMath.gfSize + 1;
+        FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
+        FECCode code2 = new PureCode(KK, lim);
+        int[] index = new int[KK];
 
-		for (int i = 0; i < KK; i++)
-			index[i] = KK - i;
-		encodeDecode(code, code2, index);
-		encodeDecode(code2, code, index);
-	}
+        for (int i = 0; i < KK; i++) {
+            index[i] = KK - i;
+        }
+        encodeDecode(code, code2, index);
+        encodeDecode(code2, code, index);
+    }
 
-	@Test
-	public void testShifted() {
-		int lim = fecMath.gfSize + 1;
-		FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
-		FECCode code2 = new PureCode(KK, lim);
-		int[] index = new int[KK];
+    @Test
+    public void testShifted() {
+        int lim = fecMath.gfSize + 1;
+        FECCode code = FECCodeFactory.getDefault().createFECCode(KK, lim);
+        FECCode code2 = new PureCode(KK, lim);
+        int[] index = new int[KK];
 
-		int max_i0 = KK / 2;
-		if (max_i0 + KK > lim)
-			max_i0 = lim - KK;
+        int max_i0 = KK / 2;
+        if (max_i0 + KK > lim) {
+            max_i0 = lim - KK;
+        }
 
-		for (int s = max_i0 - 2; s <= max_i0; s++) {
-			for (int i = 0; i < KK; i++)
-				index[i] = i + s;
-			encodeDecode(code, code2, index);
-			encodeDecode(code2, code, index);
-		}
-	}
+        for (int s = max_i0 - 2; s <= max_i0; s++) {
+            for (int i = 0; i < KK; i++) {
+                index[i] = i + s;
+            }
+            encodeDecode(code, code2, index);
+            encodeDecode(code2, code, index);
+        }
+    }
+
+    private static Buffer[] createBuffers(byte[] src) {
+        Buffer[] srcBufs = new Buffer[KK];
+        for (int i = 0; i < srcBufs.length; i++) {
+            srcBufs[i] = new Buffer(src, i * PACKET_SIZE, PACKET_SIZE);
+        }
+        return srcBufs;
+    }
 }

--- a/test/freenet/client/DefaultMIMETypesTest.java
+++ b/test/freenet/client/DefaultMIMETypesTest.java
@@ -5,18 +5,18 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class DefaultMIMETypesTest {
-	
-	@Test
-	public void testFullList() {
-		for(String mimeType : DefaultMIMETypes.getMIMETypes()) {
-			assertTrue("Failed: \""+mimeType+"\"", DefaultMIMETypes.isPlausibleMIMEType(mimeType));
-		}
-	}
-	
-	@Test
-	public void testParams() {
-		assertTrue(DefaultMIMETypes.isPlausibleMIMEType("text/xhtml+xml; charset=ISO-8859-1; blah=blah"));
-		assertTrue(DefaultMIMETypes.isPlausibleMIMEType("multipart/mixed; boundary=\"---this is a silly boundary---\""));
-	}
+
+    @Test
+    public void testFullList() {
+        for (String mimeType : DefaultMIMETypes.getMIMETypes()) {
+            assertTrue("Failed: \"" + mimeType + "\"", DefaultMIMETypes.isPlausibleMIMEType(mimeType));
+        }
+    }
+
+    @Test
+    public void testParams() {
+        assertTrue(DefaultMIMETypes.isPlausibleMIMEType("text/xhtml+xml; charset=ISO-8859-1; blah=blah"));
+        assertTrue(DefaultMIMETypes.isPlausibleMIMEType("multipart/mixed; boundary=\"---this is a silly boundary---\""));
+    }
 
 }

--- a/test/freenet/client/FailureCodeTrackerTest.java
+++ b/test/freenet/client/FailureCodeTrackerTest.java
@@ -32,13 +32,11 @@ public class FailureCodeTrackerTest {
     }
 
     private int getStoredLength(FailureCodeTracker f) throws IOException {
-        try (
-            CountedOutputStream os = new CountedOutputStream(new NullOutputStream());
-            DataOutputStream dos = new DataOutputStream(os)
-        ) {
+        CountedOutputStream os = new CountedOutputStream(new NullOutputStream());
+        try (DataOutputStream dos = new DataOutputStream(os)) {
             f.writeFixedLengthTo(dos);
-            return (int) os.written();
         }
+        return (int) os.written();
     }
 
 }

--- a/test/freenet/client/FailureCodeTrackerTest.java
+++ b/test/freenet/client/FailureCodeTrackerTest.java
@@ -12,13 +12,15 @@ import freenet.support.io.NullOutputStream;
 
 public class FailureCodeTrackerTest {
 
-    /** Test that the fixed size representation really is fixed size */
+    /**
+     * Test that the fixed size representation really is fixed size
+     */
     @Test
     public void testSize() throws IOException {
         testSize(false);
         testSize(true);
     }
-    
+
     public void testSize(boolean insert) throws IOException {
         FailureCodeTracker f = new FailureCodeTracker(insert);
         int fixedLength = FailureCodeTracker.getFixedLength(insert);
@@ -30,11 +32,13 @@ public class FailureCodeTrackerTest {
     }
 
     private int getStoredLength(FailureCodeTracker f) throws IOException {
-        CountedOutputStream os = new CountedOutputStream(new NullOutputStream());
-        DataOutputStream dos = new DataOutputStream(os);
-        f.writeFixedLengthTo(dos);
-        dos.close();
-        return (int) os.written();
+        try (
+            CountedOutputStream os = new CountedOutputStream(new NullOutputStream());
+            DataOutputStream dos = new DataOutputStream(os)
+        ) {
+            f.writeFixedLengthTo(dos);
+            return (int) os.written();
+        }
     }
 
 }

--- a/test/freenet/client/FetchContextTest.java
+++ b/test/freenet/client/FetchContextTest.java
@@ -23,7 +23,7 @@ public class FetchContextTest {
             new ArrayBucketFactory(),
             new SimpleEventProducer()
         );
-        final ArrayBucket bucket = new ArrayBucket();
+        ArrayBucket bucket = new ArrayBucket();
         try {
             try (DataOutputStream dos = new DataOutputStream(bucket.getOutputStream())) {
                 context.writeTo(dos);

--- a/test/freenet/client/FetchContextTest.java
+++ b/test/freenet/client/FetchContextTest.java
@@ -14,22 +14,28 @@ import freenet.support.io.ArrayBucketFactory;
 import freenet.support.io.StorageFormatException;
 
 public class FetchContextTest {
-    
+
     @Test
     public void testPersistence() throws IOException, StorageFormatException {
-        FetchContext context = 
-            HighLevelSimpleClientImpl.makeDefaultFetchContext(Long.MAX_VALUE, Long.MAX_VALUE, 
-                    new ArrayBucketFactory(), new SimpleEventProducer());
-        ArrayBucket bucket = new ArrayBucket();
-        DataOutputStream dos = new DataOutputStream(bucket.getOutputStream());
-        context.writeTo(dos);
-        dos.close();
-        assert(bucket.size() != 0);
-        DataInputStream dis = new DataInputStream(bucket.getInputStream());
-        FetchContext ctx = new FetchContext(dis);
-        dis.close();
-        assertTrue(ctx.equals(context));
-        bucket.free();
+        FetchContext context = HighLevelSimpleClientImpl.makeDefaultFetchContext(
+            Long.MAX_VALUE,
+            Long.MAX_VALUE,
+            new ArrayBucketFactory(),
+            new SimpleEventProducer()
+        );
+        final ArrayBucket bucket = new ArrayBucket();
+        try {
+            try (DataOutputStream dos = new DataOutputStream(bucket.getOutputStream())) {
+                context.writeTo(dos);
+            }
+            assertNotEquals(0, bucket.size());
+            FetchContext ctx;
+            try (DataInputStream dis = new DataInputStream(bucket.getInputStream())) {
+                ctx = new FetchContext(dis);
+            }
+            assertEquals(ctx, context);
+        } finally {
+            bucket.free();
+        }
     }
-
 }

--- a/test/freenet/client/OnionFECCodecTest.java
+++ b/test/freenet/client/OnionFECCodecTest.java
@@ -5,16 +5,18 @@ import static org.junit.Assert.*;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import freenet.support.TestProperty;
 
-/** Test the new (post db4o) high level FEC API */
+/**
+ * Test the new (post db4o) high level FEC API
+ */
 public class OnionFECCodecTest {
-    
+
     private static final int BLOCK_SIZE = 4096;
-    private static final int MAX_SEGMENT_SIZE = 255;
-    
+
     private final OnionFECCodec codec = new OnionFECCodec();
     private byte[][] originalDataBlocks;
     private byte[][] dataBlocks;
@@ -22,150 +24,151 @@ public class OnionFECCodecTest {
     private byte[][] checkBlocks;
     private boolean[] checkBlocksPresent;
     private boolean[] dataBlocksPresent;
-    
+    private Random random;
+
+    @Before
+    public void setUp() throws Exception {
+        random = new Random(21482106);
+    }
+
     @Test
     public void testDecodeRandomSubset() {
-        Random r = new Random(19412106);
         int iterations = TestProperty.EXTENSIVE ? 100 : 10;
-        for(int i=0;i<iterations;i++)
-            inner(128, 128, r);
-        for(int i=0;i<iterations;i++)
-            inner(127, 129, r);
-        for(int i=0;i<iterations;i++)
-            inner(129, 127, r);
+        for (int i = 0; i < iterations; i++) {
+            inner(128, 128, random);
+        }
+        for (int i = 0; i < iterations; i++) {
+            inner(127, 129, random);
+        }
+        for (int i = 0; i < iterations; i++) {
+            inner(129, 127, random);
+        }
     }
-    
+
     @Test
     public void testEncodeThrowsOnNotPaddedLastBlock() {
-        Random r = new Random(21502106);
         int data = 128;
         int check = 128;
-        originalDataBlocks = createOriginalDataBlocks(r, data);
-        originalDataBlocks[data-1] = new byte[BLOCK_SIZE/2];
+        originalDataBlocks = createOriginalDataBlocks(random, data);
+        originalDataBlocks[data - 1] = new byte[BLOCK_SIZE / 2];
         checkBlocks = setupCheckBlocks(check);
         dataBlocks = copy(originalDataBlocks);
-        
+
         // Encode the check blocks.
         checkBlocksPresent = new boolean[checkBlocks.length];
-        try {
-            codec.encode(dataBlocks, checkBlocks, checkBlocksPresent, BLOCK_SIZE);
-            assertTrue(false); // Should throw here!
-        } catch (IllegalArgumentException e) {
-            // Expected.
-        }
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> codec.encode(dataBlocks, checkBlocks, checkBlocksPresent, BLOCK_SIZE)
+        );
     }
-    
+
     @Test
     public void testDecodeThrowsOnNotPaddedLastBlock() {
-        Random r = new Random(21482106);
-        setup(128, 128, r);
+        setup(128, 128, random);
         // Now delete a random selection of blocks
-        deleteRandomBlocks(r);
-        dataBlocks[127] = new byte[BLOCK_SIZE/2];
-        try {
-            codec.decode(dataBlocks, checkBlocks, dataBlocksPresent, checkBlocksPresent, BLOCK_SIZE);
-            assertTrue(false); // Should throw
-        } catch (IllegalArgumentException e) {
-            // Ok.
-        }
+        deleteRandomBlocks(random);
+        dataBlocks[127] = new byte[BLOCK_SIZE / 2];
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> codec.encode(dataBlocks, checkBlocks, checkBlocksPresent, BLOCK_SIZE)
+        );
     }
-    
+
     @Test
     public void testDecodeAlreadyDecoded() {
-        Random r = new Random(21482106);
-        setup(128, 128, r);
+        setup(128, 128, random);
         // Now delete a random selection of blocks
         deleteAllCheckBlocks();
         decode(); // Should be a no-op.
     }
-    
+
     @Test
     public void testDecodeNoneDecoded() {
-        Random r = new Random(21482106);
-        setup(128, 128, r);
+        setup(128, 128, random);
         // Now delete a random selection of blocks
         deleteAllDataBlocks();
         decode();
     }
-    
+
     @Test
     public void testManyCheckFewData() {
-        Random r = new Random(21582106);
-        inner(2, 253, r);
-        inner(5, 250, r);
-        inner(50, 200, r);
-        inner(2, 3, r); // Common case, include it here.
+        inner(2, 253, random);
+        inner(5, 250, random);
+        inner(50, 200, random);
+        inner(2, 3, random); // Common case, include it here.
     }
-    
+
     @Test
     public void testManyDataFewCheck() {
-        Random r = new Random(21592106);
-        inner(200, 55, r);
-        inner(253, 2, r);
+        inner(200, 55, random);
+        inner(253, 2, random);
     }
-    
+
     @Test
     public void testRandomDataCheckCounts() {
-        Random r = new Random(21602106);
         int iterations = TestProperty.EXTENSIVE ? 100 : 10;
-        for(int i=0;i<iterations;i++) {
-            int data = r.nextInt(252)+2;
+        for (int i = 0; i < iterations; i++) {
+            int data = random.nextInt(252) + 2;
             int maxCheck = 255 - data;
-            int check = r.nextInt(maxCheck)+1;
-            inner(data, check, r);
+            int check = random.nextInt(maxCheck) + 1;
+            inner(data, check, random);
         }
     }
-    
+
     protected void inner(int data, int check, Random r) {
         setup(data, check, r);
         // Now delete a random selection of blocks
         deleteRandomBlocks(r);
         decode();
     }
-    
+
     protected void setup(int data, int check, Random r) {
         originalDataBlocks = createOriginalDataBlocks(r, data);
         checkBlocks = setupCheckBlocks(check);
         dataBlocks = copy(originalDataBlocks);
-        
+
         // Encode the check blocks.
         checkBlocksPresent = new boolean[checkBlocks.length];
         codec.encode(dataBlocks, checkBlocks, checkBlocksPresent, BLOCK_SIZE);
         assertBlockArrayEquals(originalDataBlocks, dataBlocks);
         originalCheckBlocks = copy(checkBlocks);
-        
+
         // Initially everything is present...
         dataBlocksPresent = new boolean[dataBlocks.length];
-        for(int i=0;i<dataBlocksPresent.length;i++) dataBlocksPresent[i] = true;
-        for(int i=0;i<checkBlocksPresent.length;i++) checkBlocksPresent[i] = true;
+        Arrays.fill(dataBlocksPresent, true);
+        Arrays.fill(checkBlocksPresent, true);
     }
-    
+
     protected void decode() {
         boolean[] oldDataBlocksPresent = dataBlocksPresent.clone();
         boolean[] oldCheckBlocksPresent = checkBlocksPresent.clone();
         codec.decode(dataBlocks, checkBlocks, dataBlocksPresent, checkBlocksPresent, BLOCK_SIZE);
         assertBlockArrayEquals(originalDataBlocks, dataBlocks);
-        assertTrue(Arrays.equals(oldDataBlocksPresent, dataBlocksPresent));
-        assertTrue(Arrays.equals(oldCheckBlocksPresent, checkBlocksPresent));
-        for(int i=0;i<dataBlocksPresent.length;i++) dataBlocksPresent[i] = true;
+        assertArrayEquals(oldDataBlocksPresent, dataBlocksPresent);
+        assertArrayEquals(oldCheckBlocksPresent, checkBlocksPresent);
+        Arrays.fill(dataBlocksPresent, true);
         codec.encode(dataBlocks, checkBlocks, checkBlocksPresent, BLOCK_SIZE);
         assertBlockArrayEquals(originalCheckBlocks, checkBlocks);
-        assertTrue(Arrays.equals(oldCheckBlocksPresent, checkBlocksPresent));
+        assertArrayEquals(oldCheckBlocksPresent, checkBlocksPresent);
     }
-    
+
     private void deleteRandomBlocks(Random r) {
         int dropped = 0;
         int data = dataBlocks.length;
         int check = checkBlocks.length;
-        while(dropped < check) {
-            int blockNo = r.nextInt(data+check);
-            if(blockNo < data) {
-                if(!dataBlocksPresent[blockNo]) continue;
+        while (dropped < check) {
+            int blockNo = r.nextInt(data + check);
+            if (blockNo < data) {
+                if (!dataBlocksPresent[blockNo]) {
+                    continue;
+                }
                 clear(dataBlocks, blockNo);
                 dataBlocksPresent[blockNo] = false;
             } else {
                 blockNo -= data;
-                if(!checkBlocksPresent[blockNo]) continue;
+                if (!checkBlocksPresent[blockNo]) {
+                    continue;
+                }
                 clear(checkBlocks, blockNo);
                 checkBlocksPresent[blockNo] = false;
             }
@@ -174,50 +177,50 @@ public class OnionFECCodecTest {
     }
 
     private void clear(byte[][] dataBlocks, int blockNo) {
-        Arrays.fill(dataBlocks[blockNo], (byte)0);
-   }
+        Arrays.fill(dataBlocks[blockNo], (byte) 0);
+    }
 
     protected byte[][] createOriginalDataBlocks(Random r, int count) {
         byte[][] blocks = new byte[count][];
-        for(int i=0;i<count;i++) {
+        for (int i = 0; i < count; i++) {
             blocks[i] = new byte[BLOCK_SIZE];
             r.nextBytes(blocks[i]);
         }
         return blocks;
     }
-    
+
     protected byte[][] setupCheckBlocks(int count) {
         byte[][] blocks = new byte[count][];
-        for(int i=0;i<count;i++) {
+        for (int i = 0; i < count; i++) {
             blocks[i] = new byte[BLOCK_SIZE];
         }
         return blocks;
     }
-    
+
     protected byte[][] copy(byte[][] blocks) {
-        byte[][] ret = new byte[blocks.length][]; // FIXME would blocks.clone() shallow or deep copy?
-        for(int i=0;i<ret.length;i++) {
-            ret[i] = blocks[i].clone();
+        byte[][] ret = new byte[blocks.length][];
+        for (int i = 0; i < ret.length; i++) {
+            ret[i] = Arrays.copyOf(blocks[i], blocks[i].length);
         }
         return ret;
     }
-    
+
     private void assertBlockArrayEquals(byte[][] blocks1, byte[][] blocks2) {
         assertEquals(blocks1.length, blocks2.length);
-        for(int i=0;i<blocks1.length;i++) {
-            assertTrue(Arrays.equals(blocks1[i], blocks2[i]));
+        for (int i = 0; i < blocks1.length; i++) {
+            assertArrayEquals(blocks1[i], blocks2[i]);
         }
     }
-    
+
     private void deleteAllDataBlocks() {
-        for(int i=0;i<dataBlocks.length;i++) {
+        for (int i = 0; i < dataBlocks.length; i++) {
             clear(dataBlocks, i);
             dataBlocksPresent[i] = false;
         }
     }
 
     private void deleteAllCheckBlocks() {
-        for(int i=0;i<checkBlocks.length;i++) {
+        for (int i = 0; i < checkBlocks.length; i++) {
             clear(checkBlocks, i);
             checkBlocksPresent[i] = false;
         }

--- a/test/freenet/client/async/SplitFileFetcherStorageTest.java
+++ b/test/freenet/client/async/SplitFileFetcherStorageTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,24 +58,17 @@ import freenet.support.io.NativeThread;
 import freenet.support.io.StorageFormatException;
 
 public class SplitFileFetcherStorageTest {
-    
-    // Setup code is considerable. See below for actual tests ...
-    
-    static DummyRandomSource random;
-    static final KeySalter salt = new KeySalter() {
 
-        @Override
-        public byte[] saltKey(Key key) {
-            return key.getRoutingKey();
-        }
-        
-    };
+    // Setup code is considerable. See below for actual tests ...
+
+    static DummyRandomSource random;
+    static final KeySalter salt = Key::getRoutingKey;
     static BucketFactory bf = new ArrayBucketFactory();
     static LockableRandomAccessBufferFactory rafFactory = new ByteArrayRandomAccessBufferFactory();
     static final WaitableExecutor exec = new WaitableExecutor(new PooledExecutor());
     static final PersistentJobRunner jobRunner = new DummyJobRunner(exec, null);
     static final Ticker ticker = new CheatingTicker(exec);
-    static MemoryLimitedJobRunner memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 20, exec, NativeThread.JAVA_PRIORITY_RANGE);
+    static MemoryLimitedJobRunner memoryLimitedJobRunner = new MemoryLimitedJobRunner(9 * 1024 * 1024L, 20, exec, NativeThread.JAVA_PRIORITY_RANGE);
     static final int BLOCK_SIZE = CHKBlock.DATA_LENGTH;
     private static final OnionFECCodec codec = new OnionFECCodec();
     private static final int MAX_SEGMENT_SIZE = 256;
@@ -82,15 +76,15 @@ public class SplitFileFetcherStorageTest {
     static final CompatibilityMode COMPATIBILITY_MODE = InsertContext.CompatibilityMode.COMPAT_1416;
     static FreenetURI URI;
     private static final List<COMPRESSOR_TYPE> NO_DECOMPRESSORS = Collections.emptyList();
-    
+
     @Before
     public void setUp() {
         // Reset RNG for each test (it's static so not reset by junit).
         random = new DummyRandomSource(1234);
         URI = FreenetURI.generateRandomCHK(random);
     }
-    
-    static class TestSplitfile {
+
+    private static class TestSplitfile {
         final Bucket originalData;
         final Metadata metadata;
         final byte[][] dataBlocks;
@@ -103,11 +97,11 @@ public class SplitFileFetcherStorageTest {
         private final int[] segmentCheckBlockCount;
         private final boolean persistent;
         final MyKeysFetchingLocally fetchingKeys;
-        
+
         private TestSplitfile(Bucket data, Metadata m, byte[][] originalDataBlocks,
-                byte[][] originalCheckBlocks, ClientCHK[] dataKeys, ClientCHK[] checkKeys,
-                byte[] cryptoKey, byte cryptoAlgorithm, int[] segmentDataBlockCount, 
-                int[] segmentCheckBlockCount, boolean persistent) {
+                              byte[][] originalCheckBlocks, ClientCHK[] dataKeys, ClientCHK[] checkKeys,
+                              byte[] cryptoKey, byte cryptoAlgorithm, int[] segmentDataBlockCount,
+                              int[] segmentCheckBlockCount, boolean persistent) {
             this.originalData = data;
             this.metadata = m;
             this.dataBlocks = originalDataBlocks;
@@ -121,14 +115,14 @@ public class SplitFileFetcherStorageTest {
             this.persistent = persistent;
             this.fetchingKeys = new MyKeysFetchingLocally();
         }
-        
+
         void free() {
             originalData.free();
         }
 
-        static TestSplitfile constructSingleSegment(long size, int checkBlocks, String mime, boolean persistent) throws IOException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException {
+        static TestSplitfile constructSingleSegment(long size, int checkBlocks, boolean persistent) throws IOException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException {
             assertTrue(checkBlocks <= MAX_SEGMENT_SIZE);
-            assertTrue(size < MAX_SEGMENT_SIZE * (long)BLOCK_SIZE);
+            assertTrue(size < MAX_SEGMENT_SIZE * (long) BLOCK_SIZE);
             Bucket data = makeRandomBucket(size);
             byte[][] originalDataBlocks = splitAndPadBlocks(data, size);
             int dataBlocks = originalDataBlocks.length;
@@ -136,17 +130,18 @@ public class SplitFileFetcherStorageTest {
             assertTrue(dataBlocks + checkBlocks <= MAX_SEGMENT_SIZE);
             byte[][] originalCheckBlocks = constructBlocks(checkBlocks);
             codec.encode(originalDataBlocks, originalCheckBlocks, falseArray(checkBlocks), BLOCK_SIZE);
-            ClientMetadata cm = new ClientMetadata(mime);
+            ClientMetadata cm = new ClientMetadata(null);
             // FIXME no hashes for now.
             // FIXME no compression for now.
             byte[] cryptoKey = randomKey();
             byte cryptoAlgorithm = Key.ALGO_AES_CTR_256_SHA256;
             ClientCHK[] dataKeys = makeKeys(originalDataBlocks, cryptoKey, cryptoAlgorithm);
             ClientCHK[] checkKeys = makeKeys(originalCheckBlocks, cryptoKey, cryptoAlgorithm);
-            Metadata m = new Metadata(SplitfileAlgorithm.ONION_STANDARD, dataKeys, checkKeys, dataBlocks, 
-                    checkBlocks, 0, cm, size, null, null, size, false, null, null, size, size, dataBlocks, 
-                    dataBlocks + checkBlocks, false, COMPATIBILITY_MODE, 
-                    cryptoAlgorithm, cryptoKey, true, 0);
+            Metadata m = new Metadata(SplitfileAlgorithm.ONION_STANDARD, dataKeys, checkKeys, dataBlocks,
+                checkBlocks, 0, cm, size, null, null, size, false, null, null, size, size, dataBlocks,
+                dataBlocks + checkBlocks, false, COMPATIBILITY_MODE,
+                cryptoAlgorithm, cryptoKey, true, 0
+            );
             // Make sure the metadata is reusable.
             // FIXME also necessary as the above constructor doesn't set segments.
             Bucket metaBucket = m.toBucket(bf);
@@ -155,36 +150,37 @@ public class SplitFileFetcherStorageTest {
             assertTrue(BucketTools.equalBuckets(metaBucket, copyBucket));
             metaBucket.free();
             copyBucket.free();
-            return new TestSplitfile(data, m1, originalDataBlocks, originalCheckBlocks, dataKeys, checkKeys, 
-                    cryptoKey, cryptoAlgorithm, null, null, persistent);
+            return new TestSplitfile(data, m1, originalDataBlocks, originalCheckBlocks, dataKeys, checkKeys,
+                cryptoKey, cryptoAlgorithm, null, null, persistent
+            );
         }
 
         /**
-         * Create a multi-segment test splitfile. The main complication with multi-segment is that we can't 
+         * Create a multi-segment test splitfile. The main complication with multi-segment is that we can't
          * choose the number of blocks in each segment arbitrarily; that depends on the metadata format; the
          * caller must ensure that the number are consistent.
+         *
          * @param size
-         * @param segmentDataBlockCount The actual number of data blocks in each segment. Must be consistent 
-         * with the other parameters; this cannot be chosen freely due to the metadata format.
-         * @param segmentCheckBlockCount The actual number of check blocks in each segment. Must be consistent 
-         * with the other parameters; this cannot be chosen freely due to the metadata format. 
-         * @param segmentSize The "typical" number of data blocks in a segment.
-         * @param checkSegmentSize The "typical" number of check blocks in a segment.
+         * @param segmentDataBlockCount    The actual number of data blocks in each segment. Must be consistent
+         *                                 with the other parameters; this cannot be chosen freely due to the metadata format.
+         * @param segmentCheckBlockCount   The actual number of check blocks in each segment. Must be consistent
+         *                                 with the other parameters; this cannot be chosen freely due to the metadata format.
+         * @param segmentSize              The "typical" number of data blocks in a segment.
+         * @param checkSegmentSize         The "typical" number of check blocks in a segment.
          * @param deductBlocksFromSegments The number of segments from which a single block has been deducted.
-         * This is used when the number of data blocks isn't an exact multiple of the number of segments.
-         * @param topCompatibilityMode The "short" value of the definitive compatibility mode used to create
-         * the splitfile. This must again be consistent with the rest, as it is sometimes used in decoding.
-         * @param mime
+         *                                 This is used when the number of data blocks isn't an exact multiple of the number of segments.
+         * @param topCompatibilityMode     The "short" value of the definitive compatibility mode used to create
+         *                                 the splitfile. This must again be consistent with the rest, as it is sometimes used in decoding.
          * @return
          * @throws IOException
          * @throws CHKEncodeException
          * @throws MetadataUnresolvedException
          * @throws MetadataParseException
          */
-        static TestSplitfile constructMultipleSegments(long size, int[] segmentDataBlockCount, 
-                int[] segmentCheckBlockCount, int segmentSize, int checkSegmentSize, 
-                int deductBlocksFromSegments, CompatibilityMode topCompatibilityMode, String mime, boolean persistent) 
-        throws IOException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException {
+        static TestSplitfile constructMultipleSegments(long size, int[] segmentDataBlockCount,
+                                                       int[] segmentCheckBlockCount, int segmentSize, int checkSegmentSize,
+                                                       int deductBlocksFromSegments, CompatibilityMode topCompatibilityMode)
+            throws IOException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException {
             int dataBlocks = sum(segmentDataBlockCount);
             int checkBlocks = sum(segmentCheckBlockCount);
             int segments = segmentDataBlockCount.length;
@@ -195,25 +191,26 @@ public class SplitFileFetcherStorageTest {
             byte[][] originalCheckBlocks = constructBlocks(checkBlocks);
             int startDataBlock = 0;
             int startCheckBlock = 0;
-            for(int seg=0;seg<segments;seg++) {
+            for (int seg = 0; seg < segments; seg++) {
                 byte[][] segmentDataBlocks = Arrays.copyOfRange(originalDataBlocks, startDataBlock, startDataBlock + segmentDataBlockCount[seg]);
                 byte[][] segmentCheckBlocks = Arrays.copyOfRange(originalCheckBlocks, startCheckBlock, startCheckBlock + segmentCheckBlockCount[seg]);
                 codec.encode(segmentDataBlocks, segmentCheckBlocks, falseArray(segmentCheckBlocks.length), BLOCK_SIZE);
                 startDataBlock += segmentDataBlockCount[seg];
                 startCheckBlock += segmentCheckBlockCount[seg];
             }
-            ClientMetadata cm = new ClientMetadata(mime);
+            ClientMetadata cm = new ClientMetadata(null);
             // FIXME no hashes for now.
             // FIXME no compression for now.
             byte[] cryptoKey = randomKey();
             byte cryptoAlgorithm = Key.ALGO_AES_CTR_256_SHA256;
             ClientCHK[] dataKeys = makeKeys(originalDataBlocks, cryptoKey, cryptoAlgorithm);
             ClientCHK[] checkKeys = makeKeys(originalCheckBlocks, cryptoKey, cryptoAlgorithm);
-            Metadata m = new Metadata(SplitfileAlgorithm.ONION_STANDARD, dataKeys, checkKeys, segmentSize, 
-                    checkSegmentSize, deductBlocksFromSegments, cm, size, null, null, size, false, null, null, 
-                    size, size, dataBlocks, dataBlocks + checkBlocks, false, topCompatibilityMode, 
-                    cryptoAlgorithm, cryptoKey, true /* FIXME try older splitfiles pre-single-key?? */, 
-                    0);
+            Metadata m = new Metadata(SplitfileAlgorithm.ONION_STANDARD, dataKeys, checkKeys, segmentSize,
+                checkSegmentSize, deductBlocksFromSegments, cm, size, null, null, size, false, null, null,
+                size, size, dataBlocks, dataBlocks + checkBlocks, false, topCompatibilityMode,
+                cryptoAlgorithm, cryptoKey, true /* FIXME try older splitfiles pre-single-key?? */,
+                0
+            );
             // Make sure the metadata is reusable.
             // FIXME also necessary as the above constructor doesn't set segments.
             Bucket metaBucket = m.toBucket(bf);
@@ -222,43 +219,45 @@ public class SplitFileFetcherStorageTest {
             assertTrue(BucketTools.equalBuckets(metaBucket, copyBucket));
             metaBucket.free();
             copyBucket.free();
-            return new TestSplitfile(data, m1, originalDataBlocks, originalCheckBlocks, dataKeys, checkKeys, 
-                    cryptoKey, cryptoAlgorithm, segmentDataBlockCount, segmentCheckBlockCount, persistent);
+            return new TestSplitfile(data, m1, originalDataBlocks, originalCheckBlocks, dataKeys, checkKeys,
+                cryptoKey, cryptoAlgorithm, segmentDataBlockCount, segmentCheckBlockCount, false
+            );
         }
-        
+
         public CHKBlock encodeDataBlock(int i) throws CHKEncodeException {
             return ClientCHKBlock.encodeSplitfileBlock(dataBlocks[i], cryptoKey, cryptoAlgorithm).getBlock();
         }
-        
+
         public CHKBlock encodeCheckBlock(int i) throws CHKEncodeException {
             return ClientCHKBlock.encodeSplitfileBlock(checkBlocks[i], cryptoKey, cryptoAlgorithm).getBlock();
         }
-        
+
         public CHKBlock encodeBlock(int block) throws CHKEncodeException {
-            if(block < dataBlocks.length)
+            if (block < dataBlocks.length) {
                 return encodeDataBlock(block);
-            else
+            } else {
                 return encodeCheckBlock(block - dataBlocks.length);
+            }
         }
 
         public int findCheckBlock(byte[] data, int start) {
             start++;
-            for(int i=start;i<checkBlocks.length;i++) {
-                if(checkBlocks[i] == data) return i;
+            for (int i = start; i < checkBlocks.length; i++) {
+                if (checkBlocks[i] == data) return i;
             }
-            for(int i=start;i<checkBlocks.length;i++) {
-                if(Arrays.equals(checkBlocks[i], data)) return i;
+            for (int i = start; i < checkBlocks.length; i++) {
+                if (Arrays.equals(checkBlocks[i], data)) return i;
             }
             return -1;
         }
 
         public int findDataBlock(byte[] data, int start) {
             start++;
-            for(int i=start;i<dataBlocks.length;i++) {
-                if(dataBlocks[i] == data) return i;
+            for (int i = start; i < dataBlocks.length; i++) {
+                if (dataBlocks[i] == data) return i;
             }
-            for(int i=start;i<dataBlocks.length;i++) {
-                if(Arrays.equals(dataBlocks[i], data)) return i;
+            for (int i = start; i < dataBlocks.length; i++) {
+                if (Arrays.equals(dataBlocks[i], data)) return i;
             }
             return -1;
         }
@@ -266,7 +265,7 @@ public class SplitFileFetcherStorageTest {
         public StorageCallback createStorageCallback() {
             return new StorageCallback(this);
         }
-        
+
         public SplitFileFetcherStorage createStorage(StorageCallback cb) throws FetchException, MetadataParseException, IOException {
             return createStorage(cb, makeFetchContext());
         }
@@ -282,90 +281,108 @@ public class SplitFileFetcherStorageTest {
                 }
 
                 @Override
-                public LockableRandomAccessBuffer makeRAF(byte[] initialContents, int offset,
-                        int size, boolean readOnly) throws IOException {
+                public LockableRandomAccessBuffer makeRAF(
+                    byte[] initialContents,
+                    int offset,
+                    int size,
+                    boolean readOnly
+                ) throws IOException {
                     LockableRandomAccessBuffer t = rafFactory.makeRAF(initialContents, offset, size, readOnly);
                     cb.snoopRAF(t);
                     return t;
                 }
-                
+
             };
             return new SplitFileFetcherStorage(metadata, cb, NO_DECOMPRESSORS, metadata.getClientMetadata(), false,
-                    (short) COMPATIBILITY_MODE.ordinal(), ctx, false, salt, URI, URI, true, new byte[0], random, bf,
-                    f, jobRunner, ticker, memoryLimitedJobRunner, new CRCChecksumChecker(), persistent, null, null, fetchingKeys);
+                (short) COMPATIBILITY_MODE.ordinal(), ctx, false, salt, URI, URI, true, new byte[0], random, bf,
+                f, jobRunner, ticker, memoryLimitedJobRunner, new CRCChecksumChecker(), persistent, null, null, fetchingKeys
+            );
         }
 
-        /** Restore a splitfile fetcher from a file. 
-         * @throws StorageFormatException 
-         * @throws IOException 
-         * @throws FetchException */
-        public SplitFileFetcherStorage createStorage(StorageCallback cb, FetchContext ctx,
-                LockableRandomAccessBuffer raf) throws IOException, StorageFormatException, FetchException {
+        /**
+         * Restore a splitfile fetcher from a file.
+         *
+         * @throws StorageFormatException
+         * @throws IOException
+         * @throws FetchException
+         */
+        public SplitFileFetcherStorage createStorage(
+            StorageCallback cb,
+            FetchContext ctx,
+            LockableRandomAccessBuffer raf
+        ) throws IOException, StorageFormatException, FetchException {
             assertTrue(persistent);
             return new SplitFileFetcherStorage(raf, false, cb, ctx, random, jobRunner, fetchingKeys, ticker, memoryLimitedJobRunner, new CRCChecksumChecker(), false, null, false, false);
         }
 
         public FetchContext makeFetchContext() {
-            return HighLevelSimpleClientImpl.makeDefaultFetchContext(Long.MAX_VALUE, Long.MAX_VALUE, 
-                    bf, new SimpleEventProducer());
+            return HighLevelSimpleClientImpl.makeDefaultFetchContext(
+                Long.MAX_VALUE,
+                Long.MAX_VALUE,
+                bf,
+                new SimpleEventProducer()
+            );
         }
 
         public void verifyOutput(SplitFileFetcherStorage storage) throws IOException {
             StreamGenerator g = storage.streamGenerator();
             Bucket out = bf.makeBucket(-1);
-            OutputStream os = out.getOutputStream();
-            g.writeTo(os, null);
-            os.close();
+            try (OutputStream os = out.getOutputStream()) {
+                g.writeTo(os, null);
+            }
             assertTrue(BucketTools.equalBuckets(originalData, out));
             out.free();
         }
 
         public NodeCHK getCHK(int block) {
-            if(block < dataBlocks.length)
+            if (block < dataBlocks.length) {
                 return dataKeys[block].getNodeCHK();
-            else
-                return checkKeys[block-dataBlocks.length].getNodeCHK();
+            } else {
+                return checkKeys[block - dataBlocks.length].getNodeCHK();
+            }
         }
 
         public int segmentFor(int block) {
             int total = 0;
             // Must be consistent with the getCHK() counting etc.
             // Count data blocks first then check blocks.
-            for(int i=0;i<segmentDataBlockCount.length;i++) {
+            for (int i = 0; i < segmentDataBlockCount.length; i++) {
                 total += segmentDataBlockCount[i];
-                if(block < total) return i;
+                if (block < total) return i;
             }
-            for(int i=0;i<segmentCheckBlockCount.length;i++) {
+            for (int i = 0; i < segmentCheckBlockCount.length; i++) {
                 total += segmentCheckBlockCount[i];
-                if(block < total) return i;
+                if (block < total) return i;
             }
-            
+
             return -1;
         }
 
     }
-    
+
     public static ClientCHK[] makeKeys(byte[][] blocks, byte[] cryptoKey, byte cryptoAlgorithm) throws CHKEncodeException {
         ClientCHK[] keys = new ClientCHK[blocks.length];
-        for(int i=0;i<blocks.length;i++)
+        for (int i = 0; i < blocks.length; i++) {
             keys[i] = ClientCHKBlock.encodeSplitfileBlock(blocks[i], cryptoKey, cryptoAlgorithm).getClientKey();
+        }
         return keys;
     }
-    
+
     public static int sum(int[] values) {
         int total = 0;
-        for(int x : values) total += x;
+        for (int x : values) {
+            total += x;
+        }
         return total;
     }
 
-    static class StorageCallback implements SplitFileFetcherStorageCallback {
-        
+    private static class StorageCallback implements SplitFileFetcherStorageCallback {
+
         final TestSplitfile splitfile;
         final boolean[] encodedBlocks;
         private boolean succeeded;
         private boolean closed;
         private boolean failed;
-        private boolean hasRestartedOnCorruption;
         private LockableRandomAccessBuffer raf;
 
         public StorageCallback(TestSplitfile splitfile) {
@@ -376,7 +393,7 @@ public class SplitFileFetcherStorageTest {
         synchronized void snoopRAF(LockableRandomAccessBuffer t) {
             this.raf = t;
         }
-        
+
         synchronized LockableRandomAccessBuffer getRAF() {
             return raf;
         }
@@ -402,7 +419,7 @@ public class SplitFileFetcherStorageTest {
         public synchronized void failOnDiskError(IOException e) {
             failed = true;
             notifyAll();
-            System.err.println("Failed on disk error: "+e);
+            System.err.println("Failed on disk error: " + e);
             e.printStackTrace();
         }
 
@@ -413,40 +430,44 @@ public class SplitFileFetcherStorageTest {
         }
 
         @Override
-        public void onSplitfileCompatibilityMode(CompatibilityMode min, CompatibilityMode max,
-                byte[] customSplitfileKey, boolean compressed, boolean bottomLayer,
-                boolean definitiveAnyway) {
+        public void onSplitfileCompatibilityMode(
+            CompatibilityMode min,
+            CompatibilityMode max,
+            byte[] customSplitfileKey,
+            boolean compressed,
+            boolean bottomLayer,
+            boolean definitiveAnyway
+        ) {
             // Ignore. FIXME?
         }
 
         @Override
         public void queueHeal(byte[] data, byte[] cryptoKey, byte cryptoAlgorithm) {
-            assertTrue(Arrays.equals(cryptoKey, splitfile.cryptoKey));
+            assertArrayEquals(cryptoKey, splitfile.cryptoKey);
             assertEquals(cryptoAlgorithm, splitfile.cryptoAlgorithm);
             int x = -1;
             boolean progress = false;
-            while((x = splitfile.findCheckBlock(data, x)) != -1) {
-                synchronized(this) {
-                    encodedBlocks[x+splitfile.dataBlocks.length] = true;
+            while ((x = splitfile.findCheckBlock(data, x)) != -1) {
+                synchronized (this) {
+                    encodedBlocks[x + splitfile.dataBlocks.length] = true;
                 }
                 progress = true;
             }
-            if(!progress) {
+            if (!progress) {
                 // Data block?
-                while((x = splitfile.findDataBlock(data, x)) != -1) {
-                    synchronized(this) {
+                while ((x = splitfile.findDataBlock(data, x)) != -1) {
+                    synchronized (this) {
                         encodedBlocks[x] = true;
                     }
                     progress = true;
                 }
             }
-            if(!progress) {
-                System.err.println("Queued healing block not in the original block list");
-                assertTrue(false);
+            if (!progress) {
+                Assert.fail("Queued healing block not in the original block list");
             }
             assertTrue(progress);
         }
-        
+
         synchronized void markDownloadedBlock(int block) {
             encodedBlocks[block] = true;
         }
@@ -456,7 +477,7 @@ public class SplitFileFetcherStorageTest {
         }
 
         public synchronized void waitForFinished() {
-            while(!(succeeded || failed)) {
+            while (!(succeeded || failed)) {
                 try {
                     wait();
                 } catch (InterruptedException e) {
@@ -464,9 +485,9 @@ public class SplitFileFetcherStorageTest {
                 }
             }
         }
-        
+
         public synchronized void waitForFailed() {
-            while(!(succeeded || failed)) {
+            while (!(succeeded || failed)) {
                 try {
                     wait();
                 } catch (InterruptedException e) {
@@ -475,10 +496,10 @@ public class SplitFileFetcherStorageTest {
             }
             assertTrue(failed);
         }
-        
-        public void waitForFree(SplitFileFetcherStorage storage) {
-            synchronized(this) {
-                while(!closed) {
+
+        public void waitForFree() {
+            synchronized (this) {
+                while (!closed) {
                     try {
                         wait();
                     } catch (InterruptedException e) {
@@ -487,9 +508,10 @@ public class SplitFileFetcherStorageTest {
                 }
                 assertTrue(succeeded);
             }
-            synchronized(this) {
-                for(int i=0;i<encodedBlocks.length;i++)
-                    assertTrue("Block "+i+" not found or decoded", encodedBlocks[i]);
+            synchronized (this) {
+                for (int i = 0; i < encodedBlocks.length; i++) {
+                    assertTrue("Block " + i + " not found or decoded", encodedBlocks[i]);
+                }
             }
         }
 
@@ -500,7 +522,7 @@ public class SplitFileFetcherStorageTest {
 
         @Override
         public void fail(FetchException fe) {
-            synchronized(this) {
+            synchronized (this) {
                 failed = true;
                 notifyAll();
             }
@@ -528,17 +550,14 @@ public class SplitFileFetcherStorageTest {
 
         @Override
         public void restartedAfterDataCorruption() {
-            // Will be used in a different test.
-            synchronized(this) {
-                hasRestartedOnCorruption = true;
-            }
+            // Ignore
         }
 
         @Override
         public void clearCooldown() {
             // Ignore.
         }
-        
+
         @Override
         public void reduceCooldown(long wakeupTime) {
             // Ignore.
@@ -551,7 +570,7 @@ public class SplitFileFetcherStorageTest {
 
         @Override
         public void failOnDiskError(ChecksumFailedException e) {
-            synchronized(this) {
+            synchronized (this) {
                 failed = true;
                 notifyAll();
             }
@@ -566,7 +585,7 @@ public class SplitFileFetcherStorageTest {
         public void onResume(int succeeded, int failed, ClientMetadata mimeType, long finalSize) {
             // Ignore.
         }
-        
+
     }
 
     public static Bucket makeRandomBucket(long size) throws IOException {
@@ -580,12 +599,12 @@ public class SplitFileFetcherStorageTest {
         byte[][] blocks = new byte[n][];
         InputStream is = data.getInputStream();
         DataInputStream dis = new DataInputStream(is);
-        for(int i=0;i<n;i++) {
+        for (int i = 0; i < n; i++) {
             blocks[i] = new byte[BLOCK_SIZE];
-            if(i < n-1) {
+            if (i < n - 1) {
                 dis.readFully(blocks[i]);
             } else {
-                int length = (int) (size - i*BLOCK_SIZE);
+                int length = (int) (size - i * BLOCK_SIZE);
                 dis.readFully(blocks[i], 0, length);
                 // Now pad it ...
                 blocks[i] = BucketTools.pad(blocks[i], BLOCK_SIZE, length);
@@ -606,38 +625,41 @@ public class SplitFileFetcherStorageTest {
 
     public static byte[][] constructBlocks(int n) {
         byte[][] blocks = new byte[n][];
-        for(int i=0;i<n;i++) blocks[i] = new byte[BLOCK_SIZE];
+        for (int i = 0; i < n; i++) {
+            blocks[i] = new byte[BLOCK_SIZE];
+        }
         return blocks;
     }
-    
+
     // Actual tests ...
-    
+
     @Test
     public void testSingleSegment() throws CHKEncodeException, IOException, FetchException, MetadataParseException, MetadataUnresolvedException {
         // 2 data blocks.
         //testSingleSegment(1, 2, BLOCK_SIZE);
         // We don't test this case because it just copies the data block to the check blocks.
         // Which breaks some of the scripts here.
-        testSingleSegment(2, 1, BLOCK_SIZE*2);
-        testSingleSegment(2, 1, BLOCK_SIZE+1);
-        testSingleSegment(2, 2, BLOCK_SIZE*2);
-        testSingleSegment(2, 2, BLOCK_SIZE+1);
-        testSingleSegment(2, 3, BLOCK_SIZE*2);
-        testSingleSegment(2, 3, BLOCK_SIZE+1);
-        testSingleSegment(128, 128, BLOCK_SIZE*128);
-        testSingleSegment(128, 128, BLOCK_SIZE*128-1);
-        testSingleSegment(129, 127, BLOCK_SIZE*129);
-        testSingleSegment(129, 127, BLOCK_SIZE*129-1);
-        testSingleSegment(127, 129, BLOCK_SIZE*127);
-        testSingleSegment(127, 129, BLOCK_SIZE*127-1);
+        testSingleSegment(2, 1, BLOCK_SIZE * 2);
+        testSingleSegment(2, 1, BLOCK_SIZE + 1);
+        testSingleSegment(2, 2, BLOCK_SIZE * 2);
+        testSingleSegment(2, 2, BLOCK_SIZE + 1);
+        testSingleSegment(2, 3, BLOCK_SIZE * 2);
+        testSingleSegment(2, 3, BLOCK_SIZE + 1);
+        testSingleSegment(128, 128, BLOCK_SIZE * 128);
+        testSingleSegment(128, 128, BLOCK_SIZE * 128 - 1);
+        testSingleSegment(129, 127, BLOCK_SIZE * 129);
+        testSingleSegment(129, 127, BLOCK_SIZE * 129 - 1);
+        testSingleSegment(127, 129, BLOCK_SIZE * 127);
+        testSingleSegment(127, 129, BLOCK_SIZE * 127 - 1);
     }
-    
+
     private void testSingleSegment(int dataBlocks, int checkBlocks, long size) throws CHKEncodeException, IOException, FetchException, MetadataParseException, MetadataUnresolvedException {
-        assertTrue(dataBlocks * (long)BLOCK_SIZE >= size);
-        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, null, false);
+        assertTrue(dataBlocks * (long) BLOCK_SIZE >= size);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, false);
         testDataBlocksOnly(test);
-        if(checkBlocks >= dataBlocks)
+        if (checkBlocks >= dataBlocks) {
             testCheckBlocksOnly(test);
+        }
         testRandomMixture(test);
         test.free();
     }
@@ -646,10 +668,10 @@ public class SplitFileFetcherStorageTest {
         StorageCallback cb = test.createStorageCallback();
         SplitFileFetcherStorage storage = test.createStorage(cb);
         SplitFileFetcherSegmentStorage segment = storage.segments[0];
-        for(int i=0;i<test.checkBlocks.length;i++) {
-            segment.onNonFatalFailure(test.dataBlocks.length+i);
+        for (int i = 0; i < test.checkBlocks.length; i++) {
+            segment.onNonFatalFailure(test.dataBlocks.length + i);
         }
-        for(int i=0;i<test.dataBlocks.length;i++) {
+        for (int i = 0; i < test.dataBlocks.length; i++) {
             assertFalse(segment.hasStartedDecode());
             assertTrue(segment.onGotKey(test.dataKeys[i].getNodeCHK(), test.encodeDataBlock(i)));
             cb.markDownloadedBlock(i);
@@ -667,7 +689,7 @@ public class SplitFileFetcherStorageTest {
         cb.checkFailed();
         waitForFinished(segment);
         cb.checkFailed();
-        cb.waitForFree(storage);
+        cb.waitForFree();
         cb.checkFailed();
     }
 
@@ -675,13 +697,13 @@ public class SplitFileFetcherStorageTest {
         StorageCallback cb = test.createStorageCallback();
         SplitFileFetcherStorage storage = test.createStorage(cb);
         SplitFileFetcherSegmentStorage segment = storage.segments[0];
-        for(int i=0;i<test.dataBlocks.length;i++) {
+        for (int i = 0; i < test.dataBlocks.length; i++) {
             segment.onNonFatalFailure(i);
         }
-        for(int i=test.dataBlocks.length;i<test.checkBlocks.length;i++) {
-            segment.onNonFatalFailure(i+test.dataBlocks.length);
+        for (int i = test.dataBlocks.length; i < test.checkBlocks.length; i++) {
+            segment.onNonFatalFailure(i + test.dataBlocks.length);
         }
-        for(int i=0;i<test.dataBlocks.length /* only need that many to decode */;i++) {
+        for (int i = 0; i < test.dataBlocks.length /* only need that many to decode */; i++) {
             assertFalse(segment.hasStartedDecode());
             assertTrue(segment.onGotKey(test.checkKeys[i].getNodeCHK(), test.encodeCheckBlock(i)));
             cb.markDownloadedBlock(i + test.dataBlocks.length);
@@ -699,19 +721,19 @@ public class SplitFileFetcherStorageTest {
         cb.checkFailed();
         waitForFinished(segment);
         cb.checkFailed();
-        cb.waitForFree(storage);
+        cb.waitForFree();
         cb.checkFailed();
     }
-    
+
     private void testRandomMixture(TestSplitfile test) throws FetchException, MetadataParseException, IOException, CHKEncodeException {
         StorageCallback cb = test.createStorageCallback();
         SplitFileFetcherStorage storage = test.createStorage(cb);
         SplitFileFetcherSegmentStorage segment = storage.segments[0];
-        int total = test.dataBlocks.length+test.checkBlocks.length;
-        for(int i=0;i<total;i++)
+        int total = test.dataBlocks.length + test.checkBlocks.length;
+        for (int i = 0; i < total; i++)
             segment.onNonFatalFailure(i); // We want healing on all blocks that aren't found.
         boolean[] hits = new boolean[total];
-        for(int i=0;i<test.dataBlocks.length;i++) {
+        for (int i = 0; i < test.dataBlocks.length; i++) {
             int block;
             do {
                 block = random.nextInt(total);
@@ -735,48 +757,48 @@ public class SplitFileFetcherStorageTest {
         cb.checkFailed();
         waitForFinished(segment);
         cb.checkFailed();
-        cb.waitForFree(storage);
+        cb.waitForFree();
         cb.checkFailed();
     }
-    
+
     // FIXME LATER Test cross-segment.
 
     @Test
     public void testMultiSegment() throws CHKEncodeException, IOException, MetadataUnresolvedException, MetadataParseException, FetchException {
         // We have to be consistent with the format, but we can in fact play with the segment sizes 
         // to some degree.
-        
+
         // Simplest case: Same number of blocks in each segment.
         // 2 blocks in each of 2 segments.
-        testMultiSegment(32768*4, new int[] { 2, 2 }, new int[] { 3, 3 }, 2, 3, 0, 
-                InsertContext.CompatibilityMode.COMPAT_1416);
-        testMultiSegment(32768*4-1, new int[] { 2, 2 }, new int[] { 3, 3 }, 2, 3, 0, 
-                InsertContext.CompatibilityMode.COMPAT_1416);
-        
+        testMultiSegment(32768 * 4, new int[]{2, 2}, new int[]{3, 3}, 2, 3, 0,
+            InsertContext.CompatibilityMode.COMPAT_1416);
+        testMultiSegment(32768 * 4 - 1, new int[]{2, 2}, new int[]{3, 3}, 2, 3, 0,
+            InsertContext.CompatibilityMode.COMPAT_1416);
+
         // 3 blocks in 3 segments
-        testMultiSegment(32768*9-1, new int[] { 3, 3, 3 }, new int[] { 4, 4, 4 }, 3, 4, 0, 
-                InsertContext.CompatibilityMode.COMPAT_1416);
-        
+        testMultiSegment(32768 * 9 - 1, new int[]{3, 3, 3}, new int[]{4, 4, 4}, 3, 4, 0,
+            InsertContext.CompatibilityMode.COMPAT_1416);
+
         // Deduct blocks. This is how we handle this situation in modern splitfiles.
-        testMultiSegment(32768*7-1, new int[] { 3, 2, 2 }, new int[] { 4, 4, 4 }, 3, 4, 2, 
-                InsertContext.CompatibilityMode.COMPAT_1416);
-        
+        testMultiSegment(32768 * 7 - 1, new int[]{3, 2, 2}, new int[]{4, 4, 4}, 3, 4, 2,
+            InsertContext.CompatibilityMode.COMPAT_1416);
+
         // Sharp truncation. This is how we used to handle non-divisible numbers...
-        testMultiSegment(32768*9-1, new int[] { 7, 2 }, new int[] { 7, 2 }, 7, 7, 0,
-                InsertContext.CompatibilityMode.COMPAT_1416);
+        testMultiSegment(32768 * 9 - 1, new int[]{7, 2}, new int[]{7, 2}, 7, 7, 0,
+            InsertContext.CompatibilityMode.COMPAT_1416);
         // Still COMPAT_1416 because has crypto key etc.
-        
+
         // FIXME test old splitfiles.
         // FIXME test really old splitfiles: last data block not padded
         // FIXME test really old splitfiles: non-redundant support
     }
-    
-    private void testMultiSegment(long size, int[] segmentDataBlockCount, 
-                int[] segmentCheckBlockCount, int segmentSize, int checkSegmentSize, 
-                int deductBlocksFromSegments, CompatibilityMode topCompatibilityMode) throws CHKEncodeException, IOException, MetadataUnresolvedException, MetadataParseException, FetchException {
+
+    private void testMultiSegment(long size, int[] segmentDataBlockCount,
+                                  int[] segmentCheckBlockCount, int segmentSize, int checkSegmentSize,
+                                  int deductBlocksFromSegments, CompatibilityMode topCompatibilityMode) throws CHKEncodeException, IOException, MetadataUnresolvedException, MetadataParseException, FetchException {
         TestSplitfile test = TestSplitfile.constructMultipleSegments(size, segmentDataBlockCount,
-                segmentCheckBlockCount, segmentSize, checkSegmentSize, deductBlocksFromSegments,
-                topCompatibilityMode, null, false);
+            segmentCheckBlockCount, segmentSize, checkSegmentSize, deductBlocksFromSegments,
+            topCompatibilityMode);
         testRandomMixtureMultiSegment(test);
         test.free();
 
@@ -785,20 +807,20 @@ public class SplitFileFetcherStorageTest {
     private void testRandomMixtureMultiSegment(TestSplitfile test) throws CHKEncodeException, IOException, FetchException, MetadataParseException {
         StorageCallback cb = test.createStorageCallback();
         SplitFileFetcherStorage storage = test.createStorage(cb);
-        int total = test.dataBlocks.length+test.checkBlocks.length;
-        for(SplitFileFetcherSegmentStorage segment : storage.segments) {
-            for(int i=0;i<segment.totalBlocks();i++)
+        int total = test.dataBlocks.length + test.checkBlocks.length;
+        for (SplitFileFetcherSegmentStorage segment : storage.segments) {
+            for (int i = 0; i < segment.totalBlocks(); i++)
                 segment.onNonFatalFailure(i); // We want healing on all blocks that aren't found.
         }
         boolean[] hits = new boolean[total];
-        for(int i=0;i<test.dataBlocks.length;i++) {
+        for (int i = 0; i < test.dataBlocks.length; i++) {
             int block;
             do {
                 block = random.nextInt(total);
             } while (hits[block]);
             hits[block] = true;
             SplitFileFetcherSegmentStorage segment = storage.segments[test.segmentFor(block)];
-            if(segment.hasStartedDecode()) {
+            if (segment.hasStartedDecode()) {
                 i--;
                 continue;
             }
@@ -807,11 +829,13 @@ public class SplitFileFetcherStorageTest {
         }
         printChosenBlocks(hits);
         cb.checkFailed();
-        for(SplitFileFetcherSegmentStorage segment : storage.segments)
+        for (SplitFileFetcherSegmentStorage segment : storage.segments) {
             assertTrue(segment.hasStartedDecode()); // All segments have started decoding.
+        }
         cb.checkFailed();
-        for(SplitFileFetcherSegmentStorage segment : storage.segments)
+        for (SplitFileFetcherSegmentStorage segment : storage.segments) {
             waitForDecode(segment);
+        }
         cb.checkFailed();
         cb.waitForFinished();
         cb.checkFailed();
@@ -819,28 +843,29 @@ public class SplitFileFetcherStorageTest {
         cb.checkFailed();
         storage.finishedFetcher();
         cb.checkFailed();
-        for(SplitFileFetcherSegmentStorage segment : storage.segments)
+        for (SplitFileFetcherSegmentStorage segment : storage.segments) {
             waitForFinished(segment);
+        }
         cb.checkFailed();
-        cb.waitForFree(storage);
+        cb.waitForFree();
         cb.checkFailed();
     }
 
     private void printChosenBlocks(boolean[] hits) {
         StringBuilder sb = new StringBuilder();
         sb.append("Blocks: ");
-        for(int i=0;i<hits.length;i++) {
-            if(hits[i]) {
+        for (int i = 0; i < hits.length; i++) {
+            if (hits[i]) {
                 sb.append(i);
                 sb.append(" ");
             }
         }
-        sb.setLength(sb.length()-1);
+        sb.setLength(sb.length() - 1);
         System.out.println(sb.toString());
     }
 
     private void waitForFinished(SplitFileFetcherSegmentStorage segment) {
-        while(!segment.isFinished()) {
+        while (!segment.isFinished()) {
             assertFalse(segment.hasFailed());
             try {
                 Thread.sleep(1);
@@ -851,7 +876,7 @@ public class SplitFileFetcherStorageTest {
     }
 
     private void waitForDecode(SplitFileFetcherSegmentStorage segment) {
-        while(!segment.hasSucceeded()) {
+        while (!segment.hasSucceeded()) {
             assertFalse(segment.hasFailed());
             try {
                 Thread.sleep(1);
@@ -860,8 +885,8 @@ public class SplitFileFetcherStorageTest {
             }
         }
     }
-    
-    static class MyKeysFetchingLocally implements KeysFetchingLocally {
+
+    private static class MyKeysFetchingLocally implements KeysFetchingLocally {
         private final HashSet<Key> keys = new HashSet<Key>();
 
         @Override
@@ -886,27 +911,27 @@ public class SplitFileFetcherStorageTest {
         public void clear() {
             keys.clear();
         }
-        
+
     }
-    
+
     @Test
     public void testChooseKeyOneTry() throws CHKEncodeException, IOException, MetadataUnresolvedException, MetadataParseException, FetchException {
         int dataBlocks = 3, checkBlocks = 3;
-        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks*BLOCK_SIZE, checkBlocks, null, false);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks * BLOCK_SIZE, checkBlocks, false);
         StorageCallback cb = test.createStorageCallback();
         FetchContext ctx = test.makeFetchContext();
         ctx.maxSplitfileBlockRetries = 0;
         SplitFileFetcherStorage storage = test.createStorage(cb, ctx);
-        boolean[] tried = new boolean[dataBlocks+checkBlocks];
+        boolean[] tried = new boolean[dataBlocks + checkBlocks];
         innerChooseKeyTest(dataBlocks, checkBlocks, storage.segments[0], tried, test, false);
-        assertEquals(storage.chooseRandomKey(), null);
+        assertNull(storage.chooseRandomKey());
         cb.waitForFailed();
     }
-    
+
     private void innerChooseKeyTest(int dataBlocks, int checkBlocks, SplitFileFetcherSegmentStorage storage, boolean[] tried, TestSplitfile test, boolean cooldown) {
         final MyKeysFetchingLocally keys = test.fetchingKeys;
         keys.clear();
-        for(int i=0;i<dataBlocks+checkBlocks;i++) {
+        for (int i = 0; i < dataBlocks + checkBlocks; i++) {
             int chosen = storage.chooseRandomKey();
             assertTrue(chosen != -1);
             assertFalse(tried[chosen]);
@@ -915,10 +940,10 @@ public class SplitFileFetcherStorageTest {
             keys.add(k);
         }
         // Every block has been tried.
-        for(boolean b : tried) {
+        for (boolean b : tried) {
             assertTrue(b);
         }
-        if(cooldown) {
+        if (cooldown) {
             assertEquals(storage.chooseRandomKey(), -1);
             // In infinite cooldown, waiting for all requests to complete.
             assertEquals(storage.getOverallCooldownTime(), Long.MAX_VALUE);
@@ -926,10 +951,10 @@ public class SplitFileFetcherStorageTest {
         // Every request is running.
         // When we complete a request, we remove it from KeysFetchingLocally *and* call onNonFatalFailure.
         // This will reset the cooldown.
-        for(int i=0;i<dataBlocks+checkBlocks;i++) {
+        for (int i = 0; i < dataBlocks + checkBlocks; i++) {
             storage.onNonFatalFailure(i);
         }
-        if(!cooldown) {
+        if (!cooldown) {
             // Cleared cooldown, if any.
             assertEquals(storage.getOverallCooldownTime(), 0);
         }
@@ -942,24 +967,24 @@ public class SplitFileFetcherStorageTest {
     @Test
     public void testChooseKeyThreeTries() throws CHKEncodeException, IOException, MetadataUnresolvedException, MetadataParseException, FetchException {
         int dataBlocks = 3, checkBlocks = 3;
-        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks*BLOCK_SIZE, checkBlocks, null, false);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks * BLOCK_SIZE, checkBlocks, false);
         StorageCallback cb = test.createStorageCallback();
         FetchContext ctx = test.makeFetchContext();
         ctx.maxSplitfileBlockRetries = 2;
         SplitFileFetcherStorage storage = test.createStorage(cb, ctx);
-        for(int i=0;i<3;i++) {
-            boolean[] tried = new boolean[dataBlocks+checkBlocks];
+        for (int i = 0; i < 3; i++) {
+            boolean[] tried = new boolean[dataBlocks + checkBlocks];
             innerChooseKeyTest(dataBlocks, checkBlocks, storage.segments[0], tried, test, false);
         }
-        assertEquals(storage.chooseRandomKey(), null);
+        assertNull(storage.chooseRandomKey());
         cb.waitForFailed();
     }
-    
+
     @Test
     public void testChooseKeyCooldown() throws CHKEncodeException, IOException, MetadataUnresolvedException, MetadataParseException, FetchException, InterruptedException {
         int dataBlocks = 3, checkBlocks = 3;
         int COOLDOWN_TIME = 200;
-        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks*BLOCK_SIZE, checkBlocks, null, false);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks * BLOCK_SIZE, checkBlocks, false);
         StorageCallback cb = test.createStorageCallback();
         FetchContext ctx = test.makeFetchContext();
         ctx.maxSplitfileBlockRetries = 5;
@@ -968,72 +993,71 @@ public class SplitFileFetcherStorageTest {
         SplitFileFetcherStorage storage = test.createStorage(cb, ctx);
         // 3 tries for each block.
         long now = System.currentTimeMillis();
-        for(int i=0;i<3;i++) {
-            boolean[] tried = new boolean[dataBlocks+checkBlocks];
+        for (int i = 0; i < 3; i++) {
+            boolean[] tried = new boolean[dataBlocks + checkBlocks];
             innerChooseKeyTest(dataBlocks, checkBlocks, storage.segments[0], tried, test, true);
         }
         assertTrue(storage.segments[0].getOverallCooldownTime() > now);
-        assertFalse(storage.segments[0].getOverallCooldownTime() == Long.MAX_VALUE);
+        assertNotEquals(Long.MAX_VALUE, storage.segments[0].getOverallCooldownTime());
         // Now in cooldown.
         test.fetchingKeys.clear();
-        assertEquals(storage.chooseRandomKey(), null);
-        Thread.sleep((long)(COOLDOWN_TIME+COOLDOWN_TIME/2+1));
+        assertNull(storage.chooseRandomKey());
+        Thread.sleep(COOLDOWN_TIME + COOLDOWN_TIME / 2 + 1);
         cb.checkFailed();
         // Should be out of cooldown now.
-        for(int i=0;i<3;i++) {
-            boolean[] tried = new boolean[dataBlocks+checkBlocks];
+        for (int i = 0; i < 3; i++) {
+            boolean[] tried = new boolean[dataBlocks + checkBlocks];
             innerChooseKeyTest(dataBlocks, checkBlocks, storage.segments[0], tried, test, true);
         }
         // Now it should fail.
         cb.waitForFailed();
     }
-    
+
     @Test
     public void testWriteReadSegmentKeys() throws FetchException, MetadataParseException, IOException, CHKEncodeException, MetadataUnresolvedException, ChecksumFailedException {
         int dataBlocks = 3, checkBlocks = 3;
-        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks*BLOCK_SIZE, checkBlocks, null, true);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(dataBlocks*BLOCK_SIZE, checkBlocks, true);
         StorageCallback cb = test.createStorageCallback();
         SplitFileFetcherStorage storage = test.createStorage(cb);
         SplitFileFetcherSegmentStorage segment = storage.segments[0];
         SplitFileSegmentKeys keys = segment.getSegmentKeys();
         SplitFileSegmentKeys moreKeys = segment.readSegmentKeys();
-        assertTrue(keys.equals(moreKeys));
+        assertEquals(keys, moreKeys);
         storage.close();
     }
 
-    /** Test persistence: Create and then reload. Don't do anything. */
+    /**
+     * Test persistence: Create and then reload. Don't do anything.
+     */
     @Test
     public void testPersistenceReload() throws CHKEncodeException, IOException, MetadataUnresolvedException, MetadataParseException, FetchException, StorageFormatException {
         int dataBlocks = 2;
         int checkBlocks = 3;
-        long size = 32768*2-1;
-        assertTrue(dataBlocks * (long)BLOCK_SIZE >= size);
-        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, null, true);
+        long size = 32768 * 2 - 1;
+        assertTrue(dataBlocks * (long) BLOCK_SIZE >= size);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, true);
         StorageCallback cb = test.createStorageCallback();
-        SplitFileFetcherStorage storage = test.createStorage(cb);
-        // No need to shutdown the old storage.
-        storage = test.createStorage(cb, test.makeFetchContext(), cb.getRAF());
+        SplitFileFetcherStorage storage = createSplitFileFetcherStorageTwice(test, cb);
         storage.close();
     }
-    
+
     @Test
     public void testPersistenceReloadThenFetch() throws IOException, StorageFormatException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException, FetchException {
         int dataBlocks = 2;
         int checkBlocks = 3;
-        long size = 32768*2-1;
-        assertTrue(dataBlocks * (long)BLOCK_SIZE >= size);
-        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, null, true);
+        long size = 32768 * 2 - 1;
+        assertTrue(dataBlocks * (long) BLOCK_SIZE >= size);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, true);
         StorageCallback cb = test.createStorageCallback();
-        SplitFileFetcherStorage storage = test.createStorage(cb);
-        // No need to shutdown the old storage.
-        storage = test.createStorage(cb, test.makeFetchContext(), cb.getRAF());
+        SplitFileFetcherStorage storage = createSplitFileFetcherStorageTwice(test, cb);
         SplitFileFetcherSegmentStorage segment = storage.segments[0];
         assertFalse(segment.corruptMetadata());
-        int total = test.dataBlocks.length+test.checkBlocks.length;
-        for(int i=0;i<total;i++)
+        int total = test.dataBlocks.length + test.checkBlocks.length;
+        for (int i = 0; i < total; i++) {
             segment.onNonFatalFailure(i); // We want healing on all blocks that aren't found.
+        }
         boolean[] hits = new boolean[total];
-        for(int i=0;i<test.dataBlocks.length;i++) {
+        for (int i = 0; i < test.dataBlocks.length; i++) {
             int block;
             do {
                 block = random.nextInt(total);
@@ -1057,47 +1081,47 @@ public class SplitFileFetcherStorageTest {
         cb.checkFailed();
         waitForFinished(segment);
         cb.checkFailed();
-        cb.waitForFree(storage);
+        cb.waitForFree();
         cb.checkFailed();
     }
-    
+
     @Test
     public void testPersistenceReloadThenChooseKey() throws IOException, StorageFormatException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException, FetchException {
         int dataBlocks = 2;
         int checkBlocks = 3;
-        long size = 32768*2-1;
-        assertTrue(dataBlocks * (long)BLOCK_SIZE >= size);
-        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, null, true);
+        long size = 32768 * 2 - 1;
+        assertTrue(dataBlocks * (long) BLOCK_SIZE >= size);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, true);
         StorageCallback cb = test.createStorageCallback();
         FetchContext ctx = test.makeFetchContext();
         ctx.maxSplitfileBlockRetries = 2;
-        SplitFileFetcherStorage storage = test.createStorage(cb, ctx);
+        test.createStorage(cb, ctx);
         // No need to shutdown the old storage.
-        storage = test.createStorage(cb, ctx, cb.getRAF());
-        for(int i=0;i<3;i++) {
-            boolean[] tried = new boolean[dataBlocks+checkBlocks];
+        SplitFileFetcherStorage storage = test.createStorage(cb, ctx, cb.getRAF());
+        for (int i = 0; i < 3; i++) {
+            boolean[] tried = new boolean[dataBlocks + checkBlocks];
             innerChooseKeyTest(dataBlocks, checkBlocks, storage.segments[0], tried, test, false);
         }
         test.fetchingKeys.clear();
-        assertEquals(storage.chooseRandomKey(), null);
+        assertNull(storage.chooseRandomKey());
         cb.waitForFailed();
     }
-    
+
     @Test
     public void testPersistenceReloadBetweenChooseKey() throws IOException, StorageFormatException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException, FetchException {
         int dataBlocks = 2;
         int checkBlocks = 3;
-        long size = 32768*2-1;
-        assertTrue(dataBlocks * (long)BLOCK_SIZE >= size);
-        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, null, true);
+        long size = 32768 * 2 - 1;
+        assertTrue(dataBlocks * (long) BLOCK_SIZE >= size);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, true);
         StorageCallback cb = test.createStorageCallback();
         FetchContext ctx = test.makeFetchContext();
         ctx.maxSplitfileBlockRetries = 2;
-        SplitFileFetcherStorage storage = test.createStorage(cb, ctx);
+        test.createStorage(cb, ctx);
         // No need to shutdown the old storage.
-        storage = test.createStorage(cb, ctx, cb.getRAF());
-        for(int i=0;i<3;i++) {
-            boolean[] tried = new boolean[dataBlocks+checkBlocks];
+        SplitFileFetcherStorage storage = test.createStorage(cb, ctx, cb.getRAF());
+        for (int i = 0; i < 3; i++) {
+            boolean[] tried = new boolean[dataBlocks + checkBlocks];
             innerChooseKeyTest(dataBlocks, checkBlocks, storage.segments[0], tried, test, false);
             // Reload.
             exec.waitForIdle();
@@ -1106,33 +1130,32 @@ public class SplitFileFetcherStorageTest {
                 assertTrue(i != 2);
                 storage.start(false);
             } catch (FetchException e) {
-                if(i != 2) throw e; // Already failed on the final iteration, otherwise is an error.
+                if (i != 2) throw e; // Already failed on the final iteration, otherwise is an error.
                 return;
             }
         }
         test.fetchingKeys.clear();
-        assertEquals(storage.chooseRandomKey(), null);
+        assertNull(storage.chooseRandomKey());
         cb.waitForFailed();
     }
-    
+
     @Test
     public void testPersistenceReloadBetweenFetches() throws IOException, StorageFormatException, CHKEncodeException, MetadataUnresolvedException, MetadataParseException, FetchException {
         int dataBlocks = 2;
         int checkBlocks = 3;
-        long size = 32768*2-1;
-        assertTrue(dataBlocks * (long)BLOCK_SIZE >= size);
-        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, null, true);
+        long size = 32768 * 2 - 1;
+        assertTrue(dataBlocks * (long) BLOCK_SIZE >= size);
+        TestSplitfile test = TestSplitfile.constructSingleSegment(size, checkBlocks, true);
         StorageCallback cb = test.createStorageCallback();
-        SplitFileFetcherStorage storage = test.createStorage(cb);
-        // No need to shutdown the old storage.
-        storage = test.createStorage(cb, test.makeFetchContext(), cb.getRAF());
+        SplitFileFetcherStorage storage = createSplitFileFetcherStorageTwice(test, cb);
         SplitFileFetcherSegmentStorage segment = storage.segments[0];
         assertFalse(segment.corruptMetadata());
-        int total = test.dataBlocks.length+test.checkBlocks.length;
-        for(int i=0;i<total;i++)
+        int total = test.dataBlocks.length + test.checkBlocks.length;
+        for (int i = 0; i < total; i++) {
             segment.onNonFatalFailure(i); // We want healing on all blocks that aren't found.
+        }
         boolean[] hits = new boolean[total];
-        for(int i=0;i<test.dataBlocks.length;i++) {
+        for (int i = 0; i < test.dataBlocks.length; i++) {
             int block;
             do {
                 block = random.nextInt(total);
@@ -1141,7 +1164,7 @@ public class SplitFileFetcherStorageTest {
             assertFalse(segment.hasStartedDecode());
             assertTrue(segment.onGotKey(test.getCHK(block), test.encodeBlock(block)));
             cb.markDownloadedBlock(block);
-            if(i != test.dataBlocks.length-1) {
+            if (i != test.dataBlocks.length - 1) {
                 // Reload.
                 exec.waitForIdle();
                 storage = test.createStorage(cb, test.makeFetchContext(), cb.getRAF());
@@ -1163,8 +1186,13 @@ public class SplitFileFetcherStorageTest {
         cb.checkFailed();
         waitForFinished(segment);
         cb.checkFailed();
-        cb.waitForFree(storage);
+        cb.waitForFree();
         cb.checkFailed();
     }
-    
+
+    private SplitFileFetcherStorage createSplitFileFetcherStorageTwice(TestSplitfile test, StorageCallback cb) throws FetchException, MetadataParseException, IOException, StorageFormatException {
+        test.createStorage(cb);
+        // No need to shutdown the old storage.
+        return test.createStorage(cb, test.makeFetchContext(), cb.getRAF());
+    }
 }

--- a/test/freenet/client/filter/BMPFilterTest.java
+++ b/test/freenet/client/filter/BMPFilterTest.java
@@ -1,12 +1,11 @@
 package freenet.client.filter;
 
+import static freenet.client.filter.ResourceFileUtil.resourceToBucket;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.FileNotFoundException;
 import java.io.OutputStream;
-import java.util.Arrays;
 
 import org.junit.Test;
 
@@ -16,162 +15,161 @@ import freenet.support.io.BucketTools;
 
 
 public class BMPFilterTest {
-	/** File of size less than 54 bytes */
-	@Test
-	public void testTooShortImage() throws IOException {
-		Bucket input = resourceToBucket("./bmp/small.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * File of size less than 54 bytes
+     */
+    @Test
+    public void testTooShortImage() throws IOException {
+        Bucket input = resourceToBucket("./bmp/small.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Illegal start word (AB instead of BM) */
-	@Test
-	public void testIllegalStartWord() throws IOException {
-		Bucket input = resourceToBucket("./bmp/one.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Illegal start word (AB instead of BM)
+     */
+    @Test
+    public void testIllegalStartWord() throws IOException {
+        Bucket input = resourceToBucket("./bmp/one.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Invalid offset i.e. starting address */
-	@Test
-	public void testInvalidOffset() throws IOException {
-		Bucket input = resourceToBucket("./bmp/two.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Invalid offset i.e. starting address
+     */
+    @Test
+    public void testInvalidOffset() throws IOException {
+        Bucket input = resourceToBucket("./bmp/two.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Invalid size of bitmap info header */
-	@Test
-	public void testInvalidBitmapInfoHeaderSize() throws IOException {
-		Bucket input = resourceToBucket("./bmp/three.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Invalid size of bitmap info header
+     */
+    @Test
+    public void testInvalidBitmapInfoHeaderSize() throws IOException {
+        Bucket input = resourceToBucket("./bmp/three.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Negative image width */
-	@Test
-	public void testNegativeImageWidth() throws IOException {
-		Bucket input = resourceToBucket("./bmp/four.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Negative image width
+     */
+    @Test
+    public void testNegativeImageWidth() throws IOException {
+        Bucket input = resourceToBucket("./bmp/four.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Invalid number of planes */
-	@Test
-	public void testInvalidNumberOfPlanes() throws IOException {
-		Bucket input = resourceToBucket("./bmp/five.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Invalid number of planes
+     */
+    @Test
+    public void testInvalidNumberOfPlanes() throws IOException {
+        Bucket input = resourceToBucket("./bmp/five.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Invalid bit depth */
-	@Test
-	public void testInvalidBitDepth() throws IOException {
-		Bucket input = resourceToBucket("./bmp/six.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Invalid bit depth
+     */
+    @Test
+    public void testInvalidBitDepth() throws IOException {
+        Bucket input = resourceToBucket("./bmp/six.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Invalid compression type */
-	@Test
-	public void testInvalidCompressionType() throws IOException {
-		Bucket input = resourceToBucket("./bmp/seven.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Invalid compression type
+     */
+    @Test
+    public void testInvalidCompressionType() throws IOException {
+        Bucket input = resourceToBucket("./bmp/seven.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Invalid image data size (i.e. not satisfying fileSize = headerSize + imagedatasize) */
-	@Test
-	public void testInvalidImageDataSize() throws IOException {
-		Bucket input = resourceToBucket("./bmp/eight.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Invalid image data size (i.e. not satisfying fileSize = headerSize + imagedatasize)
+     */
+    @Test
+    public void testInvalidImageDataSize() throws IOException {
+        Bucket input = resourceToBucket("./bmp/eight.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Invalid image resolution */
-	@Test
-	public void testInvalidImageResolution() throws IOException {
-		Bucket input = resourceToBucket("./bmp/nine.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * Invalid image resolution
+     */
+    @Test
+    public void testInvalidImageResolution() throws IOException {
+        Bucket input = resourceToBucket("./bmp/nine.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** File is shorter than expected */
-	@Test
-	public void testNotEnoughImageData() throws IOException {
-		Bucket input = resourceToBucket("./bmp/ten.bmp");
-		filterImage(input, DataFilterException.class);
-	}
+    /**
+     * File is shorter than expected
+     */
+    @Test
+    public void testNotEnoughImageData() throws IOException {
+        Bucket input = resourceToBucket("./bmp/ten.bmp");
+        filterImage(input, DataFilterException.class);
+    }
 
-	/** Tests valid image */
-	@Test
-	public void testValidImage() throws IOException {
-		Bucket input = resourceToBucket("./bmp/ok.bmp");
-		Bucket output = filterImage(input, null);
+    /**
+     * Tests valid image
+     */
+    @Test
+    public void testValidImage() throws IOException {
+        Bucket input = resourceToBucket("./bmp/ok.bmp");
+        Bucket output = filterImage(input, null);
 
-		//Filter should return the original
-		assertEquals("Input and output should be the same length", input.size(), output.size());
-		assertTrue("Input and output are not identical", Arrays.equals(BucketTools.toByteArray(input), BucketTools.toByteArray(output)));
-	}
+        //Filter should return the original
+        assertEquals("Input and output should be the same length", input.size(), output.size());
+        assertArrayEquals("Input and output are not identical", BucketTools.toByteArray(input), BucketTools.toByteArray(output));
+    }
 
-	/** Checks that the image size calculation works for images with padding */
-	@Test
-	public void testImageSizeCalculationWithPadding() throws IOException {
-		Bucket input = resourceToBucket("./bmp/sizeCalculationWithPadding.bmp");
-		Bucket output = filterImage(input, null);
+    /**
+     * Checks that the image size calculation works for images with padding
+     */
+    @Test
+    public void testImageSizeCalculationWithPadding() throws IOException {
+        Bucket input = resourceToBucket("./bmp/sizeCalculationWithPadding.bmp");
+        Bucket output = filterImage(input, null);
 
-		//Filter should return the original
-		assertEquals("Input and output should be the same length", input.size(), output.size());
-		assertTrue("Input and output are not identical", Arrays.equals(BucketTools.toByteArray(input), BucketTools.toByteArray(output)));
-	}
+        //Filter should return the original
+        assertEquals("Input and output should be the same length", input.size(), output.size());
+        assertArrayEquals("Input and output are not identical", BucketTools.toByteArray(input), BucketTools.toByteArray(output));
+    }
 
-	/** Checks that the image size calculation works for images without padding */
-	@Test
-	public void testImageSizeCalculationWithoutPadding() throws IOException {
-		Bucket input = resourceToBucket("./bmp/sizeCalculationWithoutPadding.bmp");
-		Bucket output = filterImage(input, null);
+    /**
+     * Checks that the image size calculation works for images without padding
+     */
+    @Test
+    public void testImageSizeCalculationWithoutPadding() throws IOException {
+        Bucket input = resourceToBucket("./bmp/sizeCalculationWithoutPadding.bmp");
+        Bucket output = filterImage(input, null);
 
-		//Filter should return the original
-		assertEquals("Input and output should be the same length", input.size(), output.size());
-		assertTrue("Input and output are not identical", Arrays.equals(BucketTools.toByteArray(input), BucketTools.toByteArray(output)));
-	}
+        //Filter should return the original
+        assertEquals("Input and output should be the same length", input.size(), output.size());
+        assertArrayEquals("Input and output are not identical", BucketTools.toByteArray(input), BucketTools.toByteArray(output));
+    }
 
-	private Bucket filterImage(Bucket input, Class<? extends Exception> expected) {
-		BMPFilter objBMPFilter = new BMPFilter();
-		Bucket output = new ArrayBucket();
+    private Bucket filterImage(Bucket input, Class<? extends Exception> expected) throws IOException {
+        BMPFilter objBMPFilter = new BMPFilter();
+        Bucket output = new ArrayBucket();
+        try (
+            InputStream inStream = input.getInputStream();
+            OutputStream outStream = output.getOutputStream()
+        ) {
+            if (expected != null) {
+                assertThrows(expected, () -> readFilter(objBMPFilter, inStream, outStream));
+            } else {
+                readFilter(objBMPFilter, inStream, outStream);
+            }
+        }
+        return output;
+    }
 
-		InputStream inStream;
-		OutputStream outStream;
-		try {
-			inStream = input.getInputStream();
-			outStream = output.getOutputStream();
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail("Caugth unexpected IOException: " + e);
-			return null; //Convince the compiler that we won't continue
-		}
-
-		try {
-			objBMPFilter.readFilter(inStream, outStream, "", null, null, null);
-
-			if(expected != null) {
-				fail("Filter didn't throw expected exception");
-			}
-		} catch (Exception e) {
-			if((expected == null) || (!expected.equals(e.getClass()))) {
-				//Exception is not the one we expected
-				e.printStackTrace();
-				fail("Caugth unexpected exception: " + e.getClass() + ": " + e.getMessage());
-			}
-		}
-
-		try {
-			inStream.close();
-			outStream.close();
-		} catch(IOException e) {
-			e.printStackTrace();
-			fail("Caugth unexpected IOException: " + e);
-			return null; //Convince the compiler that we won't continue
-		}
-
-		return output;
-	}
-
-	private Bucket resourceToBucket(String filename) throws IOException {
-		InputStream is = getClass().getResourceAsStream(filename);
-		if (is == null) throw new FileNotFoundException();
-		Bucket ab = new ArrayBucket();
-		BucketTools.copyFrom(ab, is, Long.MAX_VALUE);
-		return ab;
-	}
+    private static void readFilter(BMPFilter objBMPFilter, InputStream inStream, OutputStream outStream) throws IOException {
+        objBMPFilter.readFilter(inStream, outStream, "", null, null, null);
+    }
 }

--- a/test/freenet/client/filter/CSSParserTest.java
+++ b/test/freenet/client/filter/CSSParserTest.java
@@ -1,5 +1,7 @@
 package freenet.client.filter;
 
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -9,13 +11,10 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
+import java.util.*;
 import java.util.Map.Entry;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,9 +32,8 @@ public class CSSParserTest {
 
 	// FIXME should specify exact output values
 	/** CSS1 Selectors */
-	private final static HashMap<String,String> CSS1_SELECTOR= new HashMap<String,String>();
-	static
-	{
+	private final static HashMap<String,String> CSS1_SELECTOR= new HashMap<>();
+	static {
 		CSS1_SELECTOR.put("h1 {}","h1");
 		CSS1_SELECTOR.put("h1:link {}","h1:link");
 		CSS1_SELECTOR.put("h1:visited {}","");
@@ -47,17 +45,12 @@ public class CSSParserTest {
 		CSS1_SELECTOR.put("h1:focus {}" ,"h1:focus");
 		CSS1_SELECTOR.put("h1:first-line {}" ,"h1:first-line");
 		CSS1_SELECTOR.put("h1:first-letter {}" ,"h1:first-letter");
-
-
-
-
 	}
 
 	// FIXME should specify exact output values
 	/** CSS2 Selectors */
-	private final static HashMap<String,String> CSS2_SELECTOR= new HashMap<String,String>();
-	static
-	{
+	private final static HashMap<String,String> CSS2_SELECTOR= new HashMap<>();
+	static {
 		CSS2_SELECTOR.put("* {}","*");
 		CSS2_SELECTOR.put("h1[foo] {}","h1[foo]");
 		CSS2_SELECTOR.put("h1[foo=\"bar\"] {}", "h1[foo=\"bar\"]");
@@ -120,9 +113,8 @@ public class CSSParserTest {
 		// CONFORMANCE: We combine pseudo-classes and pseudo-elements, so we allow pseudo-elements on earlier selectors. This is against the spec, CSS2 section 5.10.
 	}
 
-	private final static HashSet<String> CSS2_BAD_SELECTOR= new HashSet<String>();
-	static
-	{
+	private final static HashSet<String> CSS2_BAD_SELECTOR= new HashSet<>();
+	static {
 		// Doubled =
 		CSS2_BAD_SELECTOR.add("h1[foo=bar=bat] {}");
 		CSS2_BAD_SELECTOR.add("h1[foo~=bar~=bat] {}");
@@ -147,9 +139,8 @@ public class CSSParserTest {
 
 
 	/** CSS3 Selectors */
-	private final static HashMap<String,String> CSS3_SELECTOR= new HashMap<String,String>();
-	static
-	{
+	private final static HashMap<String,String> CSS3_SELECTOR= new HashMap<>();
+	static {
 		CSS3_SELECTOR.put("tr:nth-child(odd) { background-color: red; }","tr:nth-child(odd) { background-color: red; }");
 		CSS3_SELECTOR.put("tr:nth-child(even) { background-color: yellow; }","tr:nth-child(even) { background-color: yellow; }");
 		CSS3_SELECTOR.put("tr:nth-child(1) {}","tr:nth-child(1)");
@@ -183,9 +174,8 @@ public class CSSParserTest {
 		CSS3_SELECTOR.put("h1:nth-last-of-type(even) {}","h1:nth-last-of-type(even)");
 	}
 
-	private final static HashSet<String> CSS3_BAD_SELECTOR= new HashSet<String>();
-	static
-	{
+	private final static HashSet<String> CSS3_BAD_SELECTOR= new HashSet<>();
+	static {
 		CSS3_BAD_SELECTOR.add("tr:nth-child() {}");
 		CSS3_BAD_SELECTOR.add("tr:nth-child(-) {}");
 		CSS3_BAD_SELECTOR.add("tr:nth-child(+) {}");
@@ -254,10 +244,10 @@ public class CSSParserTest {
 	private static final String CSS_IMPORT_SPACE_IN_STRING = "@import url(\"/chk@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test page\") screen;";
 	private static final String CSS_IMPORT_SPACE_IN_STRINGC = "@import url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page?type=text/css&maybecharset=UTF-8\") screen;";
 
-	private static final String CSS_IMPORT_QUOTED_STUFF = "@import url(\"/chk@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test page \\) \\\\ \\\' \\\" \") screen;";
+	private static final String CSS_IMPORT_QUOTED_STUFF = "@import url(\"/chk@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test page \\) \\\\ \\' \\\" \") screen;";
 	private static final String CSS_IMPORT_QUOTED_STUFFC = "@import url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page%20%29%20%5c%20%27%20%22%20?type=text/css&maybecharset=UTF-8\") screen;";
 
-	private static final String CSS_IMPORT_QUOTED_STUFF2 = "@import url(/chk@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test page \\) \\\\ \\\' \\\" ) screen;";
+	private static final String CSS_IMPORT_QUOTED_STUFF2 = "@import url(/chk@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test page \\) \\\\ \\' \\\" ) screen;";
 	private static final String CSS_IMPORT_QUOTED_STUFF2C = "@import url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page%20%29%20%5c%20%27%20%22?type=text/css&maybecharset=UTF-8\") screen;";
 
 	private static final String CSS_IMPORT_NOURL_TWOMEDIAS = "@import \"/chk@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/1-1.html\" screen tty;";
@@ -324,7 +314,7 @@ public class CSSParserTest {
 
 	private static final String CSS_INVALID_MEDIA_CASCADE = "@media blah { h1, h2 { color: green;} }";
 
-	private final static LinkedHashMap<String, String> propertyTests = new LinkedHashMap<String, String>();
+	private final static LinkedHashMap<String, String> propertyTests = new LinkedHashMap<>();
 	static {
 		// Check that the last part of a double bar works
 		propertyTests.put("@media speech { h1 { azimuth: behind }; }", "@media speech { h1 { azimuth: behind }}");
@@ -463,7 +453,6 @@ public class CSSParserTest {
 		// HTML tags are case insensitive, but we downcase them.
 		propertyTests.put("H3 { BACKGROUND: URL(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test page\") }", "H3 { BACKGROUND: url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }");
 		propertyTests.put("h3 { background: scroll url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }", "h3 { background: scroll url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }");
-		propertyTests.put("h3 { background: scroll #f00 url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }", "h3 { background: scroll #f00 url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }");
 		propertyTests.put("h3 { background: scroll #f00 url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }", "h3 { background: scroll #f00 url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }");
 		propertyTests.put("h3 { background: scroll rgb(100%, 2%, 1%) url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }", "h3 { background: scroll rgb(100%, 2%, 1%) url(\"/CHK@~~vxVQDfC9m8sR~M9zWJQKzCxLeZRWy6T1pWLM2XX74,2LY7xwOdUGv0AeJ2WKRXZG6NmiUL~oqVLKnh3XdviZU,AAIC--8/test%20page\") }");
 		propertyTests.put("h3 { background: 3.3cm 20%;}", "h3 { background: 3.3cm 20%;}");
@@ -825,11 +814,9 @@ public class CSSParserTest {
 		propertyTests.put("nav > ul { display: flex; }", "nav>ul { display: flex; }");
 		propertyTests.put("nav > ul > li {\n  min-width: 100px;\n  /* Prevent items from getting too small for their content. */\n  }", "nav>ul>li {\n  min-width: 100px;\n  \n  }");
 		propertyTests.put("nav > ul > #login {\n  margin-left: auto;\n}", "nav>ul>#login {\n  margin-left: auto;\n}");
-		propertyTests.put("nav > ul { display: flex; }", "nav>ul { display: flex; }");
 		propertyTests.put("div { flex-flow: row nowrap; }", "div { flex-flow: row nowrap; }");
 		propertyTests.put("div { flex-grow: 5; }", "div { flex-grow: 5; }");
 		propertyTests.put("div { flex: 64 content; }", "div { flex: 64 content; }");
-		propertyTests.put("div { flex-grow: 5; }", "div { flex-grow: 5; }");
 		propertyTests.put("div { flex-basis: 5px; }", "div { flex-basis: 5px; }");
 		propertyTests.put("div { flex-basis: content; }", "div { flex-basis: content; }");
 		propertyTests.put("div { flex: 64 ; }", "div { flex: 64; }");
@@ -880,8 +867,8 @@ public class CSSParserTest {
 		propertyTests.put("body { nav-left: div.bold '<target-name>'; }",  "body { }");
 		propertyTests.put("button#foo { nav-left: #bar \"sidebar\"; }", "button#foo { nav-left: #bar \"sidebar\"; }");
 		propertyTests.put("button#foo { nav-left: invalidSelector \"sidebar\"; }", "button#foo { }");
-		
-		// transition-* 
+
+		// transition-*
 		// valid, 1 value
 		propertyTests.put("div { transition-duration: 5s; }", "div { transition-duration: 5s; }");
 		propertyTests.put("div { transition-delay: 1s; }", "div { transition-delay: 1s; }");
@@ -918,104 +905,99 @@ public class CSSParserTest {
 
 	@Test
 	public void testCSS1Selector() throws IOException, URISyntaxException {
+		testCssSelectorFiltering(CSS1_SELECTOR);
+		assertEquals(
+			"key=\"" + CSS_DELETE_INVALID_SELECTOR + "\" value=\"" + filter(CSS_DELETE_INVALID_SELECTOR) + "\" should be \"" + CSS_DELETE_INVALID_SELECTORC + "\"",
+			CSS_DELETE_INVALID_SELECTORC,
+			filter(CSS_DELETE_INVALID_SELECTOR)
+		);
+		assertEquals(
+			"key=\"" + CSS_INVALID_MEDIA_CASCADE + "\" value=\"" + filter(CSS_INVALID_MEDIA_CASCADE) + "\"",
+			"",
+			filter(CSS_INVALID_MEDIA_CASCADE)
+		);
+	}
 
-
-		Collection<String> c = CSS1_SELECTOR.keySet();
-		Iterator<String> itr = c.iterator();
-		while(itr.hasNext())
-		{
-
-			String key=itr.next();
-			String value=CSS1_SELECTOR.get(key);
-			assertTrue("key=\""+key+"\" value=\""+filter(key)+"\" should be \""+value+"\"", filter(key).contains(value));
+	private void testCssSelectorFiltering(Map<String, String> cssSelectorMap) throws IOException, URISyntaxException {
+		for (Entry<String, String> entry : cssSelectorMap.entrySet()) {
+			String key = entry.getKey();
+			String value = entry.getValue();
+			assertTrue("key=\"" + key + "\" value=\"" + filter(key) + "\" should be \"" + value + "\"", filter(key).contains(value));
 		}
+	}
 
-		assertTrue("key=\""+CSS_DELETE_INVALID_SELECTOR+"\" value=\""+filter(CSS_DELETE_INVALID_SELECTOR)+"\" should be \""+CSS_DELETE_INVALID_SELECTORC+"\"", CSS_DELETE_INVALID_SELECTORC.equals(filter(CSS_DELETE_INVALID_SELECTOR)));
-		assertTrue("key=\""+CSS_INVALID_MEDIA_CASCADE+"\" value=\""+filter(CSS_INVALID_MEDIA_CASCADE)+"\"", "".equals(filter(CSS_INVALID_MEDIA_CASCADE)));
+	private void testBadSelectorFiltering(Set<String> badSelectorSet) throws IOException, URISyntaxException {
+		for(String key : badSelectorSet) {
+			assertEquals(
+				"Bad selector filtering should produce empty string: '" + key + "'",
+				"",
+				filter(key)
+			);
+		}
 	}
 
 	@Test
 	public void testCSS2Selector() throws IOException, URISyntaxException {
-		Collection<String> c = CSS2_SELECTOR.keySet();
-		Iterator<String> itr = c.iterator();
-		int i=0;
-		while(itr.hasNext())
-		{
-			String key=itr.next();
-			String value=CSS2_SELECTOR.get(key);
-			System.err.println("Test "+(i++)+" : "+key+" -> "+value);
-			assertTrue("key="+key+" value=\""+filter(key)+"\" should be \""+value+"\"", filter(key).contains(value));
-		}
-
-		i=0;
-		for(String key : CSS2_BAD_SELECTOR) {
-			System.err.println("Bad selector test "+(i++));
-			assertTrue("".equals(filter(key)));
-		}
-
+		testCssSelectorFiltering(CSS2_SELECTOR);
+		testBadSelectorFiltering(CSS2_BAD_SELECTOR);
 	}
 
 	@Test
 	public void testCSS3Selector() throws IOException, URISyntaxException {
-		Collection<String> c = CSS3_SELECTOR.keySet();
-		Iterator<String> itr = c.iterator();
-		int i=0;
-		while(itr.hasNext())
-		{
-			String key=itr.next();
-			String value=CSS3_SELECTOR.get(key);
-			System.err.println("CSS3 test"+(i++)+" : "+key+" -> "+value);
-			assertTrue("key="+key+" value=\""+filter(key)+"\" should be \""+value+"\"", filter(key).contains(value));
-		}
-
-		i=0;
-		for(String key : CSS3_BAD_SELECTOR) {
-			System.err.println("CSS3 bad selector test "+(i++));
-			assertTrue("".equals(filter(key)));
-		}
-
+		testCssSelectorFiltering(CSS3_SELECTOR);
+		testBadSelectorFiltering(CSS3_BAD_SELECTOR);
 	}
 
 	@Test
 	public void testNewlines() throws IOException, URISyntaxException {
-		assertTrue("key=\""+CSS_STRING_NEWLINES+"\" value=\""+filter(CSS_STRING_NEWLINES)+"\" should be: \""+CSS_STRING_NEWLINESC+"\"", CSS_STRING_NEWLINESC.equals(filter(CSS_STRING_NEWLINES)));
+		assertEquals(
+			"key=\"" + CSS_STRING_NEWLINES + "\" value=\"" + filter(CSS_STRING_NEWLINES) + "\" should be: \"" + CSS_STRING_NEWLINESC + "\"",
+			CSS_STRING_NEWLINESC,
+			filter(CSS_STRING_NEWLINES)
+		);
 	}
 
 	@Test
 	public void testBackgroundURL() throws IOException, URISyntaxException {
-		assertTrue("key="+CSS_BACKGROUND_URL+" value=\""+filter(CSS_BACKGROUND_URL)+"\" should be \""+CSS_BACKGROUND_URLC+"\"", CSS_BACKGROUND_URLC.equals(filter(CSS_BACKGROUND_URL)));
-
-		assertTrue("key="+CSS_LCASE_BACKGROUND_URL+" value=\""+filter(CSS_LCASE_BACKGROUND_URL)+"\"", CSS_LCASE_BACKGROUND_URLC.equals(filter(CSS_LCASE_BACKGROUND_URL)));
+		assertEquals("key=" + CSS_BACKGROUND_URL + " value=\"" + filter(CSS_BACKGROUND_URL) + "\" should be \"" + CSS_BACKGROUND_URLC + "\"",
+			CSS_BACKGROUND_URLC,
+			filter(CSS_BACKGROUND_URL)
+		);
+		assertEquals(
+			"key=" + CSS_LCASE_BACKGROUND_URL + " value=\"" + filter(CSS_LCASE_BACKGROUND_URL) + "\"",
+			CSS_LCASE_BACKGROUND_URLC,
+			filter(CSS_LCASE_BACKGROUND_URL)
+		);
 	}
 
 	@Test
 	public void testImports() throws IOException, URISyntaxException {
-		assertTrue("key="+CSS_IMPORT+" value=\""+filter(CSS_IMPORT)+"\"", CSS_IMPORTC.equals(filter(CSS_IMPORT)));
-		assertTrue("key="+CSS_IMPORT2+" value=\""+filter(CSS_IMPORT2)+"\"", CSS_IMPORT2C.equals(filter(CSS_IMPORT2)));
-		assertTrue("key="+CSS_IMPORT_MULTI_MEDIA+" value=\""+filter(CSS_IMPORT_MULTI_MEDIA)+"\"", CSS_IMPORT_MULTI_MEDIAC.equals(filter(CSS_IMPORT_MULTI_MEDIA)));
-		assertTrue("key="+CSS_IMPORT_MULTI_MEDIA_BOGUS+" value=\""+filter(CSS_IMPORT_MULTI_MEDIA_BOGUS)+"\"", CSS_IMPORT_MULTI_MEDIA_BOGUSC.equals(filter(CSS_IMPORT_MULTI_MEDIA_BOGUS)));
-		assertTrue("key="+CSS_IMPORT_MULTI_MEDIA_ALL+" value=\""+filter(CSS_IMPORT_MULTI_MEDIA_ALL)+"\"", CSS_IMPORT_MULTI_MEDIA_ALLC.equals(filter(CSS_IMPORT_MULTI_MEDIA_ALL)));
-		assertTrue("key="+CSS_IMPORT_TYPE+" value=\""+filter(CSS_IMPORT_TYPE)+"\"", CSS_IMPORT_TYPEC.equals(filter(CSS_IMPORT_TYPE)));
-		assertTrue("key="+CSS_IMPORT_SPACE_IN_STRING+" value=\""+filter(CSS_IMPORT_SPACE_IN_STRING)+"\"", CSS_IMPORT_SPACE_IN_STRINGC.equals(filter(CSS_IMPORT_SPACE_IN_STRING)));
-		assertTrue("key="+CSS_IMPORT_QUOTED_STUFF+" value=\""+filter(CSS_IMPORT_QUOTED_STUFF)+"\"", CSS_IMPORT_QUOTED_STUFFC.equals(filter(CSS_IMPORT_QUOTED_STUFF)));
-		assertTrue("key="+CSS_IMPORT_QUOTED_STUFF2+" value=\""+filter(CSS_IMPORT_QUOTED_STUFF2)+"\"", CSS_IMPORT_QUOTED_STUFF2C.equals(filter(CSS_IMPORT_QUOTED_STUFF2)));
-		assertTrue("key="+CSS_IMPORT_NOURL_TWOMEDIAS+" value=\""+filter(CSS_IMPORT_NOURL_TWOMEDIAS)+"\"", CSS_IMPORT_NOURL_TWOMEDIASC.equals(filter(CSS_IMPORT_NOURL_TWOMEDIAS)));
-		assertTrue("key="+CSS_IMPORT_UNQUOTED+" should be empty", "".equals(filter(CSS_IMPORT_UNQUOTED)));
-		assertTrue("key="+CSS_IMPORT_NOURL+" value=\""+filter(CSS_IMPORT_NOURL)+"\"", CSS_IMPORT_NOURLC.equals(filter(CSS_IMPORT_NOURL)));
-		assertTrue("key="+CSS_IMPORT_BRACKET+" value=\""+filter(CSS_IMPORT_BRACKET)+"\"", CSS_IMPORT_BRACKETC.equals(filter(CSS_IMPORT_BRACKET)));
-		assertTrue("key="+CSS_LATE_IMPORT+" value=\""+filter(CSS_LATE_IMPORT)+"\"", CSS_LATE_IMPORTC.equals(filter(CSS_LATE_IMPORT)));
-		assertTrue("key="+CSS_LATE_IMPORT2+" value=\""+filter(CSS_LATE_IMPORT2)+"\"", CSS_LATE_IMPORT2C.equals(filter(CSS_LATE_IMPORT2)));
-		assertTrue("key="+CSS_LATE_IMPORT3+" value=\""+filter(CSS_LATE_IMPORT3)+"\"", CSS_LATE_IMPORT3C.equals(filter(CSS_LATE_IMPORT3)));
-		assertTrue("key="+CSS_BOGUS_AT_RULE+" value=\""+filter(CSS_BOGUS_AT_RULE)+"\"", CSS_BOGUS_AT_RULEC.equals(filter(CSS_BOGUS_AT_RULE)));
-		assertTrue("key="+PRESERVE_CDO_CDC+" value=\""+filter(PRESERVE_CDO_CDC)+"\"", PRESERVE_CDO_CDCC.equals(filter(PRESERVE_CDO_CDC)));
-		assertTrue("key="+BROKEN_BEFORE_IMPORT+" value=\""+filter(BROKEN_BEFORE_IMPORT)+"\"", BROKEN_BEFORE_IMPORTC.equals(filter(BROKEN_BEFORE_IMPORT)));
-		assertTrue("key="+BROKEN_BEFORE_MEDIA+" value=\""+filter(BROKEN_BEFORE_MEDIA)+"\"", BROKEN_BEFORE_MEDIAC.equals(filter(BROKEN_BEFORE_MEDIA)));
+		assertEquals("key=" + CSS_IMPORT + " value=\"" + filter(CSS_IMPORT) + "\"", CSS_IMPORTC, filter(CSS_IMPORT));
+		assertEquals("key=" + CSS_IMPORT2 + " value=\"" + filter(CSS_IMPORT2) + "\"", CSS_IMPORT2C, filter(CSS_IMPORT2));
+		assertEquals("key=" + CSS_IMPORT_MULTI_MEDIA + " value=\"" + filter(CSS_IMPORT_MULTI_MEDIA) + "\"", CSS_IMPORT_MULTI_MEDIAC, filter(CSS_IMPORT_MULTI_MEDIA));
+		assertEquals("key=" + CSS_IMPORT_MULTI_MEDIA_BOGUS + " value=\"" + filter(CSS_IMPORT_MULTI_MEDIA_BOGUS) + "\"", CSS_IMPORT_MULTI_MEDIA_BOGUSC, filter(CSS_IMPORT_MULTI_MEDIA_BOGUS));
+		assertEquals("key=" + CSS_IMPORT_MULTI_MEDIA_ALL + " value=\"" + filter(CSS_IMPORT_MULTI_MEDIA_ALL) + "\"", CSS_IMPORT_MULTI_MEDIA_ALLC, filter(CSS_IMPORT_MULTI_MEDIA_ALL));
+		assertEquals("key=" + CSS_IMPORT_TYPE + " value=\"" + filter(CSS_IMPORT_TYPE) + "\"", CSS_IMPORT_TYPEC, filter(CSS_IMPORT_TYPE));
+		assertEquals("key=" + CSS_IMPORT_SPACE_IN_STRING + " value=\"" + filter(CSS_IMPORT_SPACE_IN_STRING) + "\"", CSS_IMPORT_SPACE_IN_STRINGC, filter(CSS_IMPORT_SPACE_IN_STRING));
+		assertEquals("key=" + CSS_IMPORT_QUOTED_STUFF + " value=\"" + filter(CSS_IMPORT_QUOTED_STUFF) + "\"", CSS_IMPORT_QUOTED_STUFFC, filter(CSS_IMPORT_QUOTED_STUFF));
+		assertEquals("key=" + CSS_IMPORT_QUOTED_STUFF2 + " value=\"" + filter(CSS_IMPORT_QUOTED_STUFF2) + "\"", CSS_IMPORT_QUOTED_STUFF2C, filter(CSS_IMPORT_QUOTED_STUFF2));
+		assertEquals("key=" + CSS_IMPORT_NOURL_TWOMEDIAS + " value=\"" + filter(CSS_IMPORT_NOURL_TWOMEDIAS) + "\"", CSS_IMPORT_NOURL_TWOMEDIASC, filter(CSS_IMPORT_NOURL_TWOMEDIAS));
+		assertEquals("key=" + CSS_IMPORT_UNQUOTED + " should be empty", "", filter(CSS_IMPORT_UNQUOTED));
+		assertEquals("key=" + CSS_IMPORT_NOURL + " value=\"" + filter(CSS_IMPORT_NOURL) + "\"", CSS_IMPORT_NOURLC, filter(CSS_IMPORT_NOURL));
+		assertEquals("key=" + CSS_IMPORT_BRACKET + " value=\"" + filter(CSS_IMPORT_BRACKET) + "\"", CSS_IMPORT_BRACKETC, filter(CSS_IMPORT_BRACKET));
+		assertEquals("key=" + CSS_LATE_IMPORT + " value=\"" + filter(CSS_LATE_IMPORT) + "\"", CSS_LATE_IMPORTC, filter(CSS_LATE_IMPORT));
+		assertEquals("key=" + CSS_LATE_IMPORT2 + " value=\"" + filter(CSS_LATE_IMPORT2) + "\"", CSS_LATE_IMPORT2C, filter(CSS_LATE_IMPORT2));
+		assertEquals("key=" + CSS_LATE_IMPORT3 + " value=\"" + filter(CSS_LATE_IMPORT3) + "\"", CSS_LATE_IMPORT3C, filter(CSS_LATE_IMPORT3));
+		assertEquals("key=" + CSS_BOGUS_AT_RULE + " value=\"" + filter(CSS_BOGUS_AT_RULE) + "\"", CSS_BOGUS_AT_RULEC, filter(CSS_BOGUS_AT_RULE));
+		assertEquals("key=" + PRESERVE_CDO_CDC + " value=\"" + filter(PRESERVE_CDO_CDC) + "\"", PRESERVE_CDO_CDCC, filter(PRESERVE_CDO_CDC));
+		assertEquals("key=" + BROKEN_BEFORE_IMPORT + " value=\"" + filter(BROKEN_BEFORE_IMPORT) + "\"", BROKEN_BEFORE_IMPORTC, filter(BROKEN_BEFORE_IMPORT));
+		assertEquals("key=" + BROKEN_BEFORE_MEDIA + " value=\"" + filter(BROKEN_BEFORE_MEDIA) + "\"", BROKEN_BEFORE_MEDIAC, filter(BROKEN_BEFORE_MEDIA));
 	}
 
 	@Test
 	public void testEscape() throws IOException, URISyntaxException {
-		assertTrue("key="+CSS_ESCAPED_LINK+" value=\""+filter(CSS_ESCAPED_LINK)+"\"", CSS_ESCAPED_LINKC.equals(filter(CSS_ESCAPED_LINK)));
-		assertTrue("key="+CSS_ESCAPED_LINK2+" value=\""+filter(CSS_ESCAPED_LINK2)+"\"", CSS_ESCAPED_LINK2C.equals(filter(CSS_ESCAPED_LINK2)));
+		assertEquals("key=" + CSS_ESCAPED_LINK + " value=\"" + filter(CSS_ESCAPED_LINK) + "\"", CSS_ESCAPED_LINKC, filter(CSS_ESCAPED_LINK));
+		assertEquals("key=" + CSS_ESCAPED_LINK2 + " value=\"" + filter(CSS_ESCAPED_LINK2) + "\"", CSS_ESCAPED_LINK2C, filter(CSS_ESCAPED_LINK2));
 	}
 
 	@Test
@@ -1023,7 +1005,7 @@ public class CSSParserTest {
 		for(Entry<String, String> entry : propertyTests.entrySet()) {
 			String key = entry.getKey();
 			String value = entry.getValue();
-			assertTrue("key=\""+key+"\" encoded=\""+filter(key)+"\" should be \""+value+"\"", value.equals(filter(key)));
+			assertEquals("key=\"" + key + "\" encoded=\"" + filter(key) + "\" should be \"" + value + "\"", value, filter(key));
 		}
 	}
 
@@ -1039,23 +1021,23 @@ public class CSSParserTest {
 	public void testCharset() throws IOException, URISyntaxException {
 		// Test whether @charset is passed through when it is correct.
 		String test = "@charset \"UTF-8\";\nh2 { color: red;}";
-		assertTrue("key=\""+test+"\" value=\""+filter(test)+"\"", filter(test).equals(test));
+		assertEquals("key=\"" + test + "\" value=\"" + filter(test) + "\"", filter(test), test);
 		// No quote marks
 		String testUnquoted = "@charset UTF-8;\nh2 { color: red;}";
-		assertTrue("key=\""+test+"\" value=\""+filter(test)+"\"", filter(testUnquoted).equals(test));
+		assertEquals("key=\"" + test + "\" value=\"" + filter(test) + "\"", filter(testUnquoted), test);
 		// Test whether the parse fails when @charset is not correct.
 		String testFail = "@charset ISO-8859-1;\nh2 { color: red;};";
-		try {
-			filter(test).equals("");
-			assertFalse("Bogus @charset should have been deleted, but result is \""+filter(testFail)+"\"", false);
-		} catch (IOException e) {
-			// Ok.
-		}
+		assertThrows(
+			"Bogus @charset should have been deleted",
+			IOException.class,
+			()-> filter(testFail)
+		);
+
 		// Test charset extraction
 		getCharsetTest("UTF-8");
 		getCharsetTest("UTF-16BE");
 		getCharsetTest("UTF-16LE");
-		// not availiable in java 1.5.0_22
+		// FIXME: these next two are not supported or produce errors
 		// getCharsetTest("UTF-32BE");
 		// getCharsetTest("UTF-32LE");
 
@@ -1083,37 +1065,33 @@ public class CSSParserTest {
 		charsetTestUnsupported("IBM01149");
 
 		// Late charset is invalid
-		assertTrue("key="+LATE_CHARSET+" value=\""+filter(LATE_CHARSET)+"\"", LATE_CHARSETC.equals(filter(LATE_CHARSET)));
+		assertEquals("key=" + LATE_CHARSET + " value=\"" + filter(LATE_CHARSET) + "\"", LATE_CHARSETC, filter(LATE_CHARSET));
 		try {
 			String output = filter(WRONG_CHARSET);
-			assertFalse("Should complain that detected charset differs from real charset, but returned \""+output+"\"", true);
+			fail("Should complain that detected charset differs from real charset, but returned \"" + output + "\"");
 		} catch (IOException e) {
 			// Ok.
 			// FIXME should have a dedicated exception.
 		}
 		try {
 			String output = filter(NONSENSE_CHARSET);
-			assertFalse("wrong charset output is \""+output+"\" but it should throw!", true);
+			fail("wrong charset output is \"" + output + "\" but it should throw!");
 		} catch (UnsupportedCharsetInFilterException e) {
 			// Ok.
 		}
 
-		assertTrue(BOM.equals(filter(BOM)));
-		assertTrue("output=\""+filter(LATE_BOM)+"\"",LATE_BOMC.equals(filter(LATE_BOM)));
+		assertEquals(BOM, filter(BOM));
+		assertEquals("output=\"" + filter(LATE_BOM) + "\"", LATE_BOMC, filter(LATE_BOM));
 	}
 
-	private void getCharsetTest(String charset) throws DataFilterException, IOException, URISyntaxException {
+	private void getCharsetTest(String charset) throws IOException, URISyntaxException {
 		getCharsetTest(charset, null);
 	}
 
-	private void getCharsetTest(String charset, String family) throws DataFilterException, IOException, URISyntaxException {
+	private void getCharsetTest(String charset, String family) throws IOException, URISyntaxException {
 		String original = "@charset \""+charset+"\";\nh2 { color: red;}";
 		byte[] bytes = original.getBytes(charset);
 		CSSReadFilter filter = new CSSReadFilter();
-		ArrayBucket inputBucket = new ArrayBucket(bytes);
-		ArrayBucket outputBucket = new ArrayBucket();
-		InputStream inputStream = inputBucket.getInputStream();
-		OutputStream outputStream = outputBucket.getOutputStream();
 		// Detect with original charset.
 		String detectedCharset = filter.getCharset(bytes, bytes.length, charset);
 		assertTrue("Charset detected \""+detectedCharset+"\" should be \""+charset+"\" even when parsing with correct charset", charset.equalsIgnoreCase(detectedCharset));
@@ -1122,83 +1100,111 @@ public class CSSParserTest {
 		assertTrue("Charset detected \""+detectedCharset+"\" should be \""+charset+"\" or \""+family+"\" from getCharsetByBOM", detectedCharset == null || charset.equalsIgnoreCase(detectedCharset) || (family != null && family.equalsIgnoreCase(detectedCharset)));
 		detectedCharset = ContentFilter.detectCharset(bytes, bytes.length, cssMIMEType, null);
 		assertTrue("Charset detected \""+detectedCharset+"\" should be \""+charset+"\" from ContentFilter.detectCharset bom=\""+bomCharset+"\"", charset.equalsIgnoreCase(detectedCharset));
-		FilterStatus filterStatus = ContentFilter.filter(inputStream, outputStream, "text/css", new URI("/CHK@OR904t6ylZOwoobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4oobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4Kqot8akqmKYXJbkD-fSj6noOVGB-K2YisZ4,AAIC--8/1-works.html"),
-        null, null, null, null);
-		inputStream.close();
-		outputStream.close();
+
+		ArrayBucket inputBucket = new ArrayBucket(bytes);
+		ArrayBucket outputBucket = new ArrayBucket();
+		FilterStatus filterStatus;
+		try (
+			InputStream inputStream = inputBucket.getInputStream();
+			OutputStream outputStream = outputBucket.getOutputStream()
+		) {
+			filterStatus = ContentFilter.filter(inputStream, outputStream, "text/css", new URI("/CHK@OR904t6ylZOwoobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4oobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4Kqot8akqmKYXJbkD-fSj6noOVGB-K2YisZ4,AAIC--8/1-works.html"),
+				null, null, null, null
+			);
+		}
 		assertEquals("text/css", filterStatus.mimeType);
 		assertEquals(charset, filterStatus.charset);
 		String filtered = new String(BucketTools.toByteArray(outputBucket), charset);
-		assertTrue("ContentFilter.filter() returns \""+filtered+"\" not original \""+original+"\" for charset \""+charset+"\"", original.equals(filtered));
+		assertEquals(
+			"ContentFilter.filter() returns \"" + filtered + "\" not original \"" + original + "\" for charset \"" + charset + "\"",
+			original,
+			filtered
+		);
 	}
 
-	private void charsetTestUnsupported(String charset) throws DataFilterException, IOException, URISyntaxException {
+	private void charsetTestUnsupported(String charset) throws IOException, URISyntaxException {
 		String original = "@charset \""+charset+"\";\nh2 { color: red;}";
 		byte[] bytes = original.getBytes(charset);
 		CSSReadFilter filter = new CSSReadFilter();
-		SimpleReadOnlyArrayBucket inputBucket = new SimpleReadOnlyArrayBucket(bytes);
-		Bucket outputBucket = new ArrayBucket();
-		InputStream inputStream = inputBucket.getInputStream();
-		OutputStream outputStream = outputBucket.getOutputStream();
 		String detectedCharset;
 		BOMDetection bom = filter.getCharsetByBOM(bytes, bytes.length);
 		String bomCharset = detectedCharset = bom == null ? null : bom.charset;
-		assertTrue("Charset detected \""+detectedCharset+"\" should be unknown testing unsupported charset \""+charset+"\" from getCharsetByBOM", detectedCharset == null);
+		assertNull(
+			"Charset detected \"" + detectedCharset + "\" should be unknown testing unsupported charset \"" + charset + "\" from getCharsetByBOM",
+			detectedCharset
+		);
 		detectedCharset = ContentFilter.detectCharset(bytes, bytes.length, cssMIMEType, null);
-		assertTrue("Charset detected \""+detectedCharset+"\" should be unknown testing unsupported charset \""+charset+"\" from ContentFilter.detectCharset bom=\""+bomCharset+"\"", charset == null || "utf-8".equalsIgnoreCase(detectedCharset));
-		try {
-			FilterStatus filterStatus = ContentFilter.filter(inputStream, outputStream, "text/css", new URI("/CHK@OR904t6ylZOwoobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4Kqot8akqmKYXJbkD-fSj6noOVGB-K2YisZ4,AAIC--8/1-works.html"),
-          null,null, null, null);
-			// It is safe to return utf-8, as long as we clobber the actual content; utf-8 is the default, but other stuff decoded to it is unlikely to be coherent...
-			assertTrue("ContentFilter.filter() returned charset \""+filterStatus.charset+"\" should be unknown testing  unsupported charset \""+charset+"\"", filterStatus.charset.equalsIgnoreCase(charset) || filterStatus.charset.equalsIgnoreCase("utf-8"));//If we switch to JUnit 4, this may be replaced with an assertThat
-			assertEquals("text/css", filterStatus.mimeType);
-			String filtered = new String(BucketTools.toByteArray(outputBucket), charset);
-			assertTrue("ContentFilter.filter() returns something: \""+filtered+"\" should be empty as unsupported charset, original: \""+original+"\" for charset \""+charset+"\"", filtered.equals(""));
-		} catch (UnsupportedCharsetInFilterException e) {
-			// Ok.
-		} catch (IOException e) {
-			// Ok.
+		assertTrue(
+			"Charset detected \""+detectedCharset+"\" should be unknown testing unsupported charset \""+charset+"\" from ContentFilter.detectCharset bom=\""+bomCharset+"\"",
+			"utf-8".equalsIgnoreCase(detectedCharset)
+		);
+		SimpleReadOnlyArrayBucket inputBucket = new SimpleReadOnlyArrayBucket(bytes);
+		Bucket outputBucket = new ArrayBucket();
+		FilterStatus filterStatus;
+		try (
+			InputStream inputStream = inputBucket.getInputStream();
+			OutputStream outputStream = outputBucket.getOutputStream()
+		) {
+			filterStatus = ContentFilter.filter(inputStream, outputStream, "text/css", new URI("/CHK@OR904t6ylZOwoobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4Kqot8akqmKYXJbkD-fSj6noOVGB-K2YisZ4,AAIC--8/1-works.html"),
+				null, null, null, null);
 		}
-		finally {
-			inputStream.close();
-			outputStream.close();
-		}
+		// It is safe to return utf-8, as long as we clobber the actual content; utf-8 is the default, but other stuff decoded to it is unlikely to be coherent...
+		MatcherAssert.assertThat(
+			"ContentFilter.filter() returned charset \""+filterStatus.charset+"\" should be unknown testing  unsupported charset \""+charset+"\"",
+			filterStatus.charset,
+			anyOf(
+				equalToIgnoringCase(charset),
+				equalToIgnoringCase("utf-8")
+			)
+		);
+		assertEquals("text/css", filterStatus.mimeType);
+		String filtered = new String(BucketTools.toByteArray(outputBucket), charset);
+		assertEquals(
+			"ContentFilter.filter() returns something: \"" + filtered + "\" should be empty as unsupported charset, original: \"" + original + "\" for charset \"" + charset + "\"",
+			"",
+			filtered
+		);
 	}
 
 	@Test
-	public void testMaybeCharset() throws UnsafeContentTypeException, URISyntaxException, IOException {
+	public void testMaybeCharset() throws URISyntaxException, IOException {
 		testUseMaybeCharset("UTF-8");
 		testUseMaybeCharset("UTF-16");
-		// not availiable in java 1.5.0_22
-		// testUseMaybeCharset("UTF-32LE");
+		testUseMaybeCharset("UTF-32LE");
 		testUseMaybeCharset("IBM01140");
 	}
 
-	private void testUseMaybeCharset(String charset) throws URISyntaxException, UnsafeContentTypeException, IOException {
+	private void testUseMaybeCharset(String charset) throws URISyntaxException, IOException {
 		String original = "h2 { color: red;}";
 		byte[] bytes = original.getBytes(charset);
 		SimpleReadOnlyArrayBucket inputBucket = new SimpleReadOnlyArrayBucket(bytes);
 		Bucket outputBucket = new ArrayBucket();
-		InputStream inputStream = inputBucket.getInputStream();
-		OutputStream outputStream = outputBucket.getOutputStream();
-		FilterStatus filterStatus = ContentFilter.filter(inputStream, outputStream, "text/css", new URI("/CHK@OR904t6ylZOwoobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4Kqot8akqmKYXJbkD-fSj6noOVGB-K2YisZ4,AAIC--8/1-works.html"),
-        null,null, null, charset);
-		inputStream.close();
-		outputStream.close();
+		FilterStatus filterStatus;
+		try (
+			InputStream inputStream = inputBucket.getInputStream();
+			OutputStream outputStream = outputBucket.getOutputStream()
+		) {
+			filterStatus = ContentFilter.filter(inputStream, outputStream, "text/css", new URI("/CHK@OR904t6ylZOwoobMJRmSn7HsPGefHSP7zAjoLyenSPw,x2EzszO4Kqot8akqmKYXJbkD-fSj6noOVGB-K2YisZ4,AAIC--8/1-works.html"),
+				null, null, null, charset);
+		}
 		assertEquals(charset, filterStatus.charset);
 		assertEquals("text/css", filterStatus.mimeType);
 		String filtered = new String(BucketTools.toByteArray(outputBucket), charset);
-		assertTrue("ContentFilter.filter() returns \""+filtered+"\" not original \""+original+"\" with maybeCharset \""+charset+"\"", original.equals(filtered));
+		assertEquals(
+			"ContentFilter.filter() returns \"" + filtered + "\" not original \"" + original + "\" with maybeCharset \"" + charset + "\"",
+			original,
+			filtered
+		);
 	}
 
 	@Test
 	public void testComment() throws IOException, URISyntaxException {
-		assertTrue("value=\""+filter(COMMENT)+"\"",COMMENTC.equals(filter(COMMENT)));
+		assertEquals("value=\"" + filter(COMMENT) + "\"", COMMENTC, filter(COMMENT));
 	}
 
 	@Test
 	public void testWhitespace() throws IOException, URISyntaxException {
-		assertTrue("value=\""+filter(CSS_COMMA_WHITESPACE)+"\"", CSS_COMMA_WHITESPACE.equals(filter(CSS_COMMA_WHITESPACE)));
+		assertEquals("value=\"" + filter(CSS_COMMA_WHITESPACE) + "\"", CSS_COMMA_WHITESPACE, filter(CSS_COMMA_WHITESPACE));
 	}
 
 	@Test

--- a/test/freenet/client/filter/CSSParserTest.java
+++ b/test/freenet/client/filter/CSSParserTest.java
@@ -11,8 +11,12 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.Before;
@@ -927,7 +931,7 @@ public class CSSParserTest {
 	}
 
 	private void testBadSelectorFiltering(Set<String> badSelectorSet) throws IOException, URISyntaxException {
-		for(String key : badSelectorSet) {
+		for (String key : badSelectorSet) {
 			assertEquals(
 				"Bad selector filtering should produce empty string: '" + key + "'",
 				"",

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -3,15 +3,20 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.filter;
 
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import freenet.client.filter.ContentFilter.FilterStatus;
@@ -27,360 +32,363 @@ import freenet.support.io.ArrayBucket;
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
  */
 public class ContentFilterTest {
-	private static final String BASE_URI_PROTOCOL = "http";
-	private static final String BASE_URI_CONTENT = "localhost:8888";
-	private static final String BASE_KEY = "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
-	private static final String BASE_URI = BASE_URI_PROTOCOL+"://"+BASE_URI_CONTENT+'/';
-	private static final String ALT_BASE_URI = BASE_URI_PROTOCOL+"://"+BASE_URI_CONTENT+'/'+BASE_KEY;
+    private static final String BASE_URI_PROTOCOL = "http";
+    private static final String BASE_URI_CONTENT = "localhost:8888";
+    private static final String BASE_KEY = "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
+    private static final String BASE_URI = BASE_URI_PROTOCOL + "://" + BASE_URI_CONTENT + '/';
+    private static final String ALT_BASE_URI = BASE_URI_PROTOCOL + "://" + BASE_URI_CONTENT + '/' + BASE_KEY;
 
-	private static final String EXTERNAL_LINK = "www.evilwebsite.gov";
-	private static final String EXTERNAL_LINK_OK = "<a />";
-	// check that external links are not allowed
-	private static final String EXTERNAL_LINK_CHECK1 = "<a href=\""+EXTERNAL_LINK+"\"/>";
-	private static final String EXTERNAL_LINK_CHECK2 = "<a href=\""+BASE_URI_PROTOCOL+"://"+EXTERNAL_LINK+"\"/>";
-	private static final String EXTERNAL_LINK_CHECK3 = "<a href=\""+BASE_URI_CONTENT+"@http://"+EXTERNAL_LINK+"\"/>";
+    private static final String EXTERNAL_LINK = "www.evilwebsite.gov";
+    private static final String EXTERNAL_LINK_OK = "<a />";
+    // check that external links are not allowed
+    private static final String EXTERNAL_LINK_CHECK1 = "<a href=\"" + EXTERNAL_LINK + "\"/>";
+    private static final String EXTERNAL_LINK_CHECK2 = "<a href=\"" + BASE_URI_PROTOCOL + "://" + EXTERNAL_LINK + "\"/>";
+    private static final String EXTERNAL_LINK_CHECK3 = "<a href=\"" + BASE_URI_CONTENT + "@http://" + EXTERNAL_LINK + "\"/>";
 
-	private static final String INTERNAL_RELATIVE_LINK = "<a href=\"/KSK@gpl.txt\" />";
-	private static final String INTERNAL_ABSOLUTE_LINK = "<a href=\""+BASE_URI+"KSK@gpl.txt\" />";
+    private static final String INTERNAL_RELATIVE_LINK = "<a href=\"/KSK@gpl.txt\" />";
+    private static final String INTERNAL_ABSOLUTE_LINK = "<a href=\"" + BASE_URI + "KSK@gpl.txt\" />";
 
-	private static final String INTERNAL_RELATIVE_LINK1 = "<a href=\"test.html\" />";
+    private static final String INTERNAL_RELATIVE_LINK1 = "<a href=\"test.html\" />";
 
-	// @see bug #710
-	private static final String ANCHOR_TEST = "<a href=\"#test\" />";
-	private static final String ANCHOR_TEST_EMPTY = "<a href=\"#\" />";
-	private static final String ANCHOR_TEST_SPECIAL = "<a href=\"#!$()*+,;=:@ABC0123-._~xyz%3f\" />"; // RFC3986 / RFC 2396
-	private static final String ANCHOR_TEST_SPECIAL2 = "<a href=\"#!$&'()*+,;=:@ABC0123-._~xyz%3f\" />";
-	private static final String ANCHOR_TEST_SPECIAL2_RESULT = "<a href=\"#!$&amp;&#39;()*+,;=:@ABC0123-._~xyz%3f\" />";
+    // @see bug #710
+    private static final String ANCHOR_TEST = "<a href=\"#test\" />";
+    private static final String ANCHOR_TEST_EMPTY = "<a href=\"#\" />";
+    private static final String ANCHOR_TEST_SPECIAL = "<a href=\"#!$()*+,;=:@ABC0123-._~xyz%3f\" />"; // RFC3986 / RFC 2396
+    private static final String ANCHOR_TEST_SPECIAL2 = "<a href=\"#!$&'()*+,;=:@ABC0123-._~xyz%3f\" />";
+    private static final String ANCHOR_TEST_SPECIAL2_RESULT = "<a href=\"#!$&amp;&#39;()*+,;=:@ABC0123-._~xyz%3f\" />";
 
-	// @see bug #2496
-	private static final String ANCHOR_RELATIVE1 = "<a href=\"/KSK@test/test.html#C2\">";
-	private static final String ANCHOR_RELATIVE2 = "<a href=\"/KSK@test/path/test.html#C2\">";
-	private static final String ANCHOR_FALSE_POS1 = "<a href=\"/KSK@test/path/test.html#%23\">"; // yes, this is valid
-	private static final String ANCHOR_FALSE_POS2 = "<a href=\"/KSK@test/path/%23.html#2\">"; // yes, this is valid too
+    // @see bug #2496
+    private static final String ANCHOR_RELATIVE1 = "<a href=\"/KSK@test/test.html#C2\">";
+    private static final String ANCHOR_RELATIVE2 = "<a href=\"/KSK@test/path/test.html#C2\">";
+    private static final String ANCHOR_FALSE_POS1 = "<a href=\"/KSK@test/path/test.html#%23\">"; // yes, this is valid
+    private static final String ANCHOR_FALSE_POS2 = "<a href=\"/KSK@test/path/%23.html#2\">"; // yes, this is valid too
 
-	// evil hack for #2496 + #2451, <SPACE><#> give <SPACE><%23>
-	private static final String ANCHOR_MIXED = "<a href=\"/KSK@test/path/music #1.ogg\">";
-	private static final String ANCHOR_MIXED_RESULT = "<a href=\"/KSK@test/path/music%20%231.ogg\">";
+    // evil hack for #2496 + #2451, <SPACE><#> give <SPACE><%23>
+    private static final String ANCHOR_MIXED = "<a href=\"/KSK@test/path/music #1.ogg\">";
+    private static final String ANCHOR_MIXED_RESULT = "<a href=\"/KSK@test/path/music%20%231.ogg\">";
 
-	// @see bug #2451
-	private static final String POUNT_CHARACTER_ENCODING_TEST = "<a href=\"/CHK@DUiGC5D1ZsnFpH07WGkNVDujNlxhtgGxXBKrMT-9Rkw,~GrAWp02o9YylpxL1Fr4fPDozWmebhGv4qUoFlrxnY4,AAIC--8/Testing - [blah] Apostrophe' - gratuitous 1 AND CAPITAL LETTERS!!!!.ogg\" />";
-	private static final String POUNT_CHARACTER_ENCODING_TEST_RESULT = "<a href=\"/CHK@DUiGC5D1ZsnFpH07WGkNVDujNlxhtgGxXBKrMT-9Rkw,~GrAWp02o9YylpxL1Fr4fPDozWmebhGv4qUoFlrxnY4,AAIC--8/Testing%20-%20%5bblah%5d%20Apostrophe%27%20-%20gratuitous%201%20AND%20CAPITAL%20LETTERS%21%21%21%21.ogg\" />";
-	// @see bug #2297
-	private static final String PREVENT_FPROXY_ACCESS = "<a href=\""+BASE_URI+"\"/>";
-	// @see bug #2921
-	private static final String PREVENT_EXTERNAL_ACCESS_CSS_SIMPLE = "<style>div { background: url("+BASE_URI+") }</style>";
-	private static final String PREVENT_EXTERNAL_ACCESS_CSS_CASE = "<style>div { background: uRl("+BASE_URI+") }</style>";
-	private static final String PREVENT_EXTERNAL_ACCESS_CSS_ESCAPE = "<style>div { background: \\u\\r\\l("+BASE_URI+") }</style>";
-	private static final String WHITELIST_STATIC_CONTENT = "<a href=\"/static/themes/clean/theme.css\" />";
-	private static final String XHTML_VOIDELEMENT="<html xmlns=\"http://www.w3.org/1999/xhtml\"><br><hr></html>";
-	private static final String XHTML_VOIDELEMENTC="<html xmlns=\"http://www.w3.org/1999/xhtml\"><br /><hr /></html>";
-	private static final String XHTML_INCOMPLETEDOCUMENT="<html xmlns=\"http://www.w3.org/1999/xhtml\"><body> <h1> helloworld <h2> helloworld";
-	private static final String XHTML_INCOMPLETEDOCUMENTC="<html xmlns=\"http://www.w3.org/1999/xhtml\"><body> <h1> helloworld <h2> helloworld</h2></h1></body></html>";
-	private static final String XHTML_IMPROPERNESTING="<html xmlns=\"http://www.w3.org/1999/xhtml\"><b><i>helloworld</b></i></html>";
-	private static final String XHTML_IMPROPERNESTINGC="<html xmlns=\"http://www.w3.org/1999/xhtml\"><b><i>helloworld</i></b></html>";
+    // @see bug #2451
+    private static final String POUNT_CHARACTER_ENCODING_TEST = "<a href=\"/CHK@DUiGC5D1ZsnFpH07WGkNVDujNlxhtgGxXBKrMT-9Rkw,~GrAWp02o9YylpxL1Fr4fPDozWmebhGv4qUoFlrxnY4,AAIC--8/Testing - [blah] Apostrophe' - gratuitous 1 AND CAPITAL LETTERS!!!!.ogg\" />";
+    private static final String POUNT_CHARACTER_ENCODING_TEST_RESULT = "<a href=\"/CHK@DUiGC5D1ZsnFpH07WGkNVDujNlxhtgGxXBKrMT-9Rkw,~GrAWp02o9YylpxL1Fr4fPDozWmebhGv4qUoFlrxnY4,AAIC--8/Testing%20-%20%5bblah%5d%20Apostrophe%27%20-%20gratuitous%201%20AND%20CAPITAL%20LETTERS%21%21%21%21.ogg\" />";
+    // @see bug #2297
+    private static final String PREVENT_FPROXY_ACCESS = "<a href=\"" + BASE_URI + "\"/>";
+    // @see bug #2921
+    private static final String PREVENT_EXTERNAL_ACCESS_CSS_SIMPLE = "<style>div { background: url(" + BASE_URI + ") }</style>";
+    private static final String PREVENT_EXTERNAL_ACCESS_CSS_CASE = "<style>div { background: uRl(" + BASE_URI + ") }</style>";
+    private static final String PREVENT_EXTERNAL_ACCESS_CSS_ESCAPE = "<style>div { background: \\u\\r\\l(" + BASE_URI + ") }</style>";
+    private static final String WHITELIST_STATIC_CONTENT = "<a href=\"/static/themes/clean/theme.css\" />";
+    private static final String XHTML_VOIDELEMENT = "<html xmlns=\"http://www.w3.org/1999/xhtml\"><br><hr></html>";
+    private static final String XHTML_VOIDELEMENTC = "<html xmlns=\"http://www.w3.org/1999/xhtml\"><br /><hr /></html>";
+    private static final String XHTML_INCOMPLETEDOCUMENT = "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body> <h1> helloworld <h2> helloworld";
+    private static final String XHTML_INCOMPLETEDOCUMENTC = "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body> <h1> helloworld <h2> helloworld</h2></h1></body></html>";
+    private static final String XHTML_IMPROPERNESTING = "<html xmlns=\"http://www.w3.org/1999/xhtml\"><b><i>helloworld</b></i></html>";
+    private static final String XHTML_IMPROPERNESTINGC = "<html xmlns=\"http://www.w3.org/1999/xhtml\"><b><i>helloworld</i></b></html>";
 
-	private static final String CSS_STRING_NEWLINES = "<style>* { content: \"this string does not terminate\n}\nbody {\nbackground: url(http://www.google.co.uk/intl/en_uk/images/logo.gif); }\n\" }</style>";
-	private static final String CSS_STRING_NEWLINESC = "<style>* {}\nbody { }\n</style>";
+    private static final String CSS_STRING_NEWLINES = "<style>* { content: \"this string does not terminate\n}\nbody {\nbackground: url(http://www.google.co.uk/intl/en_uk/images/logo.gif); }\n\" }</style>";
+    private static final String CSS_STRING_NEWLINESC = "<style>* {}\nbody { }\n</style>";
 
-	private static final String HTML_STYLESHEET_MAYBECHARSET = "<link rel=\"stylesheet\" href=\"test.css\">";
-	private static final String HTML_STYLESHEET_MAYBECHARSETC = "<link rel=\"stylesheet\" href=\"test.css?type=text/css&amp;maybecharset=iso-8859-1\" type=\"text/css\">";
+    private static final String HTML_STYLESHEET_MAYBECHARSET = "<link rel=\"stylesheet\" href=\"test.css\">";
+    private static final String HTML_STYLESHEET_MAYBECHARSETC = "<link rel=\"stylesheet\" href=\"test.css?type=text/css&amp;maybecharset=iso-8859-1\" type=\"text/css\">";
 
-	private static final String HTML_STYLESHEET_CHARSET = "<link rel=\"stylesheet\" charset=\"utf-8\" href=\"test.css\">";
-	private static final String HTML_STYLESHEET_CHARSETC = "<link rel=\"stylesheet\" charset=\"utf-8\" href=\"test.css?type=text/css%3b%20charset=utf-8\" type=\"text/css\">";
+    private static final String HTML_STYLESHEET_CHARSET = "<link rel=\"stylesheet\" charset=\"utf-8\" href=\"test.css\">";
+    private static final String HTML_STYLESHEET_CHARSETC = "<link rel=\"stylesheet\" charset=\"utf-8\" href=\"test.css?type=text/css%3b%20charset=utf-8\" type=\"text/css\">";
 
-	private static final String HTML_STYLESHEET_CHARSET_BAD = "<link rel=\"stylesheet\" charset=\"utf-8&max-size=4194304\" href=\"test.css\">";
-	private static final String HTML_STYLESHEET_CHARSET_BADC = "<link rel=\"stylesheet\" href=\"test.css?type=text/css&amp;maybecharset=iso-8859-1\" type=\"text/css\">";
+    private static final String HTML_STYLESHEET_CHARSET_BAD = "<link rel=\"stylesheet\" charset=\"utf-8&max-size=4194304\" href=\"test.css\">";
+    private static final String HTML_STYLESHEET_CHARSET_BADC = "<link rel=\"stylesheet\" href=\"test.css?type=text/css&amp;maybecharset=iso-8859-1\" type=\"text/css\">";
 
-	private static final String HTML_STYLESHEET_CHARSET_BAD1 = "<link rel=\"stylesheet\" type=\"text/css; charset=utf-8&max-size=4194304\" href=\"test.css\">";
-	private static final String HTML_STYLESHEET_CHARSET_BAD1C = "<link rel=\"stylesheet\" type=\"text/css\" href=\"test.css?type=text/css&amp;maybecharset=iso-8859-1\">";
+    private static final String HTML_STYLESHEET_CHARSET_BAD1 = "<link rel=\"stylesheet\" type=\"text/css; charset=utf-8&max-size=4194304\" href=\"test.css\">";
+    private static final String HTML_STYLESHEET_CHARSET_BAD1C = "<link rel=\"stylesheet\" type=\"text/css\" href=\"test.css?type=text/css&amp;maybecharset=iso-8859-1\">";
 
-	private static final String HTML_STYLESHEET_WITH_MEDIA = "<LINK REL=\"stylesheet\" TYPE=\"text/css\"\nMEDIA=\"print, handheld\" HREF=\"foo.css\">";
-	private static final String HTML_STYLESHEET_WITH_MEDIAC = "<LINK rel=\"stylesheet\" type=\"text/css\" media=\"print, handheld\" href=\"foo.css?type=text/css&amp;maybecharset=iso-8859-1\">";
+    private static final String HTML_STYLESHEET_WITH_MEDIA = "<LINK REL=\"stylesheet\" TYPE=\"text/css\"\nMEDIA=\"print, handheld\" HREF=\"foo.css\">";
+    private static final String HTML_STYLESHEET_WITH_MEDIAC = "<LINK rel=\"stylesheet\" type=\"text/css\" media=\"print, handheld\" href=\"foo.css?type=text/css&amp;maybecharset=iso-8859-1\">";
 
-	private static final String FRAME_SRC_CHARSET = "<frame src=\"test.html?type=text/html; charset=UTF-8\">";
-	private static final String FRAME_SRC_CHARSETC = "<frame src=\"test.html?type=text/html%3b%20charset=UTF-8\">";
+    private static final String FRAME_SRC_CHARSET = "<frame src=\"test.html?type=text/html; charset=UTF-8\">";
+    private static final String FRAME_SRC_CHARSETC = "<frame src=\"test.html?type=text/html%3b%20charset=UTF-8\">";
 
-	private static final String FRAME_SRC_CHARSET_BAD = "<frame src=\"test.html?type=text/html; charset=UTF-8&max-size=4194304\">";
-	private static final String FRAME_SRC_CHARSET_BADC = "<frame src=\"test.html?type=text/html%3b%20charset=UTF-8\">";
+    private static final String FRAME_SRC_CHARSET_BAD = "<frame src=\"test.html?type=text/html; charset=UTF-8&max-size=4194304\">";
+    private static final String FRAME_SRC_CHARSET_BADC = "<frame src=\"test.html?type=text/html%3b%20charset=UTF-8\">";
 
-	private static final String FRAME_SRC_CHARSET_BAD1 = "<frame src=\"test.html?type=text/html; charset=UTF-8%26max-size=4194304\">";
-	private static final String FRAME_SRC_CHARSET_BAD1C = "<frame src=\"test.html?type=text/html\">";
+    private static final String FRAME_SRC_CHARSET_BAD1 = "<frame src=\"test.html?type=text/html; charset=UTF-8%26max-size=4194304\">";
+    private static final String FRAME_SRC_CHARSET_BAD1C = "<frame src=\"test.html?type=text/html\">";
 
-	private static final String SPAN_WITH_STYLE = "<span style=\"font-family: verdana, sans-serif; color: red;\">";
+    private static final String SPAN_WITH_STYLE = "<span style=\"font-family: verdana, sans-serif; color: red;\">";
 
-	private static final String BASE_HREF = "<base href=\"/"+BASE_KEY+"\">";
-	private static final String BAD_BASE_HREF = "<base href=\"/\">";
-	private static final String BAD_BASE_HREF2 = "<base href=\"//www.google.com\">";
-	private static final String BAD_BASE_HREF3 = "<base>";
-	private static final String BAD_BASE_HREF4 = "<base id=\"blah\">";
-	private static final String BAD_BASE_HREF5 = "<base href=\"http://www.google.com/\">";
-	private static final String DELETED_BASE_HREF = "<!-- deleted invalid base href -->";
+    private static final String BASE_HREF = "<base href=\"/" + BASE_KEY + "\">";
+    private static final String BAD_BASE_HREF = "<base href=\"/\">";
+    private static final String BAD_BASE_HREF2 = "<base href=\"//www.google.com\">";
+    private static final String BAD_BASE_HREF3 = "<base>";
+    private static final String BAD_BASE_HREF4 = "<base id=\"blah\">";
+    private static final String BAD_BASE_HREF5 = "<base href=\"http://www.google.com/\">";
+    private static final String DELETED_BASE_HREF = "<!-- deleted invalid base href -->";
 
-	// From CSS spec
+    // From CSS spec
 
-	private static final String CSS_SPEC_EXAMPLE1 = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\">\n<HTML>\n  <HEAD>\n  <TITLE>Bach's home page</TITLE>\n  <STYLE type=\"text/css\">\n    body {\n      font-family: \"Gill Sans\", sans-serif;\n      font-size: 12pt;\n      margin: 3em;\n\n    }\n  </STYLE>\n  </HEAD>\n  <BODY>\n    <H1>Bach's home page</H1>\n    <P>Johann Sebastian Bach was a prolific composer.\n  </BODY>\n</HTML>";
+    private static final String CSS_SPEC_EXAMPLE1 = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\">\n<HTML>\n  <HEAD>\n  <TITLE>Bach's home page</TITLE>\n  <STYLE type=\"text/css\">\n    body {\n      font-family: \"Gill Sans\", sans-serif;\n      font-size: 12pt;\n      margin: 3em;\n\n    }\n  </STYLE>\n  </HEAD>\n  <BODY>\n    <H1>Bach's home page</H1>\n    <P>Johann Sebastian Bach was a prolific composer.\n  </BODY>\n</HTML>";
 
-	@Test
-	public void testHTMLFilter() throws Exception {
-		if (TestProperty.VERBOSE) {
-			Logger.setupStdoutLogging(LogLevel.MINOR, "freenet.client.filter.Generic:DEBUG");
-		}
+    @Test
+    public void testHTMLFilter() throws Exception {
+        if (TestProperty.VERBOSE) {
+            Logger.setupStdoutLogging(LogLevel.MINOR, "freenet.client.filter.Generic:DEBUG");
+        }
 
-		// General sanity checks
-		// is "relativization" working?
-		assertEquals(INTERNAL_RELATIVE_LINK, HTMLFilter(INTERNAL_RELATIVE_LINK));
-		assertEquals(INTERNAL_RELATIVE_LINK, HTMLFilter(INTERNAL_RELATIVE_LINK, true));
-		assertEquals(INTERNAL_RELATIVE_LINK1, HTMLFilter(INTERNAL_RELATIVE_LINK1, true));
-		assertEquals(INTERNAL_RELATIVE_LINK, HTMLFilter(INTERNAL_ABSOLUTE_LINK));
-		// are external links stripped out ?
-		assertTrue(HTMLFilter(EXTERNAL_LINK_CHECK1).startsWith(EXTERNAL_LINK_OK));
-		assertTrue(HTMLFilter(EXTERNAL_LINK_CHECK2).contains(ExternalLinkToadlet.PATH));
-		assertTrue(HTMLFilter(EXTERNAL_LINK_CHECK3).startsWith(EXTERNAL_LINK_OK));
+        // General sanity checks
+        // is "relativization" working?
+        assertEquals(INTERNAL_RELATIVE_LINK, htmlFilter(INTERNAL_RELATIVE_LINK));
+        assertEquals(INTERNAL_RELATIVE_LINK, htmlFilter(INTERNAL_RELATIVE_LINK, true));
+        assertEquals(INTERNAL_RELATIVE_LINK1, htmlFilter(INTERNAL_RELATIVE_LINK1, true));
+        assertEquals(INTERNAL_RELATIVE_LINK, htmlFilter(INTERNAL_ABSOLUTE_LINK));
+        // are external links stripped out ?
+        assertTrue(htmlFilter(EXTERNAL_LINK_CHECK1).startsWith(EXTERNAL_LINK_OK));
+        assertTrue(htmlFilter(EXTERNAL_LINK_CHECK2).contains(ExternalLinkToadlet.PATH));
+        assertTrue(htmlFilter(EXTERNAL_LINK_CHECK3).startsWith(EXTERNAL_LINK_OK));
 
-		// regression testing
-		// bug #710
-		assertEquals(ANCHOR_TEST, HTMLFilter(ANCHOR_TEST));
-		assertEquals(ANCHOR_TEST_EMPTY, HTMLFilter(ANCHOR_TEST_EMPTY));
-		assertEquals(ANCHOR_TEST_SPECIAL, HTMLFilter(ANCHOR_TEST_SPECIAL));
-		assertEquals(ANCHOR_TEST_SPECIAL2_RESULT, HTMLFilter(ANCHOR_TEST_SPECIAL2));
-		// bug #2496
-		assertEquals(ANCHOR_RELATIVE1, HTMLFilter(ANCHOR_RELATIVE1));
-		assertEquals(ANCHOR_RELATIVE2, HTMLFilter(ANCHOR_RELATIVE2));
-		assertEquals(ANCHOR_FALSE_POS1, HTMLFilter(ANCHOR_FALSE_POS1));
-		assertEquals(ANCHOR_FALSE_POS2, HTMLFilter(ANCHOR_FALSE_POS2));
-		// EVIL HACK TEST for #2496 + #2451
-		assertEquals(ANCHOR_MIXED_RESULT, HTMLFilter(ANCHOR_MIXED));
-		// bug #2451
-		assertEquals(POUNT_CHARACTER_ENCODING_TEST_RESULT, HTMLFilter(POUNT_CHARACTER_ENCODING_TEST));
-		// bug #2297
-		assertTrue(HTMLFilter(PREVENT_FPROXY_ACCESS).contains(ExternalLinkToadlet.PATH));
-		// bug #2921
-		assertTrue(HTMLFilter(PREVENT_EXTERNAL_ACCESS_CSS_SIMPLE).contains("div { }"));
-		assertTrue(HTMLFilter(PREVENT_EXTERNAL_ACCESS_CSS_ESCAPE).contains("div { }"));
-		assertTrue(HTMLFilter(PREVENT_EXTERNAL_ACCESS_CSS_CASE).contains("div { }"));
-		assertEquals(WHITELIST_STATIC_CONTENT, HTMLFilter(WHITELIST_STATIC_CONTENT));
-		assertEquals(XHTML_VOIDELEMENTC,HTMLFilter(XHTML_VOIDELEMENT));
-		assertEquals(XHTML_INCOMPLETEDOCUMENTC,HTMLFilter(XHTML_INCOMPLETEDOCUMENT));
-		assertEquals(XHTML_IMPROPERNESTINGC,HTMLFilter(XHTML_IMPROPERNESTING));
+        // regression testing
+        // bug #710
+        assertEquals(ANCHOR_TEST, htmlFilter(ANCHOR_TEST));
+        assertEquals(ANCHOR_TEST_EMPTY, htmlFilter(ANCHOR_TEST_EMPTY));
+        assertEquals(ANCHOR_TEST_SPECIAL, htmlFilter(ANCHOR_TEST_SPECIAL));
+        assertEquals(ANCHOR_TEST_SPECIAL2_RESULT, htmlFilter(ANCHOR_TEST_SPECIAL2));
+        // bug #2496
+        assertEquals(ANCHOR_RELATIVE1, htmlFilter(ANCHOR_RELATIVE1));
+        assertEquals(ANCHOR_RELATIVE2, htmlFilter(ANCHOR_RELATIVE2));
+        assertEquals(ANCHOR_FALSE_POS1, htmlFilter(ANCHOR_FALSE_POS1));
+        assertEquals(ANCHOR_FALSE_POS2, htmlFilter(ANCHOR_FALSE_POS2));
+        // EVIL HACK TEST for #2496 + #2451
+        assertEquals(ANCHOR_MIXED_RESULT, htmlFilter(ANCHOR_MIXED));
+        // bug #2451
+        assertEquals(POUNT_CHARACTER_ENCODING_TEST_RESULT, htmlFilter(POUNT_CHARACTER_ENCODING_TEST));
+        // bug #2297
+        assertTrue(htmlFilter(PREVENT_FPROXY_ACCESS).contains(ExternalLinkToadlet.PATH));
+        // bug #2921
+        assertTrue(htmlFilter(PREVENT_EXTERNAL_ACCESS_CSS_SIMPLE).contains("div { }"));
+        assertTrue(htmlFilter(PREVENT_EXTERNAL_ACCESS_CSS_ESCAPE).contains("div { }"));
+        assertTrue(htmlFilter(PREVENT_EXTERNAL_ACCESS_CSS_CASE).contains("div { }"));
+        assertEquals(WHITELIST_STATIC_CONTENT, htmlFilter(WHITELIST_STATIC_CONTENT));
+        assertEquals(XHTML_VOIDELEMENTC, htmlFilter(XHTML_VOIDELEMENT));
+        assertEquals(XHTML_INCOMPLETEDOCUMENTC, htmlFilter(XHTML_INCOMPLETEDOCUMENT));
+        assertEquals(XHTML_IMPROPERNESTINGC, htmlFilter(XHTML_IMPROPERNESTING));
 
-		assertEquals(CSS_STRING_NEWLINESC,HTMLFilter(CSS_STRING_NEWLINES));
+        assertEquals(CSS_STRING_NEWLINESC, htmlFilter(CSS_STRING_NEWLINES));
 
-		assertEquals(HTML_STYLESHEET_MAYBECHARSETC, HTMLFilter(HTML_STYLESHEET_MAYBECHARSET, true));
-		assertEquals(HTML_STYLESHEET_CHARSETC, HTMLFilter(HTML_STYLESHEET_CHARSET, true));
-		assertEquals(HTML_STYLESHEET_CHARSET_BADC, HTMLFilter(HTML_STYLESHEET_CHARSET_BAD, true));
-		assertEquals(HTML_STYLESHEET_CHARSET_BAD1C, HTMLFilter(HTML_STYLESHEET_CHARSET_BAD1, true));
-		assertEquals(HTML_STYLESHEET_WITH_MEDIAC, HTMLFilter(HTML_STYLESHEET_WITH_MEDIA, true));
+        assertEquals(HTML_STYLESHEET_MAYBECHARSETC, htmlFilter(HTML_STYLESHEET_MAYBECHARSET, true));
+        assertEquals(HTML_STYLESHEET_CHARSETC, htmlFilter(HTML_STYLESHEET_CHARSET, true));
+        assertEquals(HTML_STYLESHEET_CHARSET_BADC, htmlFilter(HTML_STYLESHEET_CHARSET_BAD, true));
+        assertEquals(HTML_STYLESHEET_CHARSET_BAD1C, htmlFilter(HTML_STYLESHEET_CHARSET_BAD1, true));
+        assertEquals(HTML_STYLESHEET_WITH_MEDIAC, htmlFilter(HTML_STYLESHEET_WITH_MEDIA, true));
 
-		assertEquals(FRAME_SRC_CHARSETC, HTMLFilter(FRAME_SRC_CHARSET, true));
-		assertEquals(FRAME_SRC_CHARSET_BADC, HTMLFilter(FRAME_SRC_CHARSET_BAD, true));
-		assertEquals(FRAME_SRC_CHARSET_BAD1C, HTMLFilter(FRAME_SRC_CHARSET_BAD1, true));
+        assertEquals(FRAME_SRC_CHARSETC, htmlFilter(FRAME_SRC_CHARSET, true));
+        assertEquals(FRAME_SRC_CHARSET_BADC, htmlFilter(FRAME_SRC_CHARSET_BAD, true));
+        assertEquals(FRAME_SRC_CHARSET_BAD1C, htmlFilter(FRAME_SRC_CHARSET_BAD1, true));
 
-		assertEquals(CSS_SPEC_EXAMPLE1, HTMLFilter(CSS_SPEC_EXAMPLE1));
+        assertEquals(CSS_SPEC_EXAMPLE1, htmlFilter(CSS_SPEC_EXAMPLE1));
 
-		assertEquals(SPAN_WITH_STYLE, HTMLFilter(SPAN_WITH_STYLE));
+        assertEquals(SPAN_WITH_STYLE, htmlFilter(SPAN_WITH_STYLE));
 
-		assertEquals(BASE_HREF, HTMLFilter(BASE_HREF));
-		assertEquals(DELETED_BASE_HREF, HTMLFilter(BAD_BASE_HREF));
-		assertEquals(DELETED_BASE_HREF, HTMLFilter(BAD_BASE_HREF2));
-		assertEquals(DELETED_BASE_HREF, HTMLFilter(BAD_BASE_HREF3));
-		assertEquals(DELETED_BASE_HREF, HTMLFilter(BAD_BASE_HREF4));
-		assertEquals(DELETED_BASE_HREF, HTMLFilter(BAD_BASE_HREF5));
-	}
+        assertEquals(BASE_HREF, htmlFilter(BASE_HREF));
+        assertEquals(DELETED_BASE_HREF, htmlFilter(BAD_BASE_HREF));
+        assertEquals(DELETED_BASE_HREF, htmlFilter(BAD_BASE_HREF2));
+        assertEquals(DELETED_BASE_HREF, htmlFilter(BAD_BASE_HREF3));
+        assertEquals(DELETED_BASE_HREF, htmlFilter(BAD_BASE_HREF4));
+        assertEquals(DELETED_BASE_HREF, htmlFilter(BAD_BASE_HREF5));
+    }
 
-	private static final String META_TIME_ONLY = "<meta http-equiv=\"refresh\" content=\"5\">";
-	private static final String META_TIME_ONLY_WRONG_CASE = "<meta http-equiv=\"RefResH\" content=\"5\">";
-	private static final String META_TIME_ONLY_TOO_SHORT = "<meta http-equiv=\"refresh\" content=\"0\">";
-	private static final String META_TIME_ONLY_NEGATIVE = "<meta http-equiv=\"refresh\" content=\"-5\">";
+    private static final String META_TIME_ONLY = "<meta http-equiv=\"refresh\" content=\"5\">";
+    private static final String META_TIME_ONLY_WRONG_CASE = "<meta http-equiv=\"RefResH\" content=\"5\">";
+    private static final String META_TIME_ONLY_TOO_SHORT = "<meta http-equiv=\"refresh\" content=\"0\">";
+    private static final String META_TIME_ONLY_NEGATIVE = "<meta http-equiv=\"refresh\" content=\"-5\">";
 
-	private static final String META_TIME_ONLY_BADNUM1 = "<meta http-equiv=\"refresh\" content=\"5.5\">";
-	private static final String META_TIME_ONLY_BADNUM2 = "<meta http-equiv=\"refresh\" content=\"\">";
-	private static final String META_TIME_ONLY_BADNUM_OUT = "<!-- doesn't parse as number in meta refresh -->";
+    private static final String META_TIME_ONLY_BADNUM1 = "<meta http-equiv=\"refresh\" content=\"5.5\">";
+    private static final String META_TIME_ONLY_BADNUM2 = "<meta http-equiv=\"refresh\" content=\"\">";
+    private static final String META_TIME_ONLY_BADNUM_OUT = "<!-- doesn't parse as number in meta refresh -->";
 
-	private static final String META_CHARSET = "<html><head><meta charset=\"UTF-8\" />";
-	private static final String META_CHARSET_LOWER = "<!DOCTYPE html>\n"
-			+ "<html lang=\"de\">\n"
-			+ "<head>\n"
-			+ "<!-- 2022-12-08 Do 01:20 -->\n"
-			+ "<meta charset=\"utf-8\" />\n"
-			+ "<title>Some Title</title>";
-	private static final String META_CHARSET_LOWER_RES = "<!DOCTYPE html>\n"
-			+ "<html lang=\"de\">\n"
-			+ "<head>\n"
-			+ "<!--  2022-12-08 Do 01:20  -->\n" // comment has additional spaces after content filter
-			+ "<meta charset=\"utf-8\" />\n"
-			+ "<title>Some Title</title>";
+    private static final String META_CHARSET = "<html><head><meta charset=\"UTF-8\" />";
+    private static final String META_CHARSET_LOWER = "<!DOCTYPE html>\n"
+        + "<html lang=\"de\">\n"
+        + "<head>\n"
+        + "<!-- 2022-12-08 Do 01:20 -->\n"
+        + "<meta charset=\"utf-8\" />\n"
+        + "<title>Some Title</title>";
+    private static final String META_CHARSET_LOWER_RES = "<!DOCTYPE html>\n"
+        + "<html lang=\"de\">\n"
+        + "<head>\n"
+        + "<!--  2022-12-08 Do 01:20  -->\n" // comment has additional spaces after content filter
+        + "<meta charset=\"utf-8\" />\n"
+        + "<title>Some Title</title>";
 
-	private static final String META_VALID_REDIRECT = "<meta http-equiv=\"refresh\" content=\"30; url=/KSK@gpl.txt\">";
-	private static final String META_VALID_REDIRECT_NOSPACE = "<meta http-equiv=\"refresh\" content=\"30;url=/KSK@gpl.txt\">";
+    private static final String META_VALID_REDIRECT = "<meta http-equiv=\"refresh\" content=\"30; url=/KSK@gpl.txt\">";
+    private static final String META_VALID_REDIRECT_NOSPACE = "<meta http-equiv=\"refresh\" content=\"30;url=/KSK@gpl.txt\">";
 
-	private static final String META_BOGUS_REDIRECT1 = "<meta http-equiv=\"refresh\" content=\"30; url=/\">";
-	private static final String META_BOGUS_REDIRECT2 = "<meta http-equiv=\"refresh\" content=\"30; url=/plugins\">";
-	private static final String META_BOGUS_REDIRECT3 = "<meta http-equiv=\"refresh\" content=\"30; url=http://www.google.com\">";
-	private static final String META_BOGUS_REDIRECT4 = "<meta http-equiv=\"refresh\" content=\"30; url=//www.google.com\">";
-	private static final String META_BOGUS_REDIRECT5 = "<meta http-equiv=\"refresh\" content=\"30; url=\"/KSK@gpl.txt\"\">";
-	private static final String META_BOGUS_REDIRECT6 = "<meta http-equiv=\"refresh\" content=\"30; /KSK@gpl.txt\">";
-	private static final String META_BOGUS_REDIRECT1_OUT = "<!-- GenericReadFilterCallback.malformedRelativeURL-->";
-	private static final String META_BOGUS_REDIRECT3_OUT = "<meta http-equiv=\"refresh\" content=\"30; url=/external-link/?_CHECKED_HTTP_=http://www.google.com\">";
-	private static final String META_BOGUS_REDIRECT4_OUT = "<!-- GenericReadFilterCallback.deletedURI-->";
-	private static final String META_BOGUS_REDIRECT_NO_URL = "<!-- no url but doesn't parse as number in meta refresh -->";
+    private static final String META_BOGUS_REDIRECT1 = "<meta http-equiv=\"refresh\" content=\"30; url=/\">";
+    private static final String META_BOGUS_REDIRECT2 = "<meta http-equiv=\"refresh\" content=\"30; url=/plugins\">";
+    private static final String META_BOGUS_REDIRECT3 = "<meta http-equiv=\"refresh\" content=\"30; url=http://www.google.com\">";
+    private static final String META_BOGUS_REDIRECT4 = "<meta http-equiv=\"refresh\" content=\"30; url=//www.google.com\">";
+    private static final String META_BOGUS_REDIRECT5 = "<meta http-equiv=\"refresh\" content=\"30; url=\"/KSK@gpl.txt\"\">";
+    private static final String META_BOGUS_REDIRECT6 = "<meta http-equiv=\"refresh\" content=\"30; /KSK@gpl.txt\">";
+    private static final String META_BOGUS_REDIRECT1_OUT = "<!-- GenericReadFilterCallback.malformedRelativeURL-->";
+    private static final String META_BOGUS_REDIRECT3_OUT = "<meta http-equiv=\"refresh\" content=\"30; url=/external-link/?_CHECKED_HTTP_=http://www.google.com\">";
+    private static final String META_BOGUS_REDIRECT4_OUT = "<!-- GenericReadFilterCallback.deletedURI-->";
+    private static final String META_BOGUS_REDIRECT_NO_URL = "<!-- no url but doesn't parse as number in meta refresh -->";
 
-	@Test
-	public void testMetaRefresh() throws Exception {
-		HTMLFilter.metaRefreshSamePageMinInterval = 5;
-		HTMLFilter.metaRefreshRedirectMinInterval = 30;
-		assertEquals(META_TIME_ONLY, headFilter(META_TIME_ONLY));
-		assertEquals(META_TIME_ONLY, headFilter(META_TIME_ONLY_WRONG_CASE));
-		assertEquals(META_TIME_ONLY, headFilter(META_TIME_ONLY_TOO_SHORT));
-		assertEquals("", headFilter(META_TIME_ONLY_NEGATIVE));
-		assertEquals(META_TIME_ONLY_BADNUM_OUT, headFilter(META_TIME_ONLY_BADNUM1));
-		assertEquals(META_TIME_ONLY_BADNUM_OUT, headFilter(META_TIME_ONLY_BADNUM2));
-		assertEquals(META_VALID_REDIRECT, headFilter(META_VALID_REDIRECT));
-		assertEquals(META_VALID_REDIRECT, headFilter(META_VALID_REDIRECT_NOSPACE));
-		assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT1));
-		assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT2));
-		assertEquals(META_BOGUS_REDIRECT3_OUT, headFilter(META_BOGUS_REDIRECT3));
-		assertEquals(META_BOGUS_REDIRECT4_OUT, headFilter(META_BOGUS_REDIRECT4));
-		assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT5));
-		assertEquals(META_BOGUS_REDIRECT_NO_URL, headFilter(META_BOGUS_REDIRECT6));
-		HTMLFilter.metaRefreshSamePageMinInterval = -1;
-		HTMLFilter.metaRefreshRedirectMinInterval = -1;
-		assertEquals("", headFilter(META_TIME_ONLY));
-		assertEquals("", headFilter(META_TIME_ONLY_WRONG_CASE));
-		assertEquals("", headFilter(META_TIME_ONLY_TOO_SHORT));
-		assertEquals("", headFilter(META_TIME_ONLY_NEGATIVE));
-		assertEquals("", headFilter(META_TIME_ONLY_BADNUM1));
-		assertEquals("", headFilter(META_TIME_ONLY_BADNUM2));
-		assertEquals("", headFilter(META_VALID_REDIRECT));
-		assertEquals("", headFilter(META_VALID_REDIRECT_NOSPACE));
-		assertEquals("", headFilter(META_BOGUS_REDIRECT1));
-		assertEquals("", headFilter(META_BOGUS_REDIRECT2));
-		assertEquals("", headFilter(META_BOGUS_REDIRECT3));
-		assertEquals("", headFilter(META_BOGUS_REDIRECT4));
-		assertEquals("", headFilter(META_BOGUS_REDIRECT5));
-		assertEquals("", headFilter(META_BOGUS_REDIRECT6));
-	}
+    @Test
+    public void testMetaRefresh() throws Exception {
+        HTMLFilter.metaRefreshSamePageMinInterval = 5;
+        HTMLFilter.metaRefreshRedirectMinInterval = 30;
+        assertEquals(META_TIME_ONLY, headFilter(META_TIME_ONLY));
+        assertEquals(META_TIME_ONLY, headFilter(META_TIME_ONLY_WRONG_CASE));
+        assertEquals(META_TIME_ONLY, headFilter(META_TIME_ONLY_TOO_SHORT));
+        assertEquals("", headFilter(META_TIME_ONLY_NEGATIVE));
+        assertEquals(META_TIME_ONLY_BADNUM_OUT, headFilter(META_TIME_ONLY_BADNUM1));
+        assertEquals(META_TIME_ONLY_BADNUM_OUT, headFilter(META_TIME_ONLY_BADNUM2));
+        assertEquals(META_VALID_REDIRECT, headFilter(META_VALID_REDIRECT));
+        assertEquals(META_VALID_REDIRECT, headFilter(META_VALID_REDIRECT_NOSPACE));
+        assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT1));
+        assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT2));
+        assertEquals(META_BOGUS_REDIRECT3_OUT, headFilter(META_BOGUS_REDIRECT3));
+        assertEquals(META_BOGUS_REDIRECT4_OUT, headFilter(META_BOGUS_REDIRECT4));
+        assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT5));
+        assertEquals(META_BOGUS_REDIRECT_NO_URL, headFilter(META_BOGUS_REDIRECT6));
+        HTMLFilter.metaRefreshSamePageMinInterval = -1;
+        HTMLFilter.metaRefreshRedirectMinInterval = -1;
+        assertEquals("", headFilter(META_TIME_ONLY));
+        assertEquals("", headFilter(META_TIME_ONLY_WRONG_CASE));
+        assertEquals("", headFilter(META_TIME_ONLY_TOO_SHORT));
+        assertEquals("", headFilter(META_TIME_ONLY_NEGATIVE));
+        assertEquals("", headFilter(META_TIME_ONLY_BADNUM1));
+        assertEquals("", headFilter(META_TIME_ONLY_BADNUM2));
+        assertEquals("", headFilter(META_VALID_REDIRECT));
+        assertEquals("", headFilter(META_VALID_REDIRECT_NOSPACE));
+        assertEquals("", headFilter(META_BOGUS_REDIRECT1));
+        assertEquals("", headFilter(META_BOGUS_REDIRECT2));
+        assertEquals("", headFilter(META_BOGUS_REDIRECT3));
+        assertEquals("", headFilter(META_BOGUS_REDIRECT4));
+        assertEquals("", headFilter(META_BOGUS_REDIRECT5));
+        assertEquals("", headFilter(META_BOGUS_REDIRECT6));
+    }
 
-	private String headFilter(String data) throws Exception {
-		String s = HTMLFilter("<head>"+data+"</head>");
-		if(s == null) return s;
-		if(!s.startsWith("<head>"))
-			assertTrue("Head deleted???: "+s, false);
-		s = s.substring("<head>".length());
-		if(!s.endsWith("</head>"))
-			assertTrue("Head close deleted???: "+s, false);
-		s = s.substring(0, s.length() - "</head>".length());
-		return s;
-	}
+    private String headFilter(String data) throws Exception {
+        String s = htmlFilter("<head>" + data + "</head>");
+        if (s == null) {
+            return s;
+        }
 
-	@Test
-	public void testThatHtml5MetaCharsetIsPreserved() throws Exception {
-		assertEquals(META_CHARSET, HTMLFilter(META_CHARSET));
-		assertEquals(META_CHARSET_LOWER_RES, HTMLFilter(META_CHARSET_LOWER));
-	}
+		MatcherAssert.assertThat(s, startsWith("<head>"));
+		MatcherAssert.assertThat(s, endsWith("</head>"));
 
-	@Test
-	public void testEvilCharset() throws IOException {
-		// This is why we need to disallow characters before <html> !!
-		String s = "<html><body><a href=\"http://www.google.com/\">Blah</a>";
-		String end = "</body></html>";
-		String alt = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-16\"></head><body><a href=\"http://www.freenetproject.org/\">Blah</a></body></html>";
-		if((s.length()+end.length()) % 2 == 1)
-			s += " ";
-		s = s+end;
-		byte[] buf;
-		try {
-			buf = s.getBytes("UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new Error(e);
-		}
-		byte[] utf16bom = new byte[] { (byte)0xFE, (byte)0xFF };
-		byte[] bufUTF16 = alt.getBytes("UTF-16");
-		byte[] total = new byte[buf.length+utf16bom.length+bufUTF16.length];
-		System.arraycopy(utf16bom, 0, total, 0, utf16bom.length);
-		System.arraycopy(buf, 0, total, utf16bom.length, buf.length);
-		System.arraycopy(bufUTF16, 0, total, utf16bom.length+buf.length, bufUTF16.length);
-		HTMLFilter filter = new HTMLFilter();
-		boolean failed = false;
-		FileOutputStream fos;
-		try {
-			ArrayBucket out = new ArrayBucket();
-			filter.readFilter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "UTF-16", null, null, null);
-			fos = new FileOutputStream("output.utf16");
-			fos.write(out.toByteArray());
-			fos.close();
-			failed = true;
-			assertFalse("Filter accepted dangerous UTF8 text with BOM as UTF16! (HTMLFilter)", true);
-		} catch (DataFilterException e) {
-			System.out.println("Failure: "+e);
-			e.printStackTrace();
-			if(e.getCause() != null) {
-				e.getCause().printStackTrace();
-			}
-			// Ok.
-		}
-		try {
-			ArrayBucket out = new ArrayBucket();
-			FilterStatus fo = ContentFilter.filter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "text/html", null, null, null);
-			fos = new FileOutputStream("output.filtered");
-			fos.write(out.toByteArray());
-			fos.close();
-			failed = true;
-			assertFalse("Filter accepted dangerous UTF8 text with BOM as UTF16! (ContentFilter) - Detected charset: "+fo.charset, true);
-		} catch (DataFilterException e) {
-			System.out.println("Failure: "+e);
-			e.printStackTrace();
-			if(e.getCause() != null) {
-				e.getCause().printStackTrace();
-			}
-			// Ok.
-		}
+        s = s.substring("<head>".length());
+        s = s.substring(0, s.length() - "</head>".length());
+        return s;
+    }
 
-		if(failed) {
-			fos = new FileOutputStream("unfiltered");
-			fos.write(total);
-			fos.close();
-		}
-	}
+    @Test
+    public void testThatHtml5MetaCharsetIsPreserved() throws Exception {
+        assertEquals(META_CHARSET, htmlFilter(META_CHARSET));
+        assertEquals(META_CHARSET_LOWER_RES, htmlFilter(META_CHARSET_LOWER));
+    }
 
-	public static String HTMLFilter(String data) throws Exception {
-		if(data.startsWith("<html")) return HTMLFilter(data, false);
-		if(data.startsWith("<?")) return HTMLFilter(data, false);
-		String s = HTMLFilter("<html>"+data+"</html>", false);
-		assertTrue(s.startsWith("<html>"));
-		s = s.substring("<html>".length());
-		assertTrue("s = \""+s+"\"", s.endsWith("</html>"));
-		s = s.substring(0, s.length() - "</html>".length());
-		return s;
-	}
+    @Test
+    public void testEvilCharset() throws IOException {
+        // This is why we need to disallow characters before <html> !!
+        String s = "<html><body><a href=\"http://www.google.com/\">Blah</a>";
+        String end = "</body></html>";
+        String alt = "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-16\"></head><body><a href=\"http://www.freenetproject.org/\">Blah</a></body></html>";
+        if ((s.length() + end.length()) % 2 == 1) {
+            s += " ";
+        }
+        s = s + end;
+        byte[] buf = s.getBytes(StandardCharsets.UTF_8);
+        byte[] utf16bom = new byte[]{(byte) 0xFE, (byte) 0xFF};
+        byte[] bufUTF16 = alt.getBytes(StandardCharsets.UTF_16);
+        byte[] total = new byte[buf.length + utf16bom.length + bufUTF16.length];
+        System.arraycopy(utf16bom, 0, total, 0, utf16bom.length);
+        System.arraycopy(buf, 0, total, utf16bom.length, buf.length);
+        System.arraycopy(bufUTF16, 0, total, utf16bom.length + buf.length, bufUTF16.length);
+        HTMLFilter filter = new HTMLFilter();
+        boolean failed = false;
+        List<RuntimeException> failures = new ArrayList<>();
+        try (
+            FileOutputStream fos = new FileOutputStream("output.utf16")
+        ){
+            ArrayBucket out = new ArrayBucket();
+            filter.readFilter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "UTF-16", null, null, null);
+            fos.write(out.toByteArray());
+            failed = true;
+            failures.add(new RuntimeException("Filter accepted dangerous UTF8 text with BOM as UTF16! (HTMLFilter)"));
+        } catch (DataFilterException e) {
+            System.out.println("Failure: " + e);
+            e.printStackTrace();
+            if (e.getCause() != null) {
+                e.getCause().printStackTrace();
+            }
+            // Ok.
+        }
+        try (
+            FileOutputStream fos = new FileOutputStream("output.filtered")
+        ){
+            ArrayBucket out = new ArrayBucket();
+            FilterStatus fo = ContentFilter.filter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "text/html", null, null, null);
+            fos.write(out.toByteArray());
+            failed = true;
+            failures.add(new RuntimeException("Filter accepted dangerous UTF8 text with BOM as UTF16! (ContentFilter) - Detected charset: " + fo.charset));
+        } catch (DataFilterException e) {
+            System.out.println("Failure: " + e);
+            e.printStackTrace();
+            if (e.getCause() != null) {
+                e.getCause().printStackTrace();
+            }
+            // Ok.
+        }
 
-	public static String HTMLFilter(String data, boolean alt) throws Exception {
-		String returnValue;
-		String typeName = "text/html";
-		URI baseURI = new URI(alt ? ALT_BASE_URI : BASE_URI);
-		byte[] dataToFilter = data.getBytes("UTF-8");
-		ArrayBucket input = new ArrayBucket(dataToFilter);
-		ArrayBucket output = new ArrayBucket();
-		InputStream inputStream = input.getInputStream();
-		OutputStream outputStream = output.getOutputStream();
-		ContentFilter.filter(inputStream, outputStream, typeName, baseURI,null,null, null, null);
-		inputStream.close();
-		outputStream.close();
-		returnValue = output.toString();
-		output.free();
-		input.free();
-		return returnValue;
-	}
+        if (failed) {
+            try (FileOutputStream fos = new FileOutputStream("unfiltered")) {
+                fos.write(total);
+            }
+            throw failures.get(0);
+        }
+    }
 
-	@Test
-	public void testLowerCaseExtensions() {
-		for(FilterMIMEType type : ContentFilter.mimeTypesByName.values()) {
-			String ext = type.primaryExtension;
-			if(ext != null)
-				assertEquals(ext, ext.toLowerCase());
-			String[] exts = type.alternateExtensions;
-			if(ext != null)
-				for(String s : exts)
-					assertEquals(s, s.toLowerCase());
-		}
-	}
+    public static String htmlFilter(String data) throws Exception {
+        if (data.startsWith("<html")) return htmlFilter(data, false);
+        if (data.startsWith("<?")) return htmlFilter(data, false);
+        String s = htmlFilter("<html>" + data + "</html>", false);
+        assertTrue(s.startsWith("<html>"));
+        s = s.substring("<html>".length());
+        assertTrue("s = \"" + s + "\"", s.endsWith("</html>"));
+        s = s.substring(0, s.length() - "</html>".length());
+        return s;
+    }
+
+    public static String htmlFilter(String data, boolean alt) throws Exception {
+        String typeName = "text/html";
+        URI baseURI = new URI(alt ? ALT_BASE_URI : BASE_URI);
+        byte[] dataToFilter = data.getBytes(StandardCharsets.UTF_8);
+        ArrayBucket input = new ArrayBucket(dataToFilter);
+        ArrayBucket output = new ArrayBucket();
+        try (
+            OutputStream outputStream = output.getOutputStream();
+            InputStream inputStream = input.getInputStream()
+        ) {
+            ContentFilter.filter(inputStream, outputStream, typeName, baseURI, null, null, null, null);
+        } finally {
+            input.free();
+        }
+        String returnValue = output.toString();
+        output.free();
+        return returnValue;
+    }
+
+    @Test
+    public void testLowerCaseExtensions() {
+        for (FilterMIMEType type : ContentFilter.mimeTypesByName.values()) {
+            String ext = type.primaryExtension;
+            if (ext != null) {
+                assertEquals(ext, ext.toLowerCase());
+            }
+            String[] exts = type.alternateExtensions;
+            if (ext != null) {
+                for (String s : exts) {
+                    assertEquals(s, s.toLowerCase());
+                }
+            }
+        }
+    }
 }

--- a/test/freenet/client/filter/FilterUtilsTest.java
+++ b/test/freenet/client/filter/FilterUtilsTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 public class FilterUtilsTest {
 	@Test
-	public void testValidLenthUnits() {
+	public void testValidLengthUnits() {
 		// Test all valid length units for CSS and valid values
 		assertTrue(FilterUtils.isLength("1em", false));
 		assertTrue(FilterUtils.isLength("1.12em", false));

--- a/test/freenet/client/filter/GIFFilterTest.java
+++ b/test/freenet/client/filter/GIFFilterTest.java
@@ -117,17 +117,16 @@ public class GIFFilterTest {
 
     @Test
     public void testReject() throws IOException {
+        ContentDataFilter filter = new GIFFilter();
         for (String reject : REJECT) {
             try (InputStream inStream = resourceToBucket(reject).getInputStream();
                  NullOutputStream outStream = new NullOutputStream()) {
 
-                ContentDataFilter filter = new GIFFilter();
-                try {
-                    filter.readFilter(inStream, outStream, "", null, null, null);
-                    fail("Filter did not fail on reject sample " + reject);
-                } catch (DataFilterException e) {
-                    // Expected.
-                }
+                assertThrows(
+                    "Filter did not fail on reject sample " + reject,
+                    DataFilterException.class,
+                    () -> filter.readFilter(inStream, outStream, "", null, null, null)
+                );
             }
         }
     }
@@ -180,10 +179,6 @@ public class GIFFilterTest {
      * @throws AssertionError on failure
      */
     private static Bucket resourceToBucket(String filename) throws IOException {
-        InputStream is = GIFFilterTest.class.getResourceAsStream(RESOURCE_PATH + filename);
-        Bucket ab = new ArrayBucket();
-        BucketTools.copyFrom(ab, is, Long.MAX_VALUE);
-
-        return ab;
+        return ResourceFileUtil.resourceToBucket(RESOURCE_PATH + filename);
     }
 }

--- a/test/freenet/client/filter/GIFFilterTest.java
+++ b/test/freenet/client/filter/GIFFilterTest.java
@@ -117,11 +117,11 @@ public class GIFFilterTest {
 
     @Test
     public void testReject() throws IOException {
-        ContentDataFilter filter = new GIFFilter();
         for (String reject : REJECT) {
             try (InputStream inStream = resourceToBucket(reject).getInputStream();
                  NullOutputStream outStream = new NullOutputStream()) {
 
+                ContentDataFilter filter = new GIFFilter();
                 assertThrows(
                     "Filter did not fail on reject sample " + reject,
                     DataFilterException.class,

--- a/test/freenet/client/filter/JPEGFilterTest.java
+++ b/test/freenet/client/filter/JPEGFilterTest.java
@@ -7,7 +7,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
 import java.util.HashMap;
 
 import org.junit.Test;
@@ -27,14 +26,14 @@ public class JPEGFilterTest {
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		jpegFilter.readFilter(inputStream, outputStream, "UTF-8", new HashMap<>(), null, new NullFilterCallback());
 		byte[] filteredJpegFile = outputStream.toByteArray();
-		assertTrue(Arrays.equals(jpegFile, filteredJpegFile));
+		assertArrayEquals(jpegFile, filteredJpegFile);
 	}
 
 	private byte[] createValidJpegFileWithThumbnail() throws IOException {
 		ByteArrayOutputStream jpegFile = new ByteArrayOutputStream();
 		writeStartOfImageMarker(jpegFile);
-		writeAppMarker(jpegFile, 0, new byte[]{0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-		writeAppMarker(jpegFile, 0, new byte[]{0x4a, 0x46, 0x58, 0x58, 0x00, 0x13, 0x01, 0x01, 0x00, 0x7f, 0x00});
+		writeAppMarker(jpegFile, new byte[]{0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+		writeAppMarker(jpegFile, new byte[]{0x4a, 0x46, 0x58, 0x58, 0x00, 0x13, 0x01, 0x01, 0x00, 0x7f, 0x00});
 		writeEndOfImageMarker(jpegFile);
 		return jpegFile.toByteArray();
 	}
@@ -43,8 +42,8 @@ public class JPEGFilterTest {
 		outputStream.write(new byte[]{(byte) 0xff, (byte) 0xd8});
 	}
 
-	private void writeAppMarker(OutputStream outputStream, int app, byte[] payload) throws IOException {
-		outputStream.write(new byte[]{(byte) 0xff, (byte) (0xe0 + app)});
+	private void writeAppMarker(OutputStream outputStream, byte[] payload) throws IOException {
+		outputStream.write(new byte[]{(byte) 0xff, (byte) (0xe0)});
 		int payloadLengthIncludingLength = payload.length + 2;
 		outputStream.write(new byte[]{(byte) ((payloadLengthIncludingLength >> 8) & 0xff), (byte) (payloadLengthIncludingLength & 0xff)});
 		outputStream.write(payload);

--- a/test/freenet/client/filter/M3UFilterTest.java
+++ b/test/freenet/client/filter/M3UFilterTest.java
@@ -3,17 +3,13 @@ package freenet.client.filter;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.Test;
 
 import freenet.support.api.Bucket;
 import freenet.support.io.ArrayBucket;
-import freenet.support.io.BucketTools;
 
 public class M3UFilterTest {
     protected static String[][] testPlaylists = {
@@ -34,30 +30,26 @@ public class M3UFilterTest {
             String correct = test[1];
             Bucket ibo;
             Bucket ibprocessed = new ArrayBucket();
-            Bucket ibc;
-            ibo = resourceToBucket(original);
-            ibc = resourceToBucket(correct);
+            ArrayBucket ibc;
+            ibo = ResourceFileUtil.resourceToBucket(original);
+            ibc = ResourceFileUtil.resourceToBucket(correct);
 
             try {
                 filter.readFilter(ibo.getInputStream(), ibprocessed.getOutputStream(), "UTF-8", null,
                     SCHEME_HOST_PORT, new GenericReadFilterCallback(new URI(BASE_URI), null, null, null));
                 String result = ibprocessed.toString();
 
-                assertTrue(original + " should be filtered as " + correct + " but was filtered as\n" + result + "\ninstead of the correct\n" + bucketToString((ArrayBucket)ibc), result.equals(bucketToString((ArrayBucket)ibc)));
+                assertEquals(
+                    original + " should be filtered as " + correct + " but was filtered as\n" + result + "\ninstead of the correct\n" + bucketToString(ibc),
+                    bucketToString(ibc),
+                    result
+                );
             } catch (DataFilterException dfe) {
-                assertTrue("Filtering " + original + " failed", false);
+                fail("Filtering " + original + " failed");
             } catch (URISyntaxException use) {
-                assertTrue("Creating URI from BASE_URI " + BASE_URI + " failed", false);
+                fail("Creating URI from BASE_URI " + BASE_URI + " failed");
             }
         }
-    }
-
-    protected ArrayBucket resourceToBucket(String filename) throws IOException {
-        InputStream is = getClass().getResourceAsStream(filename);
-        if (is == null) throw new java.io.FileNotFoundException(filename);
-        ArrayBucket ab = new ArrayBucket();
-        BucketTools.copyFrom(ab, is, Long.MAX_VALUE);
-        return ab;
     }
 
     protected String bucketToString(ArrayBucket bucket) throws IOException {

--- a/test/freenet/client/filter/MP3FilterTest.java
+++ b/test/freenet/client/filter/MP3FilterTest.java
@@ -106,26 +106,13 @@ public class MP3FilterTest {
         ContentDataFilter filter = new MP3Filter();
         Bucket output = new ArrayBucket();
 
-        InputStream inStream;
-        OutputStream outStream;
-        try {
-            inStream = input.getInputStream();
-            outStream = output.getOutputStream();
-        } catch (IOException e) {
-            throw new AssertionError(e);
-        }
-
-        try {
+        try (
+            InputStream inStream = input.getInputStream();
+            OutputStream outStream = output.getOutputStream();
+        ) {
             filter.readFilter(inStream, outStream, "", null, null, null);
         } catch (Exception e) {
             throw new AssertionError("Unexpected exception in the content filter.", e);
-        }
-
-        try {
-            inStream.close();
-            outStream.close();
-        } catch (IOException e) {
-            throw new AssertionError(e);
         }
 
         return output;
@@ -137,16 +124,10 @@ public class MP3FilterTest {
      * @throws AssertionError on failure
      */
     private static Bucket resourceToBucket(String filename) {
-        InputStream is = MP3FilterTest.class.getResourceAsStream(RESOURCE_PATH + filename);
-        if (is == null) {
-            throw new AssertionError("Test resource could not be opened: " + filename);
-        }
-        Bucket ab = new ArrayBucket();
-        try {
-            BucketTools.copyFrom(ab, is, Long.MAX_VALUE);
-        } catch (Exception e) {
+        try  {
+            return ResourceFileUtil.resourceToBucket(RESOURCE_PATH + filename);
+        } catch (IOException e) {
             throw new AssertionError(e);
         }
-        return ab;
     }
 }

--- a/test/freenet/client/filter/OggBitStreamFilterTest.java
+++ b/test/freenet/client/filter/OggBitStreamFilterTest.java
@@ -1,10 +1,9 @@
 package freenet.client.filter;
 
+import static freenet.client.filter.ResourceFileUtil.testResourceFile;
 import static org.junit.Assert.*;
 
-import java.io.DataInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 
 import org.junit.Test;
@@ -12,44 +11,42 @@ import org.junit.Test;
 public class OggBitStreamFilterTest {
 	@Test
 	public void testGetVorbisBitstreamFilter() throws IOException {
-		DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/vorbis_header.ogg"));
-		OggPage page = OggPage.readPage(input);
-		assertEquals(VorbisBitstreamFilter.class, getFilterClass(page));
-		input.close();
+		testResourceFile("./ogg/vorbis_header.ogg", (input) -> {
+			OggPage page = OggPage.readPage(input);
+			assertEquals(VorbisBitstreamFilter.class, getFilterClass(page));
+		});
 	}
 
 	@Test
-	public void testGetTheoraBitStreamFilter() throws IOException { 
-		DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/theora_header.ogg"));
-		OggPage page = OggPage.readPage(input);
-		assertEquals(TheoraBitstreamFilter.class, getFilterClass(page));
-		input.close();
+	public void testGetTheoraBitStreamFilter() throws IOException {
+		testResourceFile("./ogg/theora_header.ogg", (input) -> {
+			OggPage page = OggPage.readPage(input);
+			assertEquals(TheoraBitstreamFilter.class, getFilterClass(page));
+		});
 	}
 	@Test
 	public void testGetFilterForInvalidFormat() throws IOException {
-		InputStream input = getClass().getResourceAsStream("./ogg/invalid_header.ogg");
-		DataInputStream dis = new DataInputStream(input);
-		OggPage page = OggPage.readPage(dis);
-		assertEquals(null, getFilterClass(page));
-		input.close();
+		testResourceFile("./ogg/invalid_header.ogg", (input) -> {
+			OggPage page = OggPage.readPage(input);
+			assertNull(getFilterClass(page));
+		});
 	}
 
 	@Test
 	public void testPagesOutOfOrderCausesException() throws IOException {
-		DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/pages_out_of_order.ogg"));
-		OggPage page = OggPage.readPage(input);
-		OggBitstreamFilter filter = new OggBitstreamFilter(page);
-		page = OggPage.readPage(input);
-		try {
-			filter.parse(page);
-			fail("Expected exception not caught");
-		} catch(DataFilterException e) {}
-		input.close();
+		testResourceFile("./ogg/pages_out_of_order.ogg", (input) -> {
+			OggPage filterPage = OggPage.readPage(input);
+			OggBitstreamFilter filter = new OggBitstreamFilter(filterPage);
+			OggPage page = OggPage.readPage(input);
+			assertThrows(DataFilterException.class, ()-> filter.parse(page));
+		});
 	}
 
 	private Class<? extends OggBitstreamFilter> getFilterClass(OggPage page) {
 		OggBitstreamFilter filter = OggBitstreamFilter.getBitstreamFilter(page);
-		if(filter != null) return filter.getClass();
+		if(filter != null) {
+			return filter.getClass();
+		}
 		return null;
 	}
 }

--- a/test/freenet/client/filter/OggBitStreamFilterTest.java
+++ b/test/freenet/client/filter/OggBitStreamFilterTest.java
@@ -1,52 +1,49 @@
 package freenet.client.filter;
 
-import static freenet.client.filter.ResourceFileUtil.testResourceFile;
+import static freenet.client.filter.ResourceFileUtil.resourceToDataInputStream;
+import static freenet.client.filter.ResourceFileUtil.resourceToOggPage;
 import static org.junit.Assert.*;
 
+import java.io.DataInputStream;
 import java.io.IOException;
 
 
 import org.junit.Test;
 
 public class OggBitStreamFilterTest {
-	@Test
-	public void testGetVorbisBitstreamFilter() throws IOException {
-		testResourceFile("./ogg/vorbis_header.ogg", (input) -> {
-			OggPage page = OggPage.readPage(input);
-			assertEquals(VorbisBitstreamFilter.class, getFilterClass(page));
-		});
-	}
+    @Test
+    public void testGetVorbisBitstreamFilter() throws IOException {
+		OggPage page = resourceToOggPage("./ogg/vorbis_header.ogg");
+		assertEquals(VorbisBitstreamFilter.class, getFilterClass(page));
+    }
 
-	@Test
-	public void testGetTheoraBitStreamFilter() throws IOException {
-		testResourceFile("./ogg/theora_header.ogg", (input) -> {
-			OggPage page = OggPage.readPage(input);
-			assertEquals(TheoraBitstreamFilter.class, getFilterClass(page));
-		});
-	}
-	@Test
-	public void testGetFilterForInvalidFormat() throws IOException {
-		testResourceFile("./ogg/invalid_header.ogg", (input) -> {
-			OggPage page = OggPage.readPage(input);
-			assertNull(getFilterClass(page));
-		});
-	}
+    @Test
+    public void testGetTheoraBitStreamFilter() throws IOException {
+        OggPage page = resourceToOggPage("./ogg/theora_header.ogg");
+        assertEquals(TheoraBitstreamFilter.class, getFilterClass(page));
+    }
 
-	@Test
-	public void testPagesOutOfOrderCausesException() throws IOException {
-		testResourceFile("./ogg/pages_out_of_order.ogg", (input) -> {
-			OggPage filterPage = OggPage.readPage(input);
-			OggBitstreamFilter filter = new OggBitstreamFilter(filterPage);
-			OggPage page = OggPage.readPage(input);
-			assertThrows(DataFilterException.class, ()-> filter.parse(page));
-		});
-	}
+    @Test
+    public void testGetFilterForInvalidFormat() throws IOException {
+        OggPage page = resourceToOggPage("./ogg/invalid_header.ogg");
+        assertNull(getFilterClass(page));
+    }
 
-	private Class<? extends OggBitstreamFilter> getFilterClass(OggPage page) {
-		OggBitstreamFilter filter = OggBitstreamFilter.getBitstreamFilter(page);
-		if(filter != null) {
-			return filter.getClass();
-		}
-		return null;
-	}
+    @Test
+    public void testPagesOutOfOrderCausesException() throws IOException {
+        try (DataInputStream input = resourceToDataInputStream("./ogg/pages_out_of_order.ogg")) {
+            OggPage filterPage = OggPage.readPage(input);
+            OggBitstreamFilter filter = new OggBitstreamFilter(filterPage);
+            OggPage page = OggPage.readPage(input);
+            assertThrows(DataFilterException.class, () -> filter.parse(page));
+        }
+    }
+
+    private Class<? extends OggBitstreamFilter> getFilterClass(OggPage page) {
+        OggBitstreamFilter filter = OggBitstreamFilter.getBitstreamFilter(page);
+        if (filter != null) {
+            return filter.getClass();
+        }
+        return null;
+    }
 }

--- a/test/freenet/client/filter/OggFilterTest.java
+++ b/test/freenet/client/filter/OggFilterTest.java
@@ -1,14 +1,12 @@
 package freenet.client.filter;
 
+import static freenet.client.filter.ResourceFileUtil.testResourceFile;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
 
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.Before;
@@ -24,49 +22,60 @@ public class OggFilterTest {
 
 	@Test
 	public void testEmptyOutputRaisesException() throws IOException {
-		DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/invalid_header.ogg"));
-		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		try {
-			filter.readFilter(input, output, null, null, null, null);
-			fail("Expected Exception not caught. Output size: "+output.toByteArray().length);
-		} catch(DataFilterException e) {}
+		testResourceFile("./ogg/invalid_header.ogg", (input) -> {
+			assertThrows(
+				DataFilterException.class,
+				() -> filter.readFilter(input, new ByteArrayOutputStream(), null, null, null, null)
+			);
+		});
 	}
 
 	@Test
-	public void testValidSubPageStripped() throws IOException, DataFilterException {
-		DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/contains_subpages.ogg"));
-		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		try {
-			filter.readFilter(input, output, null, null, null, null);
-		} catch(DataFilterException e) {}
-		assertTrue(Arrays.equals(new byte[]{}, output.toByteArray()));
-		input.close();
-		output.close();
+	public void testValidSubPageStripped() throws IOException {
+		testResourceFile("./ogg/contains_subpages.ogg", (input) -> {
+			try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+				assertThrows(
+					DataFilterException.class,
+					() -> filter.readFilter(input, output, null, null, null, null)
+				);
+				assertArrayEquals(new byte[]{}, output.toByteArray());
+			}
+		});
 	}
 
     /** the purpose of this test is to create the testoutputFile so you can check it with a video player. */
 	@Test
-	public void testFilterFfmpegEncodedVideoSegment() throws IOException, DataFilterException {
-        String testoutputFile = getClass().getResource(
-	 			"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--filtered-testoutput.ogv")
-					.getFile();
-		DataInputStream inputFileUnchanged = new DataInputStream(getClass().getResourceAsStream(
-				"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--filtered.ogv"));
-		ByteArrayOutputStream unchangedData = new ByteArrayOutputStream();
-		IOUtils.copy(inputFileUnchanged, unchangedData);
-		DataInputStream inputFileToParse = new DataInputStream(getClass().getResourceAsStream(
-				"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--orig.ogv"));
-		DataInputStream input = inputFileToParse;
-		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		try {
-			filter.readFilter(input, output, null, null, null, null);
-			FileOutputStream newFileStream = new FileOutputStream(testoutputFile);
-			System.out.println(testoutputFile);
+	public void testFilterFfmpegEncodedVideoSegment() throws IOException {
+		try (
+			ByteArrayOutputStream unchangedData = new ByteArrayOutputStream();
+			ByteArrayOutputStream output = new ByteArrayOutputStream()
+		) {
+			testResourceFile(
+				"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--filtered.ogv",
+				(inputFileUnchanged) -> IOUtils.copy(inputFileUnchanged, unchangedData)
+			);
+			testResourceFile(
+				"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--orig.ogv",
+				(input) -> {
+					filter.readFilter(input, output, null, null, null, null);
+					writeToTestOutputFile(output);
+				}
+			);
+			assertArrayEquals(unchangedData.toByteArray(), output.toByteArray());
+		}
+	}
+
+	private void writeToTestOutputFile(ByteArrayOutputStream output) throws IOException {
+		URL resource = getClass().getResource(
+			"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--filtered-testoutput.ogv"
+		);
+		if (resource == null) {
+			throw new RuntimeException("Test file is not found");
+		}
+		String testOutputFile = resource.getFile();
+		System.out.println(testOutputFile);
+		try (FileOutputStream newFileStream = new FileOutputStream(testOutputFile)) {
 			output.writeTo(newFileStream);
-			newFileStream.close();
-		} catch(DataFilterException e) {}
-		assertTrue(Arrays.equals(unchangedData.toByteArray(), output.toByteArray()));
-		input.close();
-		output.close();
+		}
 	}
 }

--- a/test/freenet/client/filter/OggFilterTest.java
+++ b/test/freenet/client/filter/OggFilterTest.java
@@ -1,9 +1,10 @@
 package freenet.client.filter;
 
-import static freenet.client.filter.ResourceFileUtil.testResourceFile;
+import static freenet.client.filter.ResourceFileUtil.resourceToDataInputStream;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
@@ -22,47 +23,41 @@ public class OggFilterTest {
 
 	@Test
 	public void testEmptyOutputRaisesException() throws IOException {
-		testResourceFile("./ogg/invalid_header.ogg", (input) -> {
+		try (DataInputStream input = resourceToDataInputStream("./ogg/invalid_header.ogg")) {
 			assertThrows(
 				DataFilterException.class,
 				() -> filter.readFilter(input, new ByteArrayOutputStream(), null, null, null, null)
 			);
-		});
+		}
 	}
 
 	@Test
 	public void testValidSubPageStripped() throws IOException {
-		testResourceFile("./ogg/contains_subpages.ogg", (input) -> {
-			try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-				assertThrows(
-					DataFilterException.class,
-					() -> filter.readFilter(input, output, null, null, null, null)
-				);
-				assertArrayEquals(new byte[]{}, output.toByteArray());
-			}
-		});
+		try (
+			DataInputStream input = resourceToDataInputStream("./ogg/contains_subpages.ogg");
+			ByteArrayOutputStream output = new ByteArrayOutputStream()
+		) {
+			assertThrows(
+				DataFilterException.class,
+				() -> filter.readFilter(input, output, null, null, null, null)
+			);
+			assertArrayEquals(new byte[]{}, output.toByteArray());
+		}
 	}
 
     /** the purpose of this test is to create the testoutputFile so you can check it with a video player. */
 	@Test
 	public void testFilterFfmpegEncodedVideoSegment() throws IOException {
-		try (
-			ByteArrayOutputStream unchangedData = new ByteArrayOutputStream();
-			ByteArrayOutputStream output = new ByteArrayOutputStream()
-		) {
-			testResourceFile(
-				"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--filtered.ogv",
-				(inputFileUnchanged) -> IOUtils.copy(inputFileUnchanged, unchangedData)
-			);
-			testResourceFile(
-				"./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--orig.ogv",
-				(input) -> {
-					filter.readFilter(input, output, null, null, null, null);
-					writeToTestOutputFile(output);
-				}
-			);
-			assertArrayEquals(unchangedData.toByteArray(), output.toByteArray());
+		ByteArrayOutputStream expectedData = new ByteArrayOutputStream();
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		try (DataInputStream input = resourceToDataInputStream("./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--filtered.ogv")) {
+			IOUtils.copy(input, expectedData);
 		}
+		try (DataInputStream input = resourceToDataInputStream("./ogg/36C3_-_opening--cc-by--c3voc--fem-ags-opensuse--ccc--orig.ogv")) {
+			filter.readFilter(input, output, null, null, null, null);
+			writeToTestOutputFile(output);
+		}
+		assertArrayEquals(expectedData.toByteArray(), output.toByteArray());
 	}
 
 	private void writeToTestOutputFile(ByteArrayOutputStream output) throws IOException {

--- a/test/freenet/client/filter/OggPageTest.java
+++ b/test/freenet/client/filter/OggPageTest.java
@@ -1,6 +1,7 @@
 package freenet.client.filter;
 
-import static freenet.client.filter.ResourceFileUtil.testResourceFile;
+import static freenet.client.filter.ResourceFileUtil.resourceToDataInputStream;
+import static freenet.client.filter.ResourceFileUtil.resourceToOggPage;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
@@ -12,20 +13,15 @@ import org.junit.Test;
 public class OggPageTest {
 	@Test
 	public void testStripNonsenseInterruption() throws IOException {
-		try (
-			ByteArrayOutputStream actualDataStream = new ByteArrayOutputStream();
-			ByteArrayOutputStream expectedDataStream = new ByteArrayOutputStream()
-		) {
-			testResourceFile(
-				"./ogg/nonsensical_interruption_filtered.ogg",
-				(input) -> readPages(expectedDataStream, input)
-			);
-			testResourceFile(
-				"./ogg/nonsensical_interruption.ogg",
-				(input) -> readPages(actualDataStream, input)
-			);
-			assertArrayEquals(expectedDataStream.toByteArray(), actualDataStream.toByteArray());
+		ByteArrayOutputStream actualDataStream = new ByteArrayOutputStream();
+		ByteArrayOutputStream expectedDataStream = new ByteArrayOutputStream();
+		try (DataInputStream input = resourceToDataInputStream("./ogg/nonsensical_interruption_filtered.ogg")) {
+			readPages(expectedDataStream, input);
 		}
+		try (DataInputStream input = resourceToDataInputStream("./ogg/nonsensical_interruption.ogg")) {
+			readPages(actualDataStream, input);
+		}
+		assertArrayEquals(expectedDataStream.toByteArray(), actualDataStream.toByteArray());
 	}
 
 	private static void readPages(ByteArrayOutputStream output, DataInputStream input) throws IOException {
@@ -41,17 +37,13 @@ public class OggPageTest {
 
 	@Test
 	public void testChecksum() throws IOException {
-		testResourceFile("./ogg/valid_checksum.ogg", (input) -> {
-			OggPage page = OggPage.readPage(input);
-			assertTrue(page.headerValid());
-		});
+		OggPage page = resourceToOggPage("./ogg/valid_checksum.ogg");
+		assertTrue(page.headerValid());
 	}
 
 	@Test
 	public void testInvalidChecksumInvalidates() throws IOException {
-		testResourceFile("./ogg/invalid_checksum.ogg", (input) -> {
-			OggPage page = OggPage.readPage(input);
-			assertFalse(page.headerValid());
-		});
+		OggPage page = resourceToOggPage("./ogg/invalid_checksum.ogg");
+		assertFalse(page.headerValid());
 	}
 }

--- a/test/freenet/client/filter/OggPageTest.java
+++ b/test/freenet/client/filter/OggPageTest.java
@@ -1,59 +1,57 @@
 package freenet.client.filter;
 
+import static freenet.client.filter.ResourceFileUtil.testResourceFile;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
 
 import org.junit.Test;
 
 public class OggPageTest {
 	@Test
 	public void testStripNonsenseInterruption() throws IOException {
-		InputStream badData = getClass().getResourceAsStream("./ogg/nonsensical_interruption.ogg");
-		ByteArrayOutputStream filteredDataStream = new ByteArrayOutputStream();
-		DataOutputStream output = new DataOutputStream(filteredDataStream);
-		DataInputStream input = new DataInputStream(badData);
+		try (
+			ByteArrayOutputStream actualDataStream = new ByteArrayOutputStream();
+			ByteArrayOutputStream expectedDataStream = new ByteArrayOutputStream()
+		) {
+			testResourceFile(
+				"./ogg/nonsensical_interruption_filtered.ogg",
+				(input) -> readPages(expectedDataStream, input)
+			);
+			testResourceFile(
+				"./ogg/nonsensical_interruption.ogg",
+				(input) -> readPages(actualDataStream, input)
+			);
+			assertArrayEquals(expectedDataStream.toByteArray(), actualDataStream.toByteArray());
+		}
+	}
+
+	private static void readPages(ByteArrayOutputStream output, DataInputStream input) throws IOException {
 		OggPage page = OggPage.readPage(input);
-		if(page.headerValid()) output.write(page.toArray());
+		if (page.headerValid()) {
+			output.write(page.toArray());
+		}
 		page = OggPage.readPage(input);
-		if(page.headerValid()) output.write(page.toArray());
-		byte[] filteredData = filteredDataStream.toByteArray();
-		output.close();
-		input.close();
-
-		InputStream goodData = getClass().getResourceAsStream("./ogg/nonsensical_interruption_filtered.ogg");
-		input = new DataInputStream(goodData);
-		ByteArrayOutputStream expectedDataStream = new ByteArrayOutputStream();
-		output = new DataOutputStream(expectedDataStream);
-		page = OggPage.readPage(input);
-		if(page.headerValid()) output.write(page.toArray());
-		page = OggPage.readPage(input);
-		if(page.headerValid()) output.write(page.toArray());
-		byte[] expectedData = expectedDataStream.toByteArray();
-		output.close();
-		input.close();
-
-		assertTrue(Arrays.equals(filteredData, expectedData));
+		if (page.headerValid()) {
+			output.write(page.toArray());
+		}
 	}
 
 	@Test
 	public void testChecksum() throws IOException {
-		DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/valid_checksum.ogg"));
-		OggPage page = OggPage.readPage(input);
-		assertTrue(page.headerValid());
-		input.close();
+		testResourceFile("./ogg/valid_checksum.ogg", (input) -> {
+			OggPage page = OggPage.readPage(input);
+			assertTrue(page.headerValid());
+		});
 	}
 
 	@Test
 	public void testInvalidChecksumInvalidates() throws IOException {
-		DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/invalid_checksum.ogg"));
-		OggPage page = OggPage.readPage(input);
-		assertFalse(page.headerValid());
-		input.close();
+		testResourceFile("./ogg/invalid_checksum.ogg", (input) -> {
+			OggPage page = OggPage.readPage(input);
+			assertFalse(page.headerValid());
+		});
 	}
 }

--- a/test/freenet/client/filter/PNGFilterTest.java
+++ b/test/freenet/client/filter/PNGFilterTest.java
@@ -1,16 +1,14 @@
 package freenet.client.filter;
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.io.InputStream;
-
+import freenet.support.api.Bucket;
+import freenet.support.io.NullBucket;
 import org.junit.Test;
 
-import freenet.support.api.Bucket;
-import freenet.support.io.ArrayBucket;
-import freenet.support.io.BucketTools;
-import freenet.support.io.NullBucket;
+import java.io.IOException;
+
+import static freenet.client.filter.ResourceFileUtil.resourceToBucket;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PNGFilterTest {
 	protected static Object[][] testImages = {
@@ -123,13 +121,5 @@ public class PNGFilterTest {
 				assertFalse(filename + " should " + (valid ? "" : "not ") + "be valid", valid);
 			}
 		}
-	}
-
-	protected Bucket resourceToBucket(String filename) throws IOException {
-		InputStream is = getClass().getResourceAsStream(filename);
-		if (is == null) throw new java.io.FileNotFoundException();
-		ArrayBucket ab = new ArrayBucket();
-		BucketTools.copyFrom(ab, is, Long.MAX_VALUE);
-		return ab;
 	}
 }

--- a/test/freenet/client/filter/ResourceFileUtil.java
+++ b/test/freenet/client/filter/ResourceFileUtil.java
@@ -1,0 +1,41 @@
+package freenet.client.filter;
+
+import freenet.support.io.ArrayBucket;
+import freenet.support.io.BucketTools;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+class ResourceFileUtil {
+
+    @FunctionalInterface
+    interface ResourceFileStreamConsumer {
+        void processDataInputStream(DataInputStream dataInputStream) throws IOException;
+    }
+
+    static void testResourceFile(String fileName, ResourceFileStreamConsumer inputStreamConsumer) throws IOException {
+        try (
+            InputStream resourceAsStream = ResourceFileUtil.class.getResourceAsStream(fileName);
+        ) {
+            if (resourceAsStream == null) {
+                throw new RuntimeException("File should exist: " + fileName);
+            }
+            try(DataInputStream input = new DataInputStream(resourceAsStream)) {
+                inputStreamConsumer.processDataInputStream(input);
+            }
+        }
+    }
+
+    static ArrayBucket resourceToBucket(String filename) throws IOException {
+        ArrayBucket ab;
+        try (InputStream is = ResourceFileUtil.class.getResourceAsStream(filename)) {
+            if (is == null) {
+                throw new java.io.FileNotFoundException(filename);
+            }
+            ab = new ArrayBucket();
+            BucketTools.copyFrom(ab, is, Long.MAX_VALUE);
+        }
+        return ab;
+    }
+}

--- a/test/freenet/client/filter/ResourceFileUtil.java
+++ b/test/freenet/client/filter/ResourceFileUtil.java
@@ -4,34 +4,31 @@ import freenet.support.io.ArrayBucket;
 import freenet.support.io.BucketTools;
 
 import java.io.DataInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
 class ResourceFileUtil {
 
-    @FunctionalInterface
-    interface ResourceFileStreamConsumer {
-        void processDataInputStream(DataInputStream dataInputStream) throws IOException;
+    static DataInputStream resourceToDataInputStream(String fileName) throws IOException {
+        InputStream resourceAsStream = ResourceFileUtil.class.getResourceAsStream(fileName);
+        if (resourceAsStream == null) {
+            throw new FileNotFoundException(fileName);
+        }
+        return new DataInputStream(resourceAsStream);
     }
 
-    static void testResourceFile(String fileName, ResourceFileStreamConsumer inputStreamConsumer) throws IOException {
-        try (
-            InputStream resourceAsStream = ResourceFileUtil.class.getResourceAsStream(fileName);
-        ) {
-            if (resourceAsStream == null) {
-                throw new RuntimeException("File should exist: " + fileName);
-            }
-            try(DataInputStream input = new DataInputStream(resourceAsStream)) {
-                inputStreamConsumer.processDataInputStream(input);
-            }
+    static OggPage resourceToOggPage(String fileName) throws IOException {
+        try (DataInputStream input = resourceToDataInputStream(fileName)) {
+            return OggPage.readPage(input);
         }
     }
 
-    static ArrayBucket resourceToBucket(String filename) throws IOException {
+    static ArrayBucket resourceToBucket(String fileName) throws IOException {
         ArrayBucket ab;
-        try (InputStream is = ResourceFileUtil.class.getResourceAsStream(filename)) {
+        try (InputStream is = ResourceFileUtil.class.getResourceAsStream(fileName)) {
             if (is == null) {
-                throw new java.io.FileNotFoundException(filename);
+                throw new FileNotFoundException(fileName);
             }
             ab = new ArrayBucket();
             BucketTools.copyFrom(ab, is, Long.MAX_VALUE);

--- a/test/freenet/client/filter/TagVerifierTest.java
+++ b/test/freenet/client/filter/TagVerifierTest.java
@@ -21,9 +21,9 @@ public class TagVerifierTest {
 	private static final String BASE_KEY = "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
 	private static final String ALT_BASE_URI = BASE_URI_PROTOCOL+"://"+BASE_URI_CONTENT+'/'+BASE_KEY;
 	
-	static String tagname;
+	String tagname;
 	LinkedHashMap<String, String> attributes;
-	ParsedTag HTMLTag;
+	ParsedTag htmlTag;
 	TagVerifier verifier;
 	HTMLFilter filter;
 	HTMLFilter.HTMLParseContext pc;
@@ -31,7 +31,7 @@ public class TagVerifierTest {
 	@Before
 	public void setUp() throws Exception {
 		filter = new HTMLFilter();
-		attributes = new LinkedHashMap<String, String>();
+		attributes = new LinkedHashMap<>();
 		pc = filter.new HTMLParseContext(null, null, "utf-8", new GenericReadFilterCallback(new URI(ALT_BASE_URI), null, null, null), false);
 	}
 
@@ -42,11 +42,11 @@ public class TagVerifierTest {
 		pc = null;
 		tagname = null;
 		verifier = null;
-		HTMLTag = null;
+		htmlTag = null;
 	}
 
 	@Test
-	public void testHTMLTagWithInvalidNS() throws DataFilterException{
+	public void testHTMLTagWithInvalidNS() throws DataFilterException {
 		tagname = "html";
 		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
 
@@ -55,10 +55,10 @@ public class TagVerifierTest {
 		//Place a unparsed attribute into the tag
 		attributes.put("version", "-//W3C//DTD HTML 4.01 Transitional//EN");
 
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 		final String HTML_INVALID_XMLNS = "<html version=\"-//W3C//DTD HTML 4.01 Transitional//EN\" />";
 
-		assertEquals("HTML tag containing an invalid xmlns", HTML_INVALID_XMLNS, verifier.sanitize(HTMLTag, pc).toString());
+		assertEquals("HTML tag containing an invalid xmlns", HTML_INVALID_XMLNS, verifier.sanitize(htmlTag, pc).toString());
 	}
 
 	@Test
@@ -72,11 +72,11 @@ public class TagVerifierTest {
 		attributes.put("media", "print, handheld");
 		attributes.put("href", "foo.css");
 
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
 		final String LINK_STYLESHEET = "<link rel=\"stylesheet\" type=\"text/css\" target=\"_blank\" media=\"print, handheld\" href=\"foo.css?type=text/css&amp;maybecharset=utf-8\" />";
 
-		assertEquals("Link tag importing CSS", LINK_STYLESHEET, verifier.sanitize(HTMLTag, pc).toString());
+		assertEquals("Link tag importing CSS", LINK_STYLESHEET, verifier.sanitize(htmlTag, pc).toString());
 	}
 
 	@Test
@@ -86,9 +86,9 @@ public class TagVerifierTest {
 
 		attributes.put("http-equiv","Content-type");
 		attributes.put("content","text/html; charset=UTF-8");
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
-		assertEquals("Meta tag describing HTML content-type", HTMLTag.toString(), verifier.sanitize(HTMLTag, pc).toString());
+		assertEquals("Meta tag describing HTML content-type", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
 	}
 
 	@Test
@@ -98,26 +98,25 @@ public class TagVerifierTest {
 
 		attributes.put("http-equiv","Content-type");
 		attributes.put("content","application/xhtml+xml; charset=UTF-8");
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
-		assertEquals("Meta tag describing XHTML content-type", HTMLTag.toString(), verifier.sanitize(HTMLTag, pc).toString());
+		assertEquals("Meta tag describing XHTML content-type", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
 	}
 
 	@Test
-	public void testMetaTagUnknownContentType() throws DataFilterException {
+	public void testMetaTagUnknownContentType() {
 		tagname = "meta";
 		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
 
 		attributes.put("http-equiv","Content-type");
 		attributes.put("content","want/fishsticks; charset=UTF-8");
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
-		try {
-			verifier.sanitize(HTMLTag, pc);
-			assertTrue("Meta tag describing an unknown content-type: should throw an error", false);
-		} catch (DataFilterException e) {
-			// Ok.
-		}
+		assertThrows(
+			"Meta tag describing an unknown content-type: should throw an error",
+			DataFilterException.class,
+			() -> verifier.sanitize(htmlTag, pc)
+		);
 	}
 
 	@Test
@@ -129,11 +128,11 @@ public class TagVerifierTest {
 		//Let's pretend the following is malicious JavaScript
 		attributes.put("onload", "evil_scripting_magic");
 
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
 		final String BODY_TAG = "<body bgcolor=\"pink\" />";
 
-		assertEquals("Body tag", BODY_TAG, verifier.sanitize(HTMLTag, pc).toString());
+		assertEquals("Body tag", BODY_TAG, verifier.sanitize(htmlTag, pc).toString());
 	}
 
 	@Test
@@ -146,10 +145,10 @@ public class TagVerifierTest {
 		attributes.put("accept-charset", "iso-8859-1");
 		attributes.put("action", "/library/");
 
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 		final String FORM_TAG = "<form method=\"POST\" accept-charset=\"UTF-8\" action=\"/library/\" enctype=\"multipart/form-data\" />";
 
-		assertEquals("Form tag", FORM_TAG, verifier.sanitize(HTMLTag, pc).toString());
+		assertEquals("Form tag", FORM_TAG, verifier.sanitize(htmlTag, pc).toString());
 	}
 
 	@Test
@@ -160,9 +159,9 @@ public class TagVerifierTest {
 		attributes.put("method", "INVALID_METHOD");
 		attributes.put("action", "/library/");
 
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
-		assertNull("Form tag with an invalid method", verifier.sanitize(HTMLTag, pc));
+		assertNull("Form tag with an invalid method", verifier.sanitize(htmlTag, pc));
 	}
 
 	@Test
@@ -172,9 +171,9 @@ public class TagVerifierTest {
 
 		attributes.put("type", "text");
 
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
-		assertEquals("Input tag with a valid type", HTMLTag.toString(), verifier.sanitize(HTMLTag, pc).toString());
+		assertEquals("Input tag with a valid type", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
 	}
 
 	@Test
@@ -184,8 +183,8 @@ public class TagVerifierTest {
 
 		attributes.put("type", "INVALID_TYPE");
 
-		HTMLTag = new ParsedTag(tagname, attributes);
+		htmlTag = new ParsedTag(tagname, attributes);
 
-		assertNull("Input tag with an invalid type", verifier.sanitize(HTMLTag, pc));
+		assertNull("Input tag with an invalid type", verifier.sanitize(htmlTag, pc));
 	}
 }

--- a/test/freenet/client/filter/TheoraBitstreamFilterTest.java
+++ b/test/freenet/client/filter/TheoraBitstreamFilterTest.java
@@ -2,10 +2,12 @@ package freenet.client.filter;
 
 import org.junit.Test;
 
+import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 
-import static freenet.client.filter.ResourceFileUtil.testResourceFile;
+import static freenet.client.filter.ResourceFileUtil.resourceToDataInputStream;
+import static freenet.client.filter.ResourceFileUtil.resourceToOggPage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -13,17 +15,14 @@ public class TheoraBitstreamFilterTest {
 
     @Test
     public void parseIdentificationHeaderTest() throws IOException {
-        testResourceFile("./ogg/theora_header.ogg", (input) -> {
-            OggPage page = OggPage.readPage(input);
-
-            TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
-            assertEquals(page.asPackets(), theoraBitstreamFilter.parse(page).asPackets());
-        });
+        OggPage page = resourceToOggPage("./ogg/theora_header.ogg");
+        TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
+        assertEquals(page.asPackets(), theoraBitstreamFilter.parse(page).asPackets());
     }
 
     @Test
     public void parseTest() throws IOException {
-        testResourceFile("./ogg/Infinite_Hands-2008-Thusnelda-2009-09-18.ogv", (input) -> {
+        try (DataInputStream input = resourceToDataInputStream("./ogg/Infinite_Hands-2008-Thusnelda-2009-09-18.ogv")) {
             OggPage page = OggPage.readPage(input);
             int pageSerial = page.getSerial();
             TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
@@ -39,15 +38,13 @@ public class TheoraBitstreamFilterTest {
                     break;
                 }
             }
-        });
+        }
     }
 
     @Test
     public void parseInvalidHeaderTest() throws IOException {
-        testResourceFile("./ogg/invalid_header.ogg", (input) -> {
-            OggPage page = OggPage.readPage(input);
-            TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
-            assertThrows(UnknownContentTypeException.class, () -> theoraBitstreamFilter.parse(page));
-        });
+        OggPage page = resourceToOggPage("./ogg/invalid_header.ogg");
+        TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
+        assertThrows(UnknownContentTypeException.class, () -> theoraBitstreamFilter.parse(page));
     }
 }

--- a/test/freenet/client/filter/TheoraBitstreamFilterTest.java
+++ b/test/freenet/client/filter/TheoraBitstreamFilterTest.java
@@ -2,27 +2,28 @@ package freenet.client.filter;
 
 import org.junit.Test;
 
-import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static freenet.client.filter.ResourceFileUtil.testResourceFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TheoraBitstreamFilterTest {
 
     @Test
     public void parseIdentificationHeaderTest() throws IOException {
-        try (DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/theora_header.ogg"))) {
+        testResourceFile("./ogg/theora_header.ogg", (input) -> {
             OggPage page = OggPage.readPage(input);
 
             TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
             assertEquals(page.asPackets(), theoraBitstreamFilter.parse(page).asPackets());
-        }
+        });
     }
 
     @Test
     public void parseTest() throws IOException {
-        try (DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/Infinite_Hands-2008-Thusnelda-2009-09-18.ogv"))) {
+        testResourceFile("./ogg/Infinite_Hands-2008-Thusnelda-2009-09-18.ogv", (input) -> {
             OggPage page = OggPage.readPage(input);
             int pageSerial = page.getSerial();
             TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
@@ -38,16 +39,15 @@ public class TheoraBitstreamFilterTest {
                     break;
                 }
             }
-        }
+        });
     }
 
-    @Test(expected = UnknownContentTypeException.class)
+    @Test
     public void parseInvalidHeaderTest() throws IOException {
-        try (DataInputStream input = new DataInputStream(getClass().getResourceAsStream("./ogg/invalid_header.ogg"))) {
+        testResourceFile("./ogg/invalid_header.ogg", (input) -> {
             OggPage page = OggPage.readPage(input);
-
             TheoraBitstreamFilter theoraBitstreamFilter = new TheoraBitstreamFilter(page);
-            theoraBitstreamFilter.parse(page);
-        }
+            assertThrows(UnknownContentTypeException.class, () -> theoraBitstreamFilter.parse(page));
+        });
     }
 }


### PR DESCRIPTION
Improve tests in the `freenet.client` package
----
Depends on #822  and #824 
----

Adds improvements to the tests in the  `freenet.client` package:
* wraps input/output streams with try-with-resources
* removes duplication
* uses better assertion methods
* creates helper utility ResourceFileUtil
* adds better code formatting

