### PR TITLE
Fix NPE When a SimpleFieldSet’s “subsets” Are Uninitialized

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,8 +244,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.9.5"
-    testCompile "org.hamcrest:hamcrest-library:1.3"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
+    testCompile "org.hamcrest:hamcrest:2.2"
     testCompile "org.objenesis:objenesis:1.0"
 }
 
@@ -259,8 +258,7 @@ dependencyVerification {
         'org.freenetproject:freenet-ext:32f2b3d6beedf54137ea2f9a3ebef67666d769f0966b08cd17fd7db59ba4d79f',
         'junit:junit:59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a',
         'org.mockito:mockito-core:f97483ba0944b9fa133aa29638764ddbeadb51ec3dbc02074c58fa2caecd07fa',
-        'org.hamcrest:hamcrest-library:711d64522f9ec410983bd310934296da134be4254a125080a0416ec178dfad1c',
-        'org.hamcrest:hamcrest-core:66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9',
+        'org.hamcrest:hamcrest:5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1',
         'org.objenesis:objenesis:c5694b55d92527479382f254199b3c6b1d8780f652ad61e9ca59919887f491a8',
         'io.pebbletemplates:pebble:d253a6dde59e138698aaaaee546461d2f1f6c8bd2aa38ecdd347df17cf90d6f0',
         // dependencies of pebble

--- a/src/freenet/support/SimpleFieldSet.java
+++ b/src/freenet/support/SimpleFieldSet.java
@@ -31,6 +31,8 @@ import freenet.support.io.Closer;
 import freenet.support.io.LineReader;
 import freenet.support.io.Readers;
 
+import static java.util.Collections.emptyMap;
+
 /**
  * @author amphibian
  *
@@ -802,7 +804,7 @@ public class SimpleFieldSet {
      * @return
      */
     public Map<String, SimpleFieldSet> directSubsets() {
-        return Collections.unmodifiableMap(subsets);
+        return subsets == null ? emptyMap() : Collections.unmodifiableMap(subsets);
     }
 
     /** Tolerant put(); does nothing if fs is empty */

--- a/test/freenet/support/SimpleFieldSetTest.java
+++ b/test/freenet/support/SimpleFieldSetTest.java
@@ -16,6 +16,8 @@
 
 package freenet.support;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.junit.Assert.*;
 
 import java.io.BufferedReader;
@@ -840,4 +842,12 @@ public class SimpleFieldSetTest {
         assertTrue(Arrays.equals(SimpleFieldSet.split(";;blah;1;2;;"), new String[] { "", "", "blah", "1", "2", "", "" }));
         assertTrue(Arrays.equals(SimpleFieldSet.split(";;;"), new String[] { "", "", "" }));
 	}
+
+	// This fixes https://freenet.mantishub.io/view.php?id=7197.
+	@Test
+	public void directSubsetsReturnsEmptyMapWhenSubsetsIsNotInitialized() {
+		SimpleFieldSet simpleFieldSet = new SimpleFieldSet(true);
+		assertThat(simpleFieldSet.directSubsets(), anEmptyMap());
+	}
+
 }


### PR DESCRIPTION
This fixes https://freenet.mantishub.io/view.php?id=7197.

(I also sneakily updated the Hamcrest dependency to 2.2 because it has a couple more cool matchers and it doesn't need the -core/-library split anymore.)