### PR TITLE
Apply sanity check for size

### DIFF
--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -1603,6 +1603,12 @@ public class Node implements TimeSkewDetectorCallback {
 			@Override
 			public void set(Long amountOfDataToCheckCompressionRatio) {
 				synchronized(Node.this) {
+					if (amountOfDataToCheckCompressionRatio < 0 || amountOfDataToCheckCompressionRatio > 100 * 1024 * 1024) {
+						Logger.normal(Node.class, "Amount of data to check for compression should be 100 MiB max"
+								+ amountOfDataToCheckCompressionRatio);
+						return;
+					}
+
 					Node.this.amountOfDataToCheckCompressionRatio = amountOfDataToCheckCompressionRatio;
 				}
 			}

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -1604,8 +1604,8 @@ public class Node implements TimeSkewDetectorCallback {
 			public void set(Long amountOfDataToCheckCompressionRatio) {
 				synchronized(Node.this) {
 					if (amountOfDataToCheckCompressionRatio < 0 || amountOfDataToCheckCompressionRatio > 100 * 1024 * 1024) {
-						Logger.normal(Node.class, "Amount of data to check for compression should be 100 MiB max"
-								+ amountOfDataToCheckCompressionRatio);
+						Logger.normal(Node.class, "Amount of data to check for compression should be 100 MiB max, "
+								+ amountOfDataToCheckCompressionRatio + " bytes selected");
 						return;
 					}
 


### PR DESCRIPTION
There were no restraints on negative values or extremely large values of amountOfDataToCheckCompressionRatio. Add a less than zero and a max of 100 MiB check.