### PR TITLE
Problem with maxDatastoreSize

### DIFF
--- a/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
@@ -222,7 +222,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
                 if (storageLimit < MIN_STORAGE_LIMIT) { // min store size + 10% for client cache + 10% for slashdot cache
                     errors.put("storageLimitError", NodeL10n.getBase().getString("Node.invalidMinStoreSizeWithCaches"));
                 } else {
-                    long maxDatastoreSize = DatastoreUtil.maxDatastoreSize();
+                    long maxDatastoreSize = DatastoreUtil.maxDatastoreSize(config);
                     if (storageLimit > maxDatastoreSize) {
                         errors.put("storageLimitError",
                                 NodeL10n.getBase().getString("Node.invalidMaxStoreSize",

--- a/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
+++ b/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
@@ -125,7 +125,7 @@ public class DATASTORE_SIZE implements Step {
 		try {
 			long size = Fields.parseLong(selectedStoreSize);
 
-			long maxDatastoreSize = DatastoreUtil.maxDatastoreSize();
+			long maxDatastoreSize = DatastoreUtil.maxDatastoreSize(config);
 			if (size > maxDatastoreSize) {
 				throw new InvalidConfigValueException("Attempting to set DatastoreSize (" + size
 						+ ") larger than maxDatastoreSize (" + maxDatastoreSize + ")");

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -1970,7 +1970,7 @@ public class Node implements TimeSkewDetectorCallback {
 						if(storeSize < MIN_STORE_SIZE) {
 							throw new InvalidConfigValueException(l10n("invalidMinStoreSize"));
 						}
-						if(storeSize > (maxDatastoreSize = DatastoreUtil.maxDatastoreSize())) {
+						if(storeSize > (maxDatastoreSize = DatastoreUtil.maxDatastoreSize(config))) {
 							throw new InvalidConfigValueException(
 									l10n("invalidMaxStoreSize", Long.toString(maxDatastoreSize)));
 						}

--- a/src/freenet/support/io/DatastoreUtil.java
+++ b/src/freenet/support/io/DatastoreUtil.java
@@ -15,7 +15,7 @@ public class DatastoreUtil {
     public static final long oneMiB = 1024 * 1024;
     public static final long oneGiB = 1024 * 1024 * 1024;
 
-    public static long maxDatastoreSize() {
+    public static long maxDatastoreSize(Config config) {
         long maxDatastoreSize;
 
         // check ram limitations
@@ -38,10 +38,12 @@ public class DatastoreUtil {
 
         // check free disc space
         try {
-            long unallocatedSpace = Files.getFileStore(Paths.get("")).getUnallocatedSpace();
+        	String storeDirPath = config.get("node.install").getString("storeDir");
+            long unallocatedSpace = Files.getFileStore(Paths.get(storeDirPath)).getUnallocatedSpace();
             // TODO: leave some free space
             // probably limit 256GB see comments of the autodetectDatastoreSize method
-            return unallocatedSpace < maxDatastoreSize ? unallocatedSpace : maxDatastoreSize;
+            long currentStoreSize = config.get("node").getLong("storeSize");
+            return unallocatedSpace < maxDatastoreSize ? currentStoreSize + unallocatedSpace : maxDatastoreSize;
         } catch (IOException e) {
             Logger.error(DatastoreUtil.class, "Error querying space", e);
         }

--- a/src/freenet/support/io/DatastoreUtil.java
+++ b/src/freenet/support/io/DatastoreUtil.java
@@ -38,7 +38,7 @@ public class DatastoreUtil {
 
         // check free disc space
         try {
-        	String storeDirPath = config.get("node.install").getString("storeDir");
+            String storeDirPath = config.get("node.install").getString("storeDir");
             long unallocatedSpace = Files.getFileStore(Paths.get(storeDirPath)).getUnallocatedSpace();
             // TODO: leave some free space
             // probably limit 256GB see comments of the autodetectDatastoreSize method


### PR DESCRIPTION
### Situation
- 500GB disk
- 100GB datastore
- 80GB free space

### Problem 1
If you know try to set your datastore to 130GB an error appears... because because `DatastoreUtil.maxDatastoreSize()` will return  only the 80GB left (https://github.com/hyphanet/fred/blob/fcc32a21cfb962a03b731edd3a14d6d0b2e0860c/src/freenet/support/io/DatastoreUtil.java#L44)
**Solution:**  use the current datastore size + the free space as max

### Problem 2
`DatastoreUtil.maxDatastoreSize()` only checks the free space where hyphanet is executed not where the datastore is. If the datastore is on another disk this lead also to a problem.
**Solution:** use the config value for the datastore

#### Information
- please squash
- please test this