### PR TITLE
🐛 Fix JarClassLoaderTest to work with newer Java versions

### DIFF
--- a/test/freenet/support/JarClassLoaderTest.java
+++ b/test/freenet/support/JarClassLoaderTest.java
@@ -3,11 +3,9 @@ package freenet.support;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -28,33 +26,27 @@ public class JarClassLoaderTest {
 
 	@Test
 	public void serviceLoaderCanLocateTestImplementation() throws Exception {
-		JarClassLoader classLoader = new JarClassLoader(createJarFileWithTwoServiceLoaderEntries());
+		JarClassLoader classLoader = new JarClassLoader(createJarFileWithServiceLoaderEntry());
 		ServiceLoader<TestInterface> testInterface = ServiceLoader.load(TestInterface.class, classLoader);
 		List<TestInterface> implementations = new ArrayList<>();
 		testInterface.iterator().forEachRemaining(implementations::add);
-		assertThat(implementations, containsInAnyOrder(
-				instanceOf(TestImplementation1.class),
-				instanceOf(TestImplementation2.class)
-		));
+		assertThat(implementations, containsInAnyOrder(instanceOf(TestImplementation.class)));
 	}
 
 	/**
-	 * Create a temporary JAR file that contains two files that will be used by
-	 * {@link ServiceLoader} in order to provide two different implementations
-	 * of {@link TestInterface}.
+	 * Creates a temporary JAR file that contains a file that will be used by {@link ServiceLoader} in order to provide
+	 * an implementation of {@link TestInterface}.
 	 *
-	 * @return A temporary JAR file containing two service loader entries
+	 * @return A temporary JAR file containing a service loader entry
 	 * @throws Exception if an error occurs
 	 */
-	private File createJarFileWithTwoServiceLoaderEntries() throws Exception {
+	private File createJarFileWithServiceLoaderEntry() throws Exception {
 		File temporaryFile = createTempFile("jar-class-loader-test-", ".jar");
 		temporaryFile.deleteOnExit();
 		try (
 				OutputStream fileOutputStream = newOutputStream(temporaryFile.toPath());
 				JarOutputStream jarFileStream = new JarOutputStream(fileOutputStream)) {
-			createServiceLoaderEntryFor(TestImplementation1.class, jarFileStream);
-			clearNames(jarFileStream);
-			createServiceLoaderEntryFor(TestImplementation2.class, jarFileStream);
+			createServiceLoaderEntryFor(TestImplementation.class, jarFileStream);
 		}
 		return temporaryFile;
 	}
@@ -73,36 +65,15 @@ public class JarClassLoaderTest {
 	}
 
 	/**
-	 * Clears the names of already written entries of the given {@link ZipOutputStream}.
-	 * This is necessary to prevent exceptions because of duplicate file entries because
-	 * we absolutely <em>do</em> want multiple files with the same name here.
-	 *
-	 * @param zipOutputStream The ZIP output stream to process
-	 * @throws Exception if there’s a reflection error
-	 */
-	private void clearNames(ZipOutputStream zipOutputStream) throws Exception {
-		Field namesField = ZipOutputStream.class.getDeclaredField("names");
-		namesField.setAccessible(true);
-		Set<String> names = (Set<String>) namesField.get(zipOutputStream);
-		names.clear();
-	}
-
-	/**
 	 * Interface for use with the {@link ServiceLoader}.
 	 */
 	public interface TestInterface {
 	}
 
 	/**
-	 * First implementation of the {@link TestInterface} interface.
+	 * Implementation of the {@link TestInterface} interface.
 	 */
-	public static class TestImplementation1 implements TestInterface {
-	}
-
-	/**
-	 * Second implementation of the {@link TestInterface} interface.
-	 */
-	public static class TestImplementation2 implements TestInterface {
+	public static class TestImplementation implements TestInterface {
 	}
 
 }


### PR DESCRIPTION
Java 11’s new, non-native `ZipFile` implementation will return the same entry if you ask for an entry with the same name twice, whereas Java 8’s native implementation gave you the _next_ entry with the given name, leading to a test that will work with Java 8 but not with Java 11.

And also, all the hubbub with multiple entries in a JAR file with the same name is totally unnecessary, the test works just fine, the fixed version doesn’t even need reflection, and it verifies `JarClassLoader`’s functionality just as well as before.

Tested with Java 8, Java 11, Java 17, and Java 21.