### PR TITLE
Show the unencoded IP addresses before the noderef

### DIFF
--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -895,6 +895,12 @@ public abstract class ConnectionsToadlet extends Toadlet {
 					new HTMLNode[] { HTMLNode.STRONG });
 			referenceInfoboxContent.addChild("pre", "id", "reference", fs.toOrderedStringWithBase64() + '\n');
 		}
+
+		if(!isOpennet()) {
+			HTMLNode myIps = referenceInfoboxContent.addChild("p");
+			myIps.addChild("span", NodeL10n.getBase().getString("DarknetConnectionsToadlet.myIps", "ips", fs.get("physical.udp")));
+		}
+
 	}
 
 	protected abstract String getPageTitle(String titleCountString);

--- a/src/freenet/l10n/freenet.l10n.en.properties
+++ b/src/freenet/l10n/freenet.l10n.en.properties
@@ -346,6 +346,7 @@ DarknetConnectionsToadlet.foafReachableThroughTitle=Reachable Through
 DarknetConnectionsToadlet.connError=Connection failed (buggy node?)
 DarknetConnectionsToadlet.routingDisabled=Not routing traffic (we are currently connected to the node but we or it refuse to route traffic)
 DarknetConnectionsToadlet.routingDisabledShort=Not routing traffic
+DarknetConnectionsToadlet.myIps=The physical.udp field of the noderef contains the IP addresses ${ips}. To change this, set bindTo=THE_ADDRESSES (comma separated) in the file freenet.ini (the node must be stopped before editing).
 DarknetConnectionsToadlet.noLoadStats=Don't know how many requests we can send so can't send any
 DarknetConnectionsToadlet.noLoadStatsShort=No load stats
 DarknetConnectionsToadlet.myName=Nickname for this node: ${name}


### PR DESCRIPTION
This shows what the noderef will expose and can be an important warning to advanced users who have VPN addresses and real node addresses that they don’t want to show.

(in this case they’ll have to change the bindTo to the one address to use in the config)