### PR TITLE
Counting loop was not looping

### DIFF
--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -525,7 +525,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 			}
 			
 			innerRouteRequests(next, thisTag);
-			return;
+
 		}
 	}
 

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -393,7 +393,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
             
             innerRouteRequests(next, origTag);
             // Will either chain back to routeRequests(), or call onAccepted().
-           	return;
+
         }
 	}
 

--- a/src/freenet/node/SSKInsertSender.java
+++ b/src/freenet/node/SSKInsertSender.java
@@ -208,7 +208,7 @@ public class SSKInsertSender extends BaseSender implements PrioRunnable, AnyInse
             if(forkedRequestTag == null) thisTag = origTag;
             
             innerRouteRequests(next, thisTag);
-            return;
+
         }            
     }
     


### PR DESCRIPTION
Disregard.
The section of code does not do anything anymore.

According to the comments:
We always decrement on starting a sender.
However, after that, if our HTL is above the no-cache threshold, we do not want to decrement the HTL for trivial rejections (e.g. RejectedLoop), because we would end up caching data too close to the originator. So allow 5 failures and then RNF.