### PR TITLE
Move Library to advanced plugins because new users tend to get lost

### DIFF
--- a/src/freenet/pluginmanager/OfficialPlugins.java
+++ b/src/freenet/pluginmanager/OfficialPlugins.java
@@ -107,7 +107,8 @@ public class OfficialPlugins {
 					.recommendedVersion(37)
 					.minimumVersion(36)
 					.usesXml()
-					.loadedFrom("CHK@RrYmOu8RGoEY44LOgGBBgY9qRxmiev0SFAVxWAbwROI,cfYMrDcBdewk4I7AC4J3mAq0g~NH3TxVpfeSkQ9Xaa8,AAMC--8/Library.jar");
+					.loadedFrom("CHK@RrYmOu8RGoEY44LOgGBBgY9qRxmiev0SFAVxWAbwROI,cfYMrDcBdewk4I7AC4J3mAq0g~NH3TxVpfeSkQ9Xaa8,AAMC--8/Library.jar")
+					.advanced();
 			addPlugin("Spider")
 					.inGroup("index")
 					.minimumVersion(53)


### PR DESCRIPTION
Before moving it back to the default list of plugins, we need to figure out a good user experience for it. At the moment either it does not work or it floods users with bad results.