### PR TITLE
Address failing tests because of line separator issues on Windows.

### DIFF
--- a/src/freenet/client/filter/M3UFilter.java
+++ b/src/freenet/client/filter/M3UFilter.java
@@ -87,6 +87,10 @@ public class M3UFilter implements ContentDataFilter {
                 readcount = dis.read(nextbyte);
                 continue;
             }
+            if (isCarriageReturn(nextbyte)) {
+                readcount = dis.read(nextbyte);
+                continue;
+            }
             // read one line as a fileUri
             fileIndex = 0;
             fileUri = new byte[MAX_URI_LENGTH];
@@ -164,7 +168,7 @@ public class M3UFilter implements ContentDataFilter {
                             }
                             // write the newline if we're not at EOF
                             if (readcount != -1){
-                                dos.write(nextbyte);
+                                dos.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
                             }
                         }
                     }

--- a/src/freenet/support/HTMLNode.java
+++ b/src/freenet/support/HTMLNode.java
@@ -319,8 +319,8 @@ public class HTMLNode implements XMLCharacterClasses, Cloneable {
 	/**
 	 * Add a tag with several attributes inside/under this node.
 	 * @param nodeName The tag name e.g. "div".
-	 * @param attributeName The name of the attribute, e.g. "class"
-	 * @param attributeValue The value of the attribute.
+	 * @param attributeNames The name of the attribute, e.g. "class"
+	 * @param attributeValues The value of the attribute.
 	 * @return The added node. You can add more tags inside it with addChild(), or add attributes
 	 * with addAttribute() etc. If you render the parent tag with generate(), it will include this 
 	 * tag in its output. 
@@ -418,7 +418,7 @@ public class HTMLNode implements XMLCharacterClasses, Cloneable {
 			}
 		} else {
 			if (newlineOpen(name)) {
-				tagBuffer.append('\n');
+				tagBuffer.append(System.lineSeparator());
 				tagBuffer.append(indentString(indentDepth+1));
 			}
 			for (int childIndex = 0, childCount = children.size(); childIndex < childCount; childIndex++) {
@@ -428,12 +428,12 @@ public class HTMLNode implements XMLCharacterClasses, Cloneable {
 		}
 		/* add a closing tag */
 		if (newlineOpen(name)) {
-			tagBuffer.append('\n');
+			tagBuffer.append(System.lineSeparator());
 			tagBuffer.append(indentString(indentDepth));
 		}
 		tagBuffer.append(CloseTag(name));
 		if (newlineClose(name)) {
-			tagBuffer.append('\n');
+			tagBuffer.append(System.lineSeparator());
 			tagBuffer.append(indentString(indentDepth));
 		}
 		return tagBuffer;

--- a/test/freenet/clients/http/utils/PebbleUtilsTest.java
+++ b/test/freenet/clients/http/utils/PebbleUtilsTest.java
@@ -15,7 +15,7 @@ public class PebbleUtilsTest {
 	@Test
 	public void addChildAddsCorrectlyEvaluatedSimpleTemplateToHtmlNode() throws IOException {
 		PebbleUtils.addChild(emptyParentNode, "pebble-utils-test-simple", model, null);
-		assertThat(emptyParentNode.generate(), equalTo("Test!\n"));
+		assertThat(emptyParentNode.generate(), equalTo("Test!" + System.lineSeparator()));
 	}
 
 	@Test


### PR DESCRIPTION
I was building this on my local and noticed that \n was hardcoded in several spots, causing tests to fail on windows. I made the minimum code changes to get it to build on both Windows and Linux. 