### PR TITLE
Provide default Key Type for File Insert

### DIFF
--- a/src/freenet/clients/http/FileInsertWizardToadlet.java
+++ b/src/freenet/clients/http/FileInsertWizardToadlet.java
@@ -87,11 +87,13 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 		insertContent.addChild("p", l10n("insertIntro"));
 		NETWORK_THREAT_LEVEL seclevel = core.node.securityLevels.getNetworkThreatLevel();
 		HTMLNode insertForm = ctx.addFormChild(insertContent, QueueToadlet.PATH_UPLOADS, "queueInsertForm");
+		boolean preselectSsk = (!rememberedLastTime && seclevel != NETWORK_THREAT_LEVEL.LOW)
+				|| (rememberedLastTime && !wasCanonicalLastTime)
+				|| seclevel == NETWORK_THREAT_LEVEL.MAXIMUM;
 		HTMLNode input = insertForm.addChild("input",
 		        new String[] { "type", "name", "value", "id" },
 		        new String[] { "radio", "keytype", "CHK", "keytypeChk" });
-		if ((!rememberedLastTime && seclevel == NETWORK_THREAT_LEVEL.LOW) ||
-		        (rememberedLastTime && wasCanonicalLastTime && seclevel != NETWORK_THREAT_LEVEL.MAXIMUM)) {
+		if (!preselectSsk) {
 			input.addAttribute("checked", "checked");
 		}
 		insertForm.addChild("label",
@@ -105,7 +107,7 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 		input = insertForm.addChild("input",
 		        new String[] { "type", "name", "value", "id" },
 		        new String[] { "radio", "keytype", "SSK", "keytypeSsk" });
-		if (seclevel == NETWORK_THREAT_LEVEL.MAXIMUM || (rememberedLastTime && !wasCanonicalLastTime)) {
+		if (preselectSsk) {
 			input.addAttribute("checked", "checked");
 		}
 		insertForm.addChild("label",


### PR DESCRIPTION
In order:

- if seclevel maximum: always SSK
- last selection (CHK or SSK), if available
- otherwise SSK

(this was broken which was horrible UX: we know that usually SSK is better, so we should not force users to choose — enable them to choose, but do not force them)