### PR TITLE
 Remove security lowering kludge.

### DIFF
--- a/src/freenet/node/NodeCryptoConfig.java
+++ b/src/freenet/node/NodeCryptoConfig.java
@@ -240,18 +240,6 @@ public class NodeCryptoConfig {
 		});
 		
 		paddDataPackets = config.getBoolean("paddDataPackets");
-		securityLevels.addNetworkThreatLevelListener(new SecurityLevelListener<NETWORK_THREAT_LEVEL>() {
-
-			@Override
-			public void onChange(NETWORK_THREAT_LEVEL oldLevel, NETWORK_THREAT_LEVEL newLevel) {
-				// Might be useful for nodes which are running with a tight bandwidth quota to minimize the overhead,
-				// so turn it off for LOW. Otherwise is sensible.
-				if(newLevel == NETWORK_THREAT_LEVEL.LOW)
-					paddDataPackets = false;
-				if(oldLevel == NETWORK_THREAT_LEVEL.LOW)
-					paddDataPackets = true;
-			}
-		});
 	}
 
 	/** The number of config options i.e. the amount to increment sortOrder by */


### PR DESCRIPTION
 As stated in the description of this option, if a large portion of the network disables packet padding it makes the network easier to trace. 15 years later now, if network overhead is a real concern for some users they can tweak this themselves.