### PR TITLE
Build JAR File Correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,35 +71,35 @@ tasks.withType(Javadoc) {
     options.encoding = "UTF-8"
 }
 
-task compileVersion (type: JavaCompile) {
-    copy {
-        from sourceSets.main.java.srcDirs
-        into version_buildir
-        include "${version_src}"
+task generateVersionSource(type: Copy) {
+    dependsOn buildInfo
+    from(sourceSets.main.java.srcDirs) {
+        include version_src
         filter {
-            String line -> line.replaceAll("@custom@","${gitrev}")
+            String line -> line.replaceAll('@custom@', gitrev)
         }
     }
+    into version_buildir
+}
+
+task compileVersion (type: JavaCompile) {
+    dependsOn generateVersionSource, compileJava
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
     source = version_buildir
-    include "${version_src}"
+    include version_src
     classpath = files(sourceSets.main.compileClasspath, sourceSets.main.output.classesDirs)
     destinationDirectory.set(layout.buildDirectory.dir("java/version/").get())
 }
 
-compileVersion.dependsOn buildInfo
-compileVersion.dependsOn compileJava
-//processResources.dependsOn compileVersion
-
-task jar (type: Jar, overwrite: true) {
-    from (compileVersion) {
-        include 'freenet/node/Version**class'
-    }
-    from ("${buildDir}/classes/java/main/") {
+task buildJar(type: Jar) {
+    dependsOn compileVersion, processResources
+    from(processResources)
+    from(compileJava.destinationDirectory) {
         exclude 'freenet/node/Version.class'
         exclude 'freenet/node/Version$1.class'
     }
+    from(compileVersion.destinationDirectory)
     preserveFileTimestamps = true
     reproducibleFileOrder = true
     duplicatesStrategy = "warn"
@@ -120,7 +120,9 @@ task jar (type: Jar, overwrite: true) {
                    ], "common")
     }
 }
-jar.dependsOn processResources
+
+jar.enabled = false
+jar.dependsOn buildJar
 
 def jars = []
 gradle.addListener(new TaskExecutionListener() {

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ task buildJar(type: Jar) {
     from(compileVersion.destinationDirectory)
     preserveFileTimestamps = true
     reproducibleFileOrder = true
-    duplicatesStrategy = "warn"
+    duplicatesStrategy = DuplicatesStrategy.FAIL
     archivesBaseName = "freenet"
     manifest {
         attributes("Permissions": "all-permissions")

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ jar.dependsOn buildJar
 def jars = []
 gradle.addListener(new TaskExecutionListener() {
 void afterExecute(Task task, TaskState state) {
-    if(task in AbstractArchiveTask) {
+    if(task in AbstractArchiveTask && task.enabled) {
         jars << task.outputs.files.singleFile
     }
 }


### PR DESCRIPTION
The default `jar` task a pre-defined input with `compileJava`’s output, which includes the original, non-replaced `Version.class`. I have not found a way to disable the pre-defined input, or modify it in a way that would still allow me to add a `Version.class` from a different task’s output.

What’s happening now is that there is a new task, `buildJar`. It is an almost verbatim copy of what the `jar` task previously contained with an added input (`compileVersion`’s output). This `Jar` task does not have a pre-defined input and as such only includes what is being specified.

The original `jar` task has been disabled and has been given the `buildJar` task as dependency. That way the `jar` task can still be run from the command line where it doesn’t do anything (because it’s disabled) but it will require the `buildJar` task to be run which then does the actual work.