### PR TITLE
Remove hash generation to native big integer to reduce dependencies.

### DIFF
--- a/src/freenet/crypt/Hash.java
+++ b/src/freenet/crypt/Hash.java
@@ -6,7 +6,6 @@ package freenet.crypt;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 
-import net.i2p.util.NativeBigInteger;
 import freenet.support.HexUtil;
 
 /**
@@ -95,31 +94,6 @@ public final class Hash{
 	 */
 	public final String genHexHash() {
 		return HexUtil.bytesToHex(genHash());
-	}
-	
-	/**
-	 * Generates the hash as a NativeBigInteger of all the bytes in the buffer 
-	 * added with the addBytes methods. The buffer is then cleared after the hash 
-	 * has been generated.
-	 * @return The generated hash as a NativeBigInteger of all the bytes added 
-	 * since last reset.
-	 */
-	public final NativeBigInteger genNativeBigIntegerHash(){
-		return new NativeBigInteger(1, genHash());
-	}
-	
-	/**
-	 * Generates the hash as a NativeBigInteger string of only the specified 
-	 * bytes. The buffer is cleared before processing the input to ensure that 
-	 * no extra data is included. Once the hash has been generated, the buffer 
-	 * is cleared again. 
-	 * @param input The bytes to hash
-	 * @return The generated hash as a NativeBigInteger of the data
-	 */
-	public final NativeBigInteger genNativeBigIntegerHash(byte[]... data){
-		digest.reset();
-		addBytes(data);
-		return genNativeBigIntegerHash();
 	}
 	
 	/**

--- a/test/freenet/crypt/HashTest.java
+++ b/test/freenet/crypt/HashTest.java
@@ -10,8 +10,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
-import net.i2p.util.NativeBigInteger;
-
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 
@@ -131,16 +129,6 @@ public class HashTest {
 			String hexHash = hash.genHexHash();
 			assertEquals("HashType: "+types[i].name(), trueHashes[i], hexHash);
 		}
-	}
-
-	@Test
-	public void testGetNativeBigIntegerHashByteArrayArray(){
-		for(int i = 0; i < types.length; i++){
-			Hash hash = new Hash(types[i]);
-			NativeBigInteger abcVector = new NativeBigInteger(1, Hex.decode(trueHashes[i]));
-			NativeBigInteger result = hash.genNativeBigIntegerHash(helloWorld);
-			assertEquals("HashType: "+types[i].name(), abcVector, result);
-		}	
 	}
 
 	@Test


### PR DESCRIPTION
In the Guix build Hash.java was a blocker that had to be circumvented, because the i2p tools are not packaged.

Since the two methods providing NativeBigInteger are unused, this PR removes them completely.