### PR TITLE
🐛 Run Git from the project directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ def gitrev
 task buildInfo {
     try {
         def cmd = "git describe --always --abbrev=4 --dirty"
-        def proc = cmd.execute()
+        def proc = cmd.execute([], project.rootDir)
         gitrev = proc.text.trim()
     } catch (IOException ignored) {
         gitrev = "@unknown@"


### PR DESCRIPTION
When using the gradle-daemon to build a project, the working directory the script is executed in is the local directory of the gradle-daemon running the script. By explicitely specifying the directory to execute Git in, this will now work with and without gradle-daemon.