### PR TITLE
Support abridged IPv6 address

### DIFF
--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -567,7 +567,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 						foafRow.addChild("td", String.valueOf(peersWithFriend.size()));
 						HTMLNode locationCell=foafRow.addChild("td", "class", "peer-location");
 						for (PeerNodeStatus peerNodeStatus : peersWithFriend) {
-							String address=((peerNodeStatus.getPeerAddress() != null) ? (peerNodeStatus.getPeerAddress() + ':' + peerNodeStatus.getPeerPort()) : (l10n("unknownAddress")));
+							String address=((peerNodeStatus.getPeerAddress() != null) ? peerNodeStatus.getPeerAddressAndPort() : (l10n("unknownAddress")));
 							locationCell.addChild("i", address);
 							locationCell.addChild("br");
 						}
@@ -993,7 +993,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			country.renderFlagIcon(addressRow);
 		}
 
-		addressRow.addChild("#", ((peerNodeStatus.getPeerAddress() != null) ? (peerNodeStatus.getPeerAddress() + ':' + peerNodeStatus.getPeerPort()) : (l10n("unknownAddress"))) + pingTime);
+		addressRow.addChild("#", ((peerNodeStatus.getPeerAddress() != null) ? peerNodeStatus.getPeerAddressAndPort() : (l10n("unknownAddress"))) + pingTime);
 
 		// version column
 		if (peerNodeStatus.getStatusValue() != PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED && (peerNodeStatus.isPublicInvalidVersion() || peerNodeStatus.isPublicReverseInvalidVersion())) {  // Don't draw attention to a version problem if NEVER CONNECTED

--- a/src/freenet/io/AddressIdentifier.java
+++ b/src/freenet/io/AddressIdentifier.java
@@ -53,7 +53,6 @@ public class AddressIdentifier {
 		 */
 		String ipv6AddressRegex = "::(?>(?>X:){0,6}X)?|X::(?>(?>X:){0,5}X)?|X:X::(?>(?>X:){0,4}X)?|X:X:X::(?>(?>X:){0,3}X)?|(?>X:){4}:(?>(?>X:){0,2}X)?|(?>X:){5}:(?>X:)?X?|(?>X:){6}:X?|(?>X:){7}(?>X|:)";
 		ipv6AddressRegex = ipv6AddressRegex.replaceAll("X", wordRegex);
-		//String ipv6ISATAPAddressRegex = wordRegex + "?:" + wordRegex + ':' + wordRegex + ':' + wordRegex + ":(0){1,4}:5[eE][fF][eE]:" + wordRegex + ':' + wordRegex + percentScopeIDRegex;
 		// case 0: :(?>(?>:X){1,3}:0{1,4}|:0{1,4}|):5EFE:X:X
 		// case 1: X:(?>:0{1,4}|:(?>X:){1,2}0{1,4}|):5EFE:X:X
 		// case 2: X:X:(?>:0{1,4}|:(?>X:)?0{1,4}|):5EFE:X:X
@@ -61,9 +60,9 @@ public class AddressIdentifier {
 		// case 5: (?>X:){4}0{1,4}:5EFE:(?>X:X|:X?|X::)
 		String ipv6ISATAPAddressRegex = ":(?>(?>:X){1,3}:0{1,4}|:0{1,4}|):5EFE:X:X|X:(?>:0{1,4}|:(?>X:){1,2}0{1,4}|):5EFE:X:X|X:X:(?>:0{1,4}|:(?>X:)?0{1,4}|):5EFE:X:X|X:X:X:(?>X:0{1,4}|:0{1,4}|X:|):5EFE:X:X|(?>X:){4}0{1,4}:5EFE:(?>X:X|:X?|X::)";
 		ipv6ISATAPAddressRegex = ipv6ISATAPAddressRegex.replaceAll("X", wordRegex);
-		ipv6Pattern = Pattern.compile(ipv6AddressRegex);
-		ipv6PatternWithPercentScopeID = Pattern.compile(ipv6AddressRegex + percentScopeIDRegex, Pattern.CASE_INSENSITIVE);
-		ipv6ISATAPPattern = Pattern.compile(ipv6ISATAPAddressRegex, Pattern.CASE_INSENSITIVE);
+		ipv6Pattern = Pattern.compile(ipv6AddressRegex, Pattern.CASE_INSENSITIVE);
+		ipv6PatternWithPercentScopeID = Pattern.compile("(?>" + ipv6AddressRegex + ")" + percentScopeIDRegex, Pattern.CASE_INSENSITIVE);
+		ipv6ISATAPPattern = Pattern.compile("(?>" + ipv6ISATAPAddressRegex + ")" + percentScopeIDRegex, Pattern.CASE_INSENSITIVE);
 	}
 	
 	public enum AddressType {

--- a/src/freenet/io/AddressIdentifier.java
+++ b/src/freenet/io/AddressIdentifier.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
  * <li>IPv4 unabridged (a.b.c.d)</li>
  * <li>IPv4 abridged (a.b.d or a.d)</li>
  * <li>IPv6 unabridged (a:b:c:d:e:f:g:h)</li>
+ * <li>IPv6 abridged (a::b:c:d:e)</li>
  * </ul>
  * 
  * @author David Roden &lt;droden@gmail.com&gt;
@@ -38,13 +39,31 @@ public class AddressIdentifier {
 		String ipv4AddressRegex = byteRegex + "\\.(?>" + byteRegex + "\\.)?(?>" + byteRegex + "\\.)?" + byteRegex;
 		ipv4Pattern = Pattern.compile(ipv4AddressRegex);
 		
-		String wordRegex = "(?>[0-9a-fA-F]{1,4})";
+		String wordRegex = "(?>[0-9a-f]{1,4})";
 		String percentScopeIDRegex = "(?>%[0-9]{1,3})?";
-		String ipv6AddressRegex = wordRegex + "?:" + wordRegex + ':' + wordRegex + ':' + wordRegex + ':' + wordRegex + ':' + wordRegex + ':' + wordRegex + ':' + wordRegex;
-		String ipv6ISATAPAddressRegex = wordRegex + "?:" + wordRegex + ':' + wordRegex + ':' + wordRegex + ":(0){1,4}:5(efe|EFE):" + wordRegex + ':' + wordRegex + percentScopeIDRegex;
+		/*
+		 * ::(?>(?>X:){0,6}X)?
+		 * X::(?>(?>X:){0,5}X)?
+		 * X:X::(?>(?>X:){0,4}X)?
+		 * X:X:X::(?>(?>X:){0,3}X)?
+		 * (?>X:){4}:(?>(?>X:){0,2}X)?
+		 * (?>X:){5}:(?>X:)?X?
+		 * (?>X:){6}:X?
+		 * (?>X:){7}(?>X|:)
+		 */
+		String ipv6AddressRegex = "::(?>(?>X:){0,6}X)?|X::(?>(?>X:){0,5}X)?|X:X::(?>(?>X:){0,4}X)?|X:X:X::(?>(?>X:){0,3}X)?|(?>X:){4}:(?>(?>X:){0,2}X)?|(?>X:){5}:(?>X:)?X?|(?>X:){6}:X?|(?>X:){7}(?>X|:)";
+		ipv6AddressRegex = ipv6AddressRegex.replaceAll("X", wordRegex);
+		//String ipv6ISATAPAddressRegex = wordRegex + "?:" + wordRegex + ':' + wordRegex + ':' + wordRegex + ":(0){1,4}:5[eE][fF][eE]:" + wordRegex + ':' + wordRegex + percentScopeIDRegex;
+		// case 0: :(?>(?>:X){1,3}:0{1,4}|:0{1,4}|):5EFE:X:X
+		// case 1: X:(?>:0{1,4}|:(?>X:){1,2}0{1,4}|):5EFE:X:X
+		// case 2: X:X:(?>:0{1,4}|:(?>X:)?0{1,4}|):5EFE:X:X
+		// case 3 and 4: X:X:X:(?>X:0{1,4}|:0{1,4}|X:|):5EFE:X:X
+		// case 5: (?>X:){4}0{1,4}:5EFE:(?>X:X|:X?|X::)
+		String ipv6ISATAPAddressRegex = ":(?>(?>:X){1,3}:0{1,4}|:0{1,4}|):5EFE:X:X|X:(?>:0{1,4}|:(?>X:){1,2}0{1,4}|):5EFE:X:X|X:X:(?>:0{1,4}|:(?>X:)?0{1,4}|):5EFE:X:X|X:X:X:(?>X:0{1,4}|:0{1,4}|X:|):5EFE:X:X|(?>X:){4}0{1,4}:5EFE:(?>X:X|:X?|X::)";
+		ipv6ISATAPAddressRegex = ipv6ISATAPAddressRegex.replaceAll("X", wordRegex);
 		ipv6Pattern = Pattern.compile(ipv6AddressRegex);
-		ipv6PatternWithPercentScopeID = Pattern.compile(ipv6AddressRegex + percentScopeIDRegex);
-		ipv6ISATAPPattern = Pattern.compile(ipv6ISATAPAddressRegex);
+		ipv6PatternWithPercentScopeID = Pattern.compile(ipv6AddressRegex + percentScopeIDRegex, Pattern.CASE_INSENSITIVE);
+		ipv6ISATAPPattern = Pattern.compile(ipv6ISATAPAddressRegex, Pattern.CASE_INSENSITIVE);
 	}
 	
 	public enum AddressType {

--- a/src/freenet/io/Inet4AddressMatcher.java
+++ b/src/freenet/io/Inet4AddressMatcher.java
@@ -49,7 +49,7 @@ public class Inet4AddressMatcher implements AddressMatcher {
 	 * @param cidrHostname
 	 *            The address range this matcher matches
 	 */
-	public Inet4AddressMatcher(String cidrHostname) {
+	public Inet4AddressMatcher(String cidrHostname) throws IllegalArgumentException {
 		int slashPosition = cidrHostname.indexOf('/');
 		if (slashPosition == -1) {
 			address = convertToBytes(cidrHostname);

--- a/src/freenet/io/Inet6AddressMatcher.java
+++ b/src/freenet/io/Inet6AddressMatcher.java
@@ -19,8 +19,6 @@ package freenet.io;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.util.Arrays;
-import java.util.StringTokenizer;
-
 import freenet.io.AddressIdentifier.AddressType;
 
 /**
@@ -40,7 +38,7 @@ public class Inet6AddressMatcher implements AddressMatcher {
 	private byte[] address;
 	private byte[] netmask;
 
-	public Inet6AddressMatcher(String pattern) {
+	public Inet6AddressMatcher(String pattern) throws IllegalArgumentException {
 		if (pattern.indexOf('/') != -1) {
 			address = convertToBytes(pattern.substring(0, pattern.indexOf('/')));
 			String netmaskString = pattern.substring(pattern.indexOf('/') + 1).trim();
@@ -66,18 +64,67 @@ public class Inet6AddressMatcher implements AddressMatcher {
 		}
 	}
 
-	private byte[] convertToBytes(String address) {
-		StringTokenizer addressTokens = new StringTokenizer(address, ":");
-		if (addressTokens.countTokens() != 8) {
+	private byte[] convertToBytes(String address) throws IllegalArgumentException {
+		String[] addressTokens = address.split(":");
+		int tokenPosition = 0;
+		byte[] addressBytes = new byte[16];
+		byte[] addressBytesEnd = new byte[16];
+		int count = 0;
+		int endCount = -1;
+		if(address.startsWith(":")) {
+			if(address.startsWith("::")) {
+				if(address == "::") {
+					return addressBytes;
+				}
+				tokenPosition+=2; // This is an empty token, could be mistaken as duplicate ::
+				endCount = 0;
+			} else {
+				throw new IllegalArgumentException(address + " is not an IPv6 address.");
+			}
+		}
+		while (tokenPosition < addressTokens.length) {
+			String token = addressTokens[tokenPosition];
+			tokenPosition++;
+			if(!token.isEmpty() ) {
+				int addressWord;
+				try {
+					addressWord = Integer.parseInt(token, 16);
+				} catch(NumberFormatException e) {
+					throw new IllegalArgumentException(address + " is not an IPv6 address.");
+				}
+				if(endCount == -1) {
+					if(count >= 8) {
+						throw new IllegalArgumentException(address + " is not an IPv6 address.");
+					}
+					addressBytes[count * 2] = (byte) ((addressWord >> 8) & 0xff);
+					addressBytes[count * 2 + 1] = (byte) (addressWord & 0xff);
+					count++;
+				} else {
+					if(count + endCount >= 7) {
+						throw new IllegalArgumentException(address + " is not an IPv6 address.");
+					}
+					addressBytesEnd[endCount * 2] = (byte) ((addressWord >> 8) & 0xff);
+					addressBytesEnd[endCount * 2 + 1] = (byte) (addressWord & 0xff);
+					endCount++;
+				}
+			} else if(endCount == -1) {
+				endCount = 0;
+			} else {
+				throw new IllegalArgumentException(address + " is not an IPv6 address.");
+			}
+		}
+		if(endCount != -1 && count + endCount >= 8) { // Maybe not needed
 			throw new IllegalArgumentException(address + " is not an IPv6 address.");
 		}
-		byte[] addressBytes = new byte[16];
-		int count = 0;
-		while (addressTokens.hasMoreTokens()) {
-			int addressWord = Integer.parseInt(addressTokens.nextToken(), 16);
-			addressBytes[count * 2] = (byte) ((addressWord >> 8) & 0xff);
-			addressBytes[count * 2 + 1] = (byte) (addressWord & 0xff);
-			count++;
+		if(endCount != -1) {
+			for(int index = count; index < 8 - endCount; index++) {
+				addressBytes[index * 2] = 0;
+				addressBytes[index * 2 + 1] = 0;
+			}
+			for(int index = 0; index < endCount; index++) {
+				addressBytes[(8 - endCount + index) * 2] = addressBytesEnd[index * 2];
+				addressBytes[(8 - endCount + index) * 2 + 1] = addressBytesEnd[index * 2 + 1];
+			}
 		}
 		return addressBytes;
 	}
@@ -94,7 +141,7 @@ public class Inet6AddressMatcher implements AddressMatcher {
 		return true;
 	}
 
-	public static boolean matches(String pattern, InetAddress address) {
+	public static boolean matches(String pattern, InetAddress address) throws IllegalArgumentException {
 		return new Inet6AddressMatcher(pattern).matches(address);
 	}
 

--- a/src/freenet/node/PeerNodeStatus.java
+++ b/src/freenet/node/PeerNodeStatus.java
@@ -347,6 +347,17 @@ public class PeerNodeStatus {
 	public int getPeerPort() {
 		return peerPort;
 	}
+	
+	/**
+	 * @return the string representation of peerAddress and peerPort
+	 */
+	public String getPeerAddressAndPort() {
+		if(peerAddressBytes != null && peerAddressBytes.length == 16) { // IPv6 address have [] around
+			return '[' + peerAddress + "]:" + peerPort;
+		} else {
+			return peerAddress + ':' + peerPort;
+		}
+	}
 
 	/**
 	 * @return the routingBackoffLength
@@ -420,7 +431,7 @@ public class PeerNodeStatus {
 
 	@Override
 	public String toString() {
-		return statusName + ' ' + peerAddress + ':' + peerPort + ' ' + location + ' ' + version + " RT backoff: " + routingBackoffLengthRT + " (" + (Math.max(routingBackedOffUntilRT - System.currentTimeMillis(), 0)) + " ) bulk backoff: " + routingBackoffLengthBulk + " (" + (Math.max(routingBackedOffUntilBulk - System.currentTimeMillis(), 0)) + ')';
+		return statusName + ' ' + getPeerAddressAndPort() + ' ' + location + ' ' + version + " RT backoff: " + routingBackoffLengthRT + " (" + (Math.max(routingBackedOffUntilRT - System.currentTimeMillis(), 0)) + " ) bulk backoff: " + routingBackoffLengthBulk + " (" + (Math.max(routingBackedOffUntilBulk - System.currentTimeMillis(), 0)) + ')';
 	}
 
 	@Override

--- a/test/freenet/io/AddressIdentifierTest.java
+++ b/test/freenet/io/AddressIdentifierTest.java
@@ -49,9 +49,53 @@ public class AddressIdentifierTest {
 		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("0:0:0:0:0:0:0:1"));
 		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("fe80:0:0:0:203:dff:fe22:420f"));
 
+		/* test real abridged IPv6 addresses */
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5:6:7"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5:6"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5:6:7"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5:6"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5:6:7"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5:6"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5:6:7"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5:6"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5:6:7"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5:6"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::6:7"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::6"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6::7"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6:7::"));
+
 		/* test fake IPv6 addresses */
 		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1:2:3:4:5:6:7:8:9"));
 		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("12345:6:7:8:9"));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType(":1:2:3:4:5:6:7:8"));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3:4:5:6:7:8:9"));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("::1::2:3"));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3::"));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3::4"));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("12:34:56:78:9a:bc:de:fg"));
 	}
 	
 	@Test
@@ -59,6 +103,30 @@ public class AddressIdentifierTest {
 		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("fe80:0:0:0:203:dff:fe22:420f"));
 		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("fe80:0:5efe:0:203:dff:fe22:420f"));
 		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("2001:1:2:3:0:5efe:c801:20a"));
+		// Some abridged addresses
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("::1:2:3:0:5efe:6:7"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("::1:2:0:5efE:5:6"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("::1:0:5eFe:4:5"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("::0:5eFE:3:4"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("::5Efe:2:3"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1::2:3:0:5EfE:6:7"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1::2:0:5EFe:5:6"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1::0:5EFE:4:5"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1::5efe:3:4"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2::3:0:5efe:6:7"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2::0:5efe:5:6"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2::5efe:4:5"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2:3::0:5efe:6:7"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2:3::5efe:5:6"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2:3:4::5efe:6:7"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2:3:4:0:5efe::7"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2:3:4:0:5efe::"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("1:2:3:4:0:5efe:7::"));
+		// Some invalid addresses
+		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("2001:1:2:3:5efe:c801:20a"));
+		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("2001:1:2:3:4:5:5efe:c801:20a"));
+		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("2001::1::5efe:c801:20a"));
+		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("1:2:3:0:5efe::"));
 	}
 
 }

--- a/test/freenet/io/AddressIdentifierTest.java
+++ b/test/freenet/io/AddressIdentifierTest.java
@@ -46,56 +46,65 @@ public class AddressIdentifierTest {
 		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("127.0.0.0.1"));
 
 		/* test real unabridged IPv6 addresses */
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("0:0:0:0:0:0:0:1"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("fe80:0:0:0:203:dff:fe22:420f"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("0:0:0:0:0:0:0:1", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("fe80:0:0:0:203:dff:fe22:420f", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("FE80:0:0:0:203:DFF:FE22:420F", false));
 
 		/* test real abridged IPv6 addresses */
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5:6:7"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5:6"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5:6:7"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5:6"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5:6:7"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5:6"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5:6:7"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5:6"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5:6:7"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5:6"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::6:7"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::6"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6::7"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6::"));
-		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6:7::"));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5:6:7", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5:6", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4:5", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3:4", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2:3", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1:2", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::1", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5:6:7", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5:6", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4:5", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3:4", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2:3", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::2", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5:6:7", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5:6", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4:5", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3:4", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::3", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5:6:7", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5:6", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4:5", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::4", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5:6:7", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5:6", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::5", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::6:7", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::6", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6::7", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("1:2:3:4:5:6:7::", false));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("fe80::203:dff:fe22:420f%10", true));
+		assertEquals(AddressType.IPv6, AddressIdentifier.getAddressType("FE80::203:DFF:FE22:420F%10", true));
 
 		/* test fake IPv6 addresses */
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1:2:3:4:5:6:7:8:9"));
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("12345:6:7:8:9"));
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType(":1:2:3:4:5:6:7:8"));
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3:4:5:6:7:8:9"));
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("::1::2:3"));
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3::"));
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3::4"));
-		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("12:34:56:78:9a:bc:de:fg"));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1:2:3:4:5:6:7:8:9", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("12345:6:7:8:9", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1:2:3:4:5:6:7:8%10", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType(":1:2:3:4:5:6:7:8", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType(":1:2:3:4:5:6:7", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1:2:3:4:5:6:7:", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType(":1:2::3:4", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1:2::3:4:", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3:4:5:6:7:8:9", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("::1::2:3", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3::", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("1::2:3::4", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("12:34:56:78:9a:bc:de:fg", false));
+		assertEquals(AddressType.OTHER, AddressIdentifier.getAddressType("fe80::203:dff:fe22:420f%a", true));
 	}
 	
 	@Test
@@ -103,6 +112,7 @@ public class AddressIdentifierTest {
 		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("fe80:0:0:0:203:dff:fe22:420f"));
 		assertFalse(AddressIdentifier.isAnISATAPIPv6Address("fe80:0:5efe:0:203:dff:fe22:420f"));
 		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("2001:1:2:3:0:5efe:c801:20a"));
+		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("2001:1:2:3:0:5efe:c801:20a%10"));
 		// Some abridged addresses
 		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("::1:2:3:0:5efe:6:7"));
 		assertTrue(AddressIdentifier.isAnISATAPIPv6Address("::1:2:0:5efE:5:6"));

--- a/test/freenet/io/Inet6AddressMatcherTest.java
+++ b/test/freenet/io/Inet6AddressMatcherTest.java
@@ -37,31 +37,56 @@ public class Inet6AddressMatcherTest {
 	@Test
 	public void test() throws Exception {
 		Inet6AddressMatcher matcher = new Inet6AddressMatcher("0:0:0:0:0:0:0:0/0");
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
 
 		matcher = new Inet6AddressMatcher("fe80:0:0:0:203:dff:fe22:420f/64");
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:0203:0dff:fe22:420f")));
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:0204:0dff:fe22:420f")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("fe81:0:0:0:0203:0dff:fe22:420f")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("0:0:0:0:0:0:0:1")));
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:0:0:0:1")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:0203:0dff:fe22:420f")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:0204:0dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("fe81:0:0:0:0203:0dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("0:0:0:0:0:0:0:1")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:0:0:0:1")));
 
 		matcher = new Inet6AddressMatcher("fe80:0:0:0:203:dff:fe22:420f/ffff:ffff:ffff:ffff:0:0:0:0");
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:0203:0dff:fe22:420f")));
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:0204:0dff:fe22:420f")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("fe81:0:0:0:0203:0dff:fe22:420f")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("0:0:0:0:0:0:0:1")));
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:0:0:0:1")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:0203:0dff:fe22:420f")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:0204:0dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("fe81:0:0:0:0203:0dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("0:0:0:0:0:0:0:1")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:0:0:0:1")));
 
 		matcher = new Inet6AddressMatcher("fe80:0:0:0:203:dff:fe22:420f/128");
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
-		assertEquals(true, matcher.matches(InetAddress.getByName("fe80:0:0:0:0203:0dff:fe22:420f")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("fe80:0:0:0:0204:0dff:fe22:420f")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("fe81:0:0:0:0203:0dff:fe22:420f")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("0:0:0:0:0:0:0:1")));
-		assertEquals(false, matcher.matches(InetAddress.getByName("fe80:0:0:0:0:0:0:1")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:203:dff:fe22:420f")));
+		assertTrue(matcher.matches(InetAddress.getByName("fe80:0:0:0:0203:0dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("fe80:0:0:0:0204:0dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("fe81:0:0:0:0203:0dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("0:0:0:0:0:0:0:1")));
+		assertFalse(matcher.matches(InetAddress.getByName("fe80:0:0:0:0:0:0:1")));
+
+		matcher = new Inet6AddressMatcher("::/0");
+		assertTrue(matcher.matches(InetAddress.getByName("fe80::203:dff:fe22:420f")));
+
+		matcher = new Inet6AddressMatcher("fe80::/64");
+		assertTrue(matcher.matches(InetAddress.getByName("fe80::203:dff:fe22:420f")));
+		assertFalse(matcher.matches(InetAddress.getByName("fe80:203::dff:fe22:420f")));
+		
+		matcher = new Inet6AddressMatcher("1::fe80/64");
+		assertFalse(matcher.matches(InetAddress.getByName("::")));
+		assertFalse(matcher.matches(InetAddress.getByName("1::2:3:4:5:6:7")));
+		assertFalse(matcher.matches(InetAddress.getByName("1::2:3:4:5:6")));
+		assertTrue(matcher.matches(InetAddress.getByName("1::2:3:4:5")));
+		assertTrue(matcher.matches(InetAddress.getByName("1::2:3:4")));
+		assertTrue(matcher.matches(InetAddress.getByName("1::2:3")));
+		assertTrue(matcher.matches(InetAddress.getByName("1::2")));
+		assertTrue(matcher.matches(InetAddress.getByName("1::")));
+		assertFalse(matcher.matches(InetAddress.getByName("1:2::3:4:5:6:7")));
+
+		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("192.168.1.1"));
+		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("1::2::3"));
+		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("::1::2"));
+		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("::1:2:3:4:5:6:7:8"));
+		assertTrue(Inet6AddressMatcher.matches("::1", InetAddress.getByName("::1")));
+		assertTrue(Inet6AddressMatcher.matches("fe80::", InetAddress.getByName("fe80::")));
 	}
 
 }

--- a/test/freenet/io/Inet6AddressMatcherTest.java
+++ b/test/freenet/io/Inet6AddressMatcherTest.java
@@ -85,6 +85,9 @@ public class Inet6AddressMatcherTest {
 		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("1::2::3"));
 		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("::1::2"));
 		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("::1:2:3:4:5:6:7:8"));
+		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher(":1:2:3:4:5:6:7"));
+		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("1:2:3:4:5:6:7:"));
+		assertThrows(IllegalArgumentException.class, () -> new Inet6AddressMatcher("123456::789abcde"));
 		assertTrue(Inet6AddressMatcher.matches("::1", InetAddress.getByName("::1")));
 		assertTrue(Inet6AddressMatcher.matches("fe80::", InetAddress.getByName("fe80::")));
 	}


### PR DESCRIPTION
Compacted IPV6 address like `::1` and `2001:db8::1234` can now be used. Connections page show IPV6 address like `[address]:port`.