### PR TITLE
Reduce recently failed and data not found wait times

### DIFF
--- a/src/freenet/node/FailureTable.java
+++ b/src/freenet/node/FailureTable.java
@@ -74,12 +74,12 @@ public class FailureTable {
 	/** Terminate a request if there was a DNF on the same key less than 10 minutes ago.
 	 * Maximum time for any FailureTable i.e. for this period after a DNF, we will avoid the node that 
 	 * DNFed. */
-	static final long REJECT_TIME = MINUTES.toMillis(10);
+	static final long REJECT_TIME = MINUTES.toMillis(3);
 	/** Maximum time for a RecentlyFailed. I.e. until this period expires, we take a request into account
 	 * when deciding whether we have recently failed to this peer. If we get a DNF, we use this figure.
 	 * If we get a RF, we use what it tells us, which can be less than this. Most other failures use
 	 * shorter periods. */
-	static final long RECENTLY_FAILED_TIME = MINUTES.toMillis(30);
+	static final long RECENTLY_FAILED_TIME = MINUTES.toMillis(5);
 	/** After 1 hour we forget about an entry completely */
 	static final long MAX_LIFETIME = MINUTES.toMillis(60);
 	/** Offers expire after 10 minutes */

--- a/src/freenet/node/FailureTable.java
+++ b/src/freenet/node/FailureTable.java
@@ -71,7 +71,7 @@ public class FailureTable {
 	static final int MAX_ENTRIES = 20*1000;
 	/** Maximum number of offers to track */
 	static final int MAX_OFFERS = 10*1000;
-	/** Terminate a request if there was a DNF on the same key less than 10 minutes ago.
+	/** Terminate a request if there was a DNF on the same key less than this time ago.
 	 * Maximum time for any FailureTable i.e. for this period after a DNF, we will avoid the node that 
 	 * DNFed. */
 	static final long REJECT_TIME = MINUTES.toMillis(3);


### PR DESCRIPTION
Since we have 5 minutes time to receive a USK update, RF should be at most that long. Otherwise RF will block keys if the uploader checked them a bit too early.