### PR TITLE
Show the noderef in basic-mode: it is now robust enough

### DIFF
--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -588,7 +588,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 		// our reference
 		if(shouldDrawNoderefBox(advancedMode)) {
 			drawAddPeerBox(contentNode, ctx);
-			drawNoderefBox(contentNode, getNoderef(), true);
+			drawNoderefBox(contentNode, getNoderef());
 		}
 		
 		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
@@ -863,13 +863,10 @@ public abstract class ConnectionsToadlet extends Toadlet {
 	final HTMLNode REFTEXT_LINK;
 
 	/**
-	 *
 	 * @param contentNode Node to add noderef box to.
 	 * @param fs Noderef to render as text if requested.
-	 * @param showNoderef If true, render the text of the noderef so that it may be copy-pasted. If false, only
-	 *                    show a link to download it.
 	 */
-	void drawNoderefBox(HTMLNode contentNode, SimpleFieldSet fs, boolean showNoderef) {
+	void drawNoderefBox(HTMLNode contentNode, SimpleFieldSet fs) {
 		HTMLNode referenceInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
 		HTMLNode headerReferenceInfobox = referenceInfobox.addChild("div", "class", "infobox-header");
 		// FIXME better way to deal with this sort of thing???
@@ -888,13 +885,12 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			myName.addChild("span", "]");
 		}
 
-		if (showNoderef) {
-			HTMLNode warningSentence = referenceInfoboxContent.addChild("p");
-			NodeL10n.getBase().addL10nSubstitution(warningSentence, "DarknetConnectionsToadlet.referenceCopyWarning",
-					new String[] { "bold" },
-					new HTMLNode[] { HTMLNode.STRONG });
-			referenceInfoboxContent.addChild("pre", "id", "reference", fs.toOrderedStringWithBase64() + '\n');
-		}
+		HTMLNode warningSentence = referenceInfoboxContent.addChild("p");
+		NodeL10n.getBase().addL10nSubstitution(warningSentence, "DarknetConnectionsToadlet.referenceCopyWarning",
+				new String[] { "bold" },
+				new HTMLNode[] { HTMLNode.STRONG });
+		referenceInfoboxContent.addChild("pre", "id", "reference", fs.toOrderedStringWithBase64() + '\n');
+
 	}
 
 	protected abstract String getPageTitle(String titleCountString);

--- a/src/freenet/clients/http/DarknetAddRefToadlet.java
+++ b/src/freenet/clients/http/DarknetAddRefToadlet.java
@@ -86,7 +86,7 @@ public class DarknetAddRefToadlet extends Toadlet {
 		
 		ConnectionsToadlet.drawAddPeerBox(contentNode, ctx, false, friendsToadlet.path());
 		
-		friendsToadlet.drawNoderefBox(contentNode, getNoderef(), true);
+		friendsToadlet.drawNoderefBox(contentNode, getNoderef());
 		
 		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
 	}

--- a/src/freenet/clients/http/DarknetAddRefToadlet.java
+++ b/src/freenet/clients/http/DarknetAddRefToadlet.java
@@ -86,7 +86,7 @@ public class DarknetAddRefToadlet extends Toadlet {
 		
 		ConnectionsToadlet.drawAddPeerBox(contentNode, ctx, false, friendsToadlet.path());
 		
-		friendsToadlet.drawNoderefBox(contentNode, getNoderef(), pageMaker.advancedMode(request, this.container));
+		friendsToadlet.drawNoderefBox(contentNode, getNoderef(), true);
 		
 		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
 	}


### PR DESCRIPTION
Previously the noderef was hidden in basic mode to get people to send it as file, because line terminators made problems (\n vs \r\n vs \r) and inserted linebreaks broke the noderef.

It has been made much more resilient since then, so the added click is now a bigger problem than potential breakage due to corruption.