### PR TITLE
✨ Allow Registering of Ignored Options

### DIFF
--- a/src/freenet/config/SubConfig.java
+++ b/src/freenet/config/SubConfig.java
@@ -152,6 +152,21 @@ public class SubConfig implements Comparable<SubConfig> {
 		register(new StringArrOption(this, optionName, defaultValue, sortOrder, expert, forceWrite, shortDesc, longDesc, cb));
 	}
 
+	/**
+	 * Registers an option that cannot be used.
+	 * <p>
+	 * It is not listed, it is not exported, it is not persisted, it doesn’t
+	 * have a value, you cannot change the value. It only exists so that
+	 * Fred doesn’t log an error message if this particular option is used in
+	 * a config file.
+	 *
+	 * @param optionName The name of the option to ignore
+	 * @see PersistentConfig#finishedInit()
+	 */
+	public void registerIgnoredOption(String optionName) {
+		config.onRegister(this, new IgnoredOption(optionName));
+	}
+
 	public int getInt(String optionName) {
 		IntOption o;
 		synchronized(this) {
@@ -382,6 +397,33 @@ public class SubConfig implements Comparable<SubConfig> {
 			if(fs == null) return null;
 			return fs.get(prefix + SimpleFieldSet.MULTI_LEVEL_CHAR + name);
 		} else return null;
+	}
+
+	private class IgnoredOption extends Option<Void> {
+
+		public IgnoredOption(String optionName) {
+			super(SubConfig.this, optionName, new ConfigCallback<Void>() {
+				@Override
+				public Void get() {
+					return null;
+				}
+
+				@Override
+				public void set(Void value) {
+				}
+			}, -1, false, false, null, null, null);
+		}
+
+		@Override
+		protected Void parseString(String val) {
+			return null;
+		}
+
+		@Override
+		protected String toString(Void val) {
+			return null;
+		}
+
 	}
 
 }

--- a/test/freenet/config/PersistentConfigTest.java
+++ b/test/freenet/config/PersistentConfigTest.java
@@ -1,0 +1,59 @@
+package freenet.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import freenet.support.Logger;
+import freenet.support.LoggerHook;
+import freenet.support.SimpleFieldSet;
+import org.junit.Test;
+
+import static freenet.support.Logger.LogLevel.MINIMAL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+public class PersistentConfigTest {
+
+	@Test
+	public void configDoesNotLogAnErrorWhenIgnoredOptionIsRead() {
+		List<String> messages = interceptLogger(config::finishedInit);
+		assertThat(messages, empty());
+	}
+
+	@Test
+	public void configDoesNotContainIgnoredOptionWhenExported() {
+		assertThat(config.exportFieldSet().isEmpty(), equalTo(true));
+	}
+
+	private List<String> interceptLogger(Runnable runnable) {
+		List<String> messages = new ArrayList<>();
+		LoggerHook loggerHook = new LoggerHook(MINIMAL) {
+			@Override
+			public void log(Object o, Class<?> source, String message, Throwable e, LogLevel priority) {
+				if (source == PersistentConfig.class) {
+					messages.add(message);
+				}
+			}
+		};
+		Logger.globalAddHook(loggerHook);
+		runnable.run();
+		Logger.globalRemoveHook(loggerHook);
+		return messages;
+	}
+
+	private final SimpleFieldSet fieldSetWithIgnoredOption = new SimpleFieldSet(true);
+
+	{
+		fieldSetWithIgnoredOption.put("sub.ignored", true);
+	}
+
+	private final PersistentConfig config = new PersistentConfig(fieldSetWithIgnoredOption);
+	private final SubConfig subConfig = config.createSubConfig("sub");
+
+	{
+		subConfig.registerIgnoredOption("ignored");
+		subConfig.finishedInitialization();
+	}
+
+}

--- a/test/freenet/config/SubConfigTest.java
+++ b/test/freenet/config/SubConfigTest.java
@@ -1,0 +1,26 @@
+package freenet.config;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.equalTo;
+
+public class SubConfigTest {
+
+	@Test
+	public void registeredIgnoredOptionDoesNotShowUpInRegisteredOptions() {
+		subConfig.registerIgnoredOption("ignored");
+		assertThat(subConfig.getOptions(), emptyArray());
+	}
+
+	@Test
+	public void ignoredOptionIsNotExported() {
+		subConfig.registerIgnoredOption("ignored");
+		assertThat(subConfig.exportFieldSet().isEmpty(), equalTo(true));
+	}
+
+	private final Config config = new Config();
+	private final SubConfig subConfig = config.createSubConfig("");
+
+}


### PR DESCRIPTION
The whole reason for this is that Fred logs messages at ERROR if a config file contains an option it does not know about. As the plan is to remove a number of options, not having these values show up in log files is a definite plus.