### PR TITLE
[CI] Update actions, fix actions cache

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,20 +10,29 @@ jobs:
   build-deb:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
         distribution: [temurin]
         java: [17]
 
-    runs-on: ubuntu-latest
+    runs-on: '${{ matrix.os }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Wrapper validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
 
-      - name: Setup java
-        uses: actions/setup-java@v3
+      - name: Speedup dpkg
+        run: sudo sh -c "echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/force-unsafe-io"
+
+      - name: Fix 'Setup Java' action Gradle caching
+        run: |
+          sudo mkdir -p /tmp/fred-build/gradle
+          sudo ln -s /tmp/fred-build/gradle ~/.gradle
+          sudo chmod o+rwx ~/.gradle
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
           cache: 'gradle'
           distribution: '${{ matrix.distribution }}'
@@ -50,7 +59,10 @@ jobs:
           cp ../freenet*.deb ./
 
       - name: Provide Debian Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian-package
           path: freenet_*.deb
+          # Since .deb file is compressed archive itself,
+          # additional compression useless
+          compression-level: 0


### PR DESCRIPTION
Actions updated due to [deprecation actions on Node v16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
Fixed cache in "Setup Java" action
Changed installation via apt to another action with cache