### PR TITLE
Remove pooling and other special cases for SHA-256 digests

### DIFF
--- a/src/freenet/client/Metadata.java
+++ b/src/freenet/client/Metadata.java
@@ -737,9 +737,7 @@ public class Metadata implements Cloneable, Serializable {
 		MessageDigest md = SHA256.getMessageDigest();
 		md.update(hash);
 		md.update(SPLITKEY);
-		byte[] buf = md.digest();
-		SHA256.returnMessageDigest(md);
-		return buf;
+		return md.digest();
 	}
 
 	public static byte[] getCrossSegmentSeed(HashResult[] hashes, byte[] hashThisLayerOnly) {
@@ -758,9 +756,7 @@ public class Metadata implements Cloneable, Serializable {
 		MessageDigest md = SHA256.getMessageDigest();
 		md.update(hash);
 		md.update(CROSS_SEGMENT_SEED);
-		byte[] buf = md.digest();
-		SHA256.returnMessageDigest(md);
-		return buf;
+		return md.digest();
 	}
 
 	/**

--- a/src/freenet/client/async/KeyListenerTracker.java
+++ b/src/freenet/client/async/KeyListenerTracker.java
@@ -6,13 +6,13 @@ package freenet.client.async;
 import static java.lang.String.format;
 
 import java.security.MessageDigest;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.List;
 
 import freenet.crypt.RandomSource;
 import freenet.crypt.SHA256;
@@ -20,7 +20,6 @@ import freenet.keys.Key;
 import freenet.keys.KeyBlock;
 import freenet.keys.NodeSSK;
 import freenet.node.SendableGet;
-import freenet.node.SendableRequest;
 import freenet.support.ByteArrayWrapper;
 import freenet.support.LogThresholdCallback;
 import freenet.support.Logger;
@@ -469,9 +468,7 @@ class KeyListenerTracker implements KeySalter {
 		MessageDigest md = SHA256.getMessageDigest();
 		md.update(key);
 		md.update(globalSalt);
-		byte[] ret = md.digest();
-		SHA256.returnMessageDigest(md);
-		return ret;
+		return md.digest();
 	}
 	
 	protected void hintGlobalSalt(byte[] globalSalt2) {

--- a/src/freenet/client/async/SplitFileFetcherKeyListener.java
+++ b/src/freenet/client/async/SplitFileFetcherKeyListener.java
@@ -204,9 +204,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
         MessageDigest md = SHA256.getMessageDigest();
         md.update(key.getRoutingKey());
         md.update(localSalt);
-        byte[] ret = md.digest();
-        SHA256.returnMessageDigest(md);
-        return ret;
+        return md.digest();
     }
     
     /** The segment bloom filters should only need to be written ONCE, and can all be written at 

--- a/src/freenet/clients/fcp/ClientPut.java
+++ b/src/freenet/clients/fcp/ClientPut.java
@@ -236,7 +236,6 @@ public class ClientPut extends ClientPutBase {
 				is = data.getInputStream();
 				SHA256.hash(is, md);
 			} catch (IOException e) {
-				SHA256.returnMessageDigest(md);
 				Logger.error(this, "Got IOE: " + e.getMessage(), e);
 				throw new MessageInvalidException(ProtocolErrorMessage.COULD_NOT_READ_FILE,
 						"Unable to access file: " + e, identifier, global);
@@ -244,7 +243,6 @@ public class ClientPut extends ClientPutBase {
 				Closer.close(is);
 			}
 			foundHash = md.digest();
-			SHA256.returnMessageDigest(md);
 
 			if(logMINOR) Logger.minor(this, "FileHash result : we found " + Base64.encode(foundHash) + " and were given " + Base64.encode(saltedHash) + '.');
 

--- a/src/freenet/crypt/HashType.java
+++ b/src/freenet/crypt/HashType.java
@@ -6,9 +6,8 @@ package freenet.crypt;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.bitpedia.util.TigerTree;
-
 import freenet.support.Logger;
+import org.bitpedia.util.TigerTree;
 
 public enum HashType {
 	// warning: keep in sync with Util.mdProviders!
@@ -46,7 +45,6 @@ public enum HashType {
 				return new TigerTree();
 		}
 		if(name().equals("SHA256")) {
-			// Use the pool
 			return freenet.crypt.SHA256.getMessageDigest();
 		} else {
 			try {
@@ -58,9 +56,10 @@ public enum HashType {
 		}
 	}
 
+	/**
+	 * @deprecated message digests are no longer pooled, there is no need to recycle them
+	 */
+	@Deprecated
 	public final void recycle(MessageDigest md) {
-		if(this.equals(SHA256)) {
-			freenet.crypt.SHA256.returnMessageDigest(md);
-		} // Else no pooling.
 	}
 }

--- a/src/freenet/crypt/HashType.java
+++ b/src/freenet/crypt/HashType.java
@@ -5,14 +5,14 @@ package freenet.crypt;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 
-import freenet.support.Logger;
 import org.bitpedia.util.TigerTree;
 
 public enum HashType {
 	// warning: keep in sync with Util.mdProviders!
-	SHA1(1, 20),
-	MD5(2, 16),
+	SHA1(1, "SHA1", 20),
+	MD5(2, "MD5", 16),
 	SHA256(4, "SHA-256", 32),
 	SHA384(8, "SHA-384", 48),
 	SHA512(16, "SHA-512", 64),
@@ -25,34 +25,26 @@ public enum HashType {
 	public final String javaName;
 	public final int hashLength;
 
-	private HashType(int bitmask, int hashLength) {
-		this.bitmask = bitmask;
-		this.javaName = super.name();
-		this.hashLength = hashLength;
-	}
+	private final Provider provider;
 
-	private HashType(int bitmask, String name, int hashLength) {
+	HashType(int bitmask, String name, int hashLength) {
 		this.bitmask = bitmask;
 		this.javaName = name;
 		this.hashLength = hashLength;
+		this.provider = javaName != null ? Util.mdProviders.get(javaName) : null;
 	}
 
 	public final MessageDigest get() {
-		if(javaName == null) {
-			if(this.name().equals("ED2K"))
-				return new Ed2MessageDigest();
-			if(this.name().equals("TTH"))
-				return new TigerTree();
+		if (this == ED2K) {
+			return new Ed2MessageDigest();
 		}
-		if(name().equals("SHA256")) {
-			return freenet.crypt.SHA256.getMessageDigest();
-		} else {
-			try {
-				return MessageDigest.getInstance(javaName, Util.mdProviders.get(javaName));
-			} catch (NoSuchAlgorithmException e) {
-				Logger.error(HashType.class, "Internal error; please report:", e);
-			}
-			return null;
+		if (this == TTH) {
+			return new TigerTree();
+		}
+		try {
+			return MessageDigest.getInstance(javaName, provider);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("Unsupported digest algorithm " + javaName, e);
 		}
 	}
 

--- a/src/freenet/crypt/SHA256.java
+++ b/src/freenet/crypt/SHA256.java
@@ -39,9 +39,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 
-import freenet.node.NodeInitException;
 import freenet.support.io.Closer;
-import org.tanukisoftware.wrapper.WrapperManager;
 
 /**
  * @author  Jeroen C. van Gelderen (gelderen@cryptix.org)
@@ -75,14 +73,12 @@ public class SHA256 {
 
 	/**
 	 * Create a new SHA-256 MessageDigest
-	 * Either succeed or stop the node.
 	 */
 	public static MessageDigest getMessageDigest() {
 		try {
 			return MessageDigest.getInstance("SHA-256", mdProvider);
 		} catch (NoSuchAlgorithmException e) {
-			WrapperManager.stop(NodeInitException.EXIT_CRAPPY_JVM);
-			throw new RuntimeException(e);
+			throw new IllegalStateException("SHA-256 not supported", e);
 		}
 	}
 

--- a/src/freenet/crypt/SHA256.java
+++ b/src/freenet/crypt/SHA256.java
@@ -35,19 +35,13 @@ package freenet.crypt;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.SoftReference;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.tanukisoftware.wrapper.WrapperManager;
-
-import freenet.node.Node;
 import freenet.node.NodeInitException;
-import freenet.support.Logger;
 import freenet.support.io.Closer;
+import org.tanukisoftware.wrapper.WrapperManager;
 
 /**
  * @author  Jeroen C. van Gelderen (gelderen@cryptix.org)
@@ -55,7 +49,8 @@ import freenet.support.io.Closer;
 public class SHA256 {
 	/** Size (in bytes) of this hash */
 	private static final int HASH_SIZE = 32;
-	private static final Queue<SoftReference<MessageDigest>> digests = new ConcurrentLinkedQueue<>();
+
+	private static final Provider mdProvider = Util.mdProviders.get("SHA-256");
 
 	/**
 	 * It won't reset the Message Digest for you!
@@ -78,54 +73,30 @@ public class SHA256 {
 		}
 	}
 
-	private static final Provider mdProvider = Util.mdProviders.get("SHA-256");
-
 	/**
 	 * Create a new SHA-256 MessageDigest
 	 * Either succeed or stop the node.
 	 */
 	public static MessageDigest getMessageDigest() {
 		try {
-			SoftReference<MessageDigest> item = null;
-			while (((item = digests.poll()) != null)) {
-				MessageDigest md = item.get();
-				if (md != null) {
-					return md;
-				}
-			}
 			return MessageDigest.getInstance("SHA-256", mdProvider);
-		} catch(NoSuchAlgorithmException e2) {
-			//TODO: maybe we should point to a HOWTO for freejvms
-			Logger.error(Node.class, "Check your JVM settings especially the JCE!" + e2);
-			System.err.println("Check your JVM settings especially the JCE!" + e2);
-			e2.printStackTrace();
+		} catch (NoSuchAlgorithmException e) {
+			WrapperManager.stop(NodeInitException.EXIT_CRAPPY_JVM);
+			throw new RuntimeException(e);
 		}
-		WrapperManager.stop(NodeInitException.EXIT_CRAPPY_JVM);
-		throw new RuntimeException();
 	}
 
 	/**
-	 * Return a MessageDigest to the pool.
-	 * Must be SHA-256 !
+	 * No-op function retained for backwards compatibility.
+	 *
+	 * @deprecated message digests are no longer pooled, there is no need to return them
 	 */
+	@Deprecated
 	public static void returnMessageDigest(MessageDigest md256) {
-		if(md256 == null)
-			return;
-		String algo = md256.getAlgorithm();
-		if(!(algo.equals("SHA-256") || algo.equals("SHA256")))
-			throw new IllegalArgumentException("Should be SHA-256 but is " + algo);
-		md256.reset();
-		digests.add(new SoftReference<>(md256));
 	}
 
 	public static byte[] digest(byte[] data) {
-		MessageDigest md = null;
-		try {
-			md = getMessageDigest();
-			return md.digest(data);
-		} finally {
-			returnMessageDigest(md);
-		}
+		return getMessageDigest().digest(data);
 	}
 
 	public static int getDigestLength() {

--- a/src/freenet/crypt/SHA256.java
+++ b/src/freenet/crypt/SHA256.java
@@ -36,8 +36,6 @@ package freenet.crypt;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
 
 import freenet.support.io.Closer;
 
@@ -45,10 +43,6 @@ import freenet.support.io.Closer;
  * @author  Jeroen C. van Gelderen (gelderen@cryptix.org)
  */
 public class SHA256 {
-	/** Size (in bytes) of this hash */
-	private static final int HASH_SIZE = 32;
-
-	private static final Provider mdProvider = Util.mdProviders.get("SHA-256");
 
 	/**
 	 * It won't reset the Message Digest for you!
@@ -75,11 +69,7 @@ public class SHA256 {
 	 * Create a new SHA-256 MessageDigest
 	 */
 	public static MessageDigest getMessageDigest() {
-		try {
-			return MessageDigest.getInstance("SHA-256", mdProvider);
-		} catch (NoSuchAlgorithmException e) {
-			throw new IllegalStateException("SHA-256 not supported", e);
-		}
+		return HashType.SHA256.get();
 	}
 
 	/**
@@ -96,6 +86,6 @@ public class SHA256 {
 	}
 
 	public static int getDigestLength() {
-		return HASH_SIZE;
+		return HashType.SHA256.hashLength;
 	}
 }

--- a/src/freenet/keys/CHKBlock.java
+++ b/src/freenet/keys/CHKBlock.java
@@ -81,7 +81,6 @@ public class CHKBlock implements KeyBlock {
         md.update(headers);
         md.update(data);
         byte[] hash = md.digest();
-        SHA256.returnMessageDigest(md);
         if(key == null) {
         	chk = new NodeCHK(hash, cryptoAlgorithm);
         } else {

--- a/src/freenet/keys/ClientCHKBlock.java
+++ b/src/freenet/keys/ClientCHKBlock.java
@@ -9,12 +9,6 @@ import java.security.MessageDigest;
 import java.security.Provider;
 import java.util.Arrays;
 
-import javax.crypto.Cipher;
-import javax.crypto.Mac;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
-
 import freenet.crypt.BlockCipher;
 import freenet.crypt.CTRBlockCipher;
 import freenet.crypt.JceLoader;
@@ -33,6 +27,11 @@ import freenet.support.io.ArrayBucket;
 import freenet.support.io.ArrayBucketFactory;
 import freenet.support.io.BucketTools;
 import freenet.support.math.MersenneTwister;
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * @author amphibian
@@ -142,7 +141,6 @@ public class ClientCHKBlock implements ClientKeyBlock {
         byte[] dkey = key.cryptoKey;
         // Check: IV == hash of decryption key
         byte[] predIV = md256.digest(dkey);
-        SHA256.returnMessageDigest(md256); md256 = null;
         // Extract the IV
         byte[] iv = Arrays.copyOf(hbuf, 32);
         if(!Arrays.equals(iv, predIV))
@@ -496,9 +494,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
         // Now calculate the final hash
         md256.update(header);
         byte[] finalHash = md256.digest(cdata);
-        
-        SHA256.returnMessageDigest(md256);
-        
+
         // Now convert it into a ClientCHK
         ClientCHK finalKey = new ClientCHK(finalHash, encKey, asMetadata, cryptoAlgorithm, compressionAlgorithm);
         
@@ -570,9 +566,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
         // Now calculate the final hash
         md256.update(header);
         byte[] finalHash = md256.digest(cdata);
-        
-        SHA256.returnMessageDigest(md256);
-        
+
         // Now convert it into a ClientCHK
         ClientCHK finalKey = new ClientCHK(finalHash, encKey, asMetadata, cryptoAlgorithm, compressionAlgorithm);
         
@@ -631,9 +625,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
         // Now calculate the final hash
         md256.update(header);
         byte[] finalHash = md256.digest(data);
-        
-        SHA256.returnMessageDigest(md256);
-        
+
         // Now convert it into a ClientCHK
         key = new ClientCHK(finalHash, encKey, asMetadata, cryptoAlgorithm, compressionAlgorithm);
         

--- a/src/freenet/keys/ClientKSK.java
+++ b/src/freenet/keys/ClientKSK.java
@@ -5,16 +5,16 @@ package freenet.keys;
 
 /** A KSK. We know the private key from the keyword, so this can be both 
  * requested and inserted. */
+
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-
-import freenet.support.math.MersenneTwister;
 
 import freenet.crypt.DSAPrivateKey;
 import freenet.crypt.DSAPublicKey;
 import freenet.crypt.Global;
 import freenet.crypt.SHA256;
+import freenet.support.math.MersenneTwister;
 
 public class ClientKSK extends InsertableClientSSK {
 
@@ -44,19 +44,15 @@ public class ClientKSK extends InsertableClientSSK {
 	
 	public static ClientKSK create(String keyword) {
 		MessageDigest md256 = SHA256.getMessageDigest();
+		byte[] keywordHash = md256.digest(keyword.getBytes(StandardCharsets.UTF_8));
+		MersenneTwister mt = new MersenneTwister(keywordHash);
+		DSAPrivateKey privKey = new DSAPrivateKey(Global.DSAgroupBigA, mt);
+		DSAPublicKey pubKey = new DSAPublicKey(Global.DSAgroupBigA, privKey);
+		byte[] pubKeyHash = md256.digest(pubKey.asBytes());
 		try {
-			byte[] keywordHash = md256.digest(keyword.getBytes(StandardCharsets.UTF_8));
-			MersenneTwister mt = new MersenneTwister(keywordHash);
-			DSAPrivateKey privKey = new DSAPrivateKey(Global.DSAgroupBigA, mt);
-			DSAPublicKey pubKey = new DSAPublicKey(Global.DSAgroupBigA, privKey);
-			byte[] pubKeyHash = md256.digest(pubKey.asBytes());
-			try {
-				return new ClientKSK(keyword, pubKeyHash, pubKey, privKey, keywordHash);
-			} catch (MalformedURLException e) {
-				throw new Error(e);
-			}
-		} finally {
-			SHA256.returnMessageDigest(md256);
+			return new ClientKSK(keyword, pubKeyHash, pubKey, privKey, keywordHash);
+		} catch (MalformedURLException e) {
+			throw new Error(e);
 		}
 	}
 	

--- a/src/freenet/keys/ClientSSK.java
+++ b/src/freenet/keys/ClientSSK.java
@@ -74,27 +74,23 @@ public class ClientSSK extends ClientKey {
 		if(cryptoKey.length != CRYPTO_KEY_LENGTH)
 			throw new MalformedURLException("Decryption key wrong length: "+cryptoKey.length+" should be "+CRYPTO_KEY_LENGTH);
 		MessageDigest md = SHA256.getMessageDigest();
+		if (pubKey != null) {
+			byte[] pubKeyAsBytes = pubKey.asBytes();
+			md.update(pubKeyAsBytes);
+			byte[] otherPubKeyHash = md.digest();
+			if (!Arrays.equals(otherPubKeyHash, pubKeyHash))
+				throw new IllegalArgumentException();
+		}
+		this.cryptoKey = cryptoKey;
+		md.update(docName.getBytes(StandardCharsets.UTF_8));
+		byte[] buf = md.digest();
 		try {
-			if (pubKey != null) {
-				byte[] pubKeyAsBytes = pubKey.asBytes();
-				md.update(pubKeyAsBytes);
-				byte[] otherPubKeyHash = md.digest();
-				if (!Arrays.equals(otherPubKeyHash, pubKeyHash))
-					throw new IllegalArgumentException();
-			}
-			this.cryptoKey = cryptoKey;
-			md.update(docName.getBytes(StandardCharsets.UTF_8));
-			byte[] buf = md.digest();
-			try {
-				Rijndael aes = new Rijndael(256, 256);
-				aes.initialize(cryptoKey);
-				aes.encipher(buf, buf);
-				ehDocname = buf;
-			} catch (UnsupportedCipherException e) {
-				throw new Error(e);
-			}
-		} finally {
-			SHA256.returnMessageDigest(md);
+			Rijndael aes = new Rijndael(256, 256);
+			aes.initialize(cryptoKey);
+			aes.encipher(buf, buf);
+			ehDocname = buf;
+		} catch (UnsupportedCipherException e) {
+			throw new Error(e);
 		}
 		if(ehDocname == null)
 			throw new NullPointerException();

--- a/src/freenet/keys/Key.java
+++ b/src/freenet/keys/Key.java
@@ -134,7 +134,6 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
         md.update((byte)(TYPE >> 8));
         md.update((byte)TYPE);
         byte[] digest = md.digest();
-        SHA256.returnMessageDigest(md); md = null;
 			cachedNormalizedDouble = Util.keyDigestAsNormalizedDouble(digest);
 			return cachedNormalizedDouble;
     }

--- a/src/freenet/keys/NodeSSK.java
+++ b/src/freenet/keys/NodeSSK.java
@@ -107,9 +107,7 @@ public class NodeSSK extends Key {
 		MessageDigest md256 = SHA256.getMessageDigest();
 		md256.update(ehDocname);
 		md256.update(pkHash);
-		byte[] key = md256.digest();
-		SHA256.returnMessageDigest(md256);
-		return key;
+		return md256.digest();
 	}
 	
 	@Override

--- a/src/freenet/keys/SSKBlock.java
+++ b/src/freenet/keys/SSKBlock.java
@@ -3,9 +3,6 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.keys;
 
-import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
-import org.bouncycastle.crypto.signers.DSASigner;
-
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.util.Arrays;
@@ -16,6 +13,8 @@ import freenet.crypt.SHA256;
 import freenet.support.Fields;
 import freenet.support.HexUtil;
 import freenet.support.Logger;
+import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
+import org.bouncycastle.crypto.signers.DSASigner;
 
 /**
  * SSKBlock. Contains a full fetched key. Can do a node-level verification. Can 
@@ -138,21 +137,16 @@ public class SSKBlock implements KeyBlock {
 			System.arraycopy(headers, x, bufS, 0, SIG_S_LENGTH);
 			x+=SIG_S_LENGTH;
 
-			MessageDigest md = null;
 			byte[] overallHash;
-			try {
-				md = SHA256.getMessageDigest();
-				md.update(data);
-				byte[] dataHash = md.digest();
-				// All headers up to and not including the signature
-				md.update(headers, 0, headersOffset + ENCRYPTED_HEADERS_LENGTH);
-				// Then the implicit data hash
-				md.update(dataHash);
-				// Makes the implicit overall hash
-				overallHash = md.digest();
-			} finally {
-				SHA256.returnMessageDigest(md);
-			}
+			MessageDigest md = SHA256.getMessageDigest();
+			md.update(data);
+			byte[] dataHash = md.digest();
+			// All headers up to and not including the signature
+			md.update(headers, 0, headersOffset + ENCRYPTED_HEADERS_LENGTH);
+			// Then the implicit data hash
+			md.update(dataHash);
+			// Makes the implicit overall hash
+			overallHash = md.digest();
 			
 			// Now verify it
 			BigInteger r = new BigInteger(1, bufR);

--- a/src/freenet/node/FNPPacketMangler.java
+++ b/src/freenet/node/FNPPacketMangler.java
@@ -3,6 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.File;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
@@ -47,10 +51,6 @@ import freenet.support.TimeUtil;
 import freenet.support.io.FileUtil;
 import freenet.support.io.InetAddressComparator;
 import freenet.support.io.NativeThread;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * @author amphibian
@@ -1760,7 +1760,6 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		// Similar to JFK keygen, should be safe enough.
 		md.update("INITIAL0".getBytes(StandardCharsets.UTF_8));
 		byte[] hashed = md.digest();
-		SHA256.returnMessageDigest(md);
 		return Fields.bytesToInt(hashed, 0);
 	}
 
@@ -1771,7 +1770,6 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		// Similar to JFK keygen, should be safe enough.
 		md.update("INITIAL1".getBytes(StandardCharsets.UTF_8));
 		byte[] hashed = md.digest();
-		SHA256.returnMessageDigest(md);
 		return Fields.bytesToInt(hashed, 0);
 	}
 

--- a/src/freenet/node/LocationManager.java
+++ b/src/freenet/node/LocationManager.java
@@ -694,8 +694,6 @@ public class LocationManager implements ByteCounter {
                 announceLocChange(true, true, false);
                 node.writeNodeFile();
             }
-
-            SHA256.returnMessageDigest(md);
         } catch (Throwable t) {
             Logger.error(this, "Caught "+t, t);
         } finally {

--- a/src/freenet/node/MasterKeys.java
+++ b/src/freenet/node/MasterKeys.java
@@ -164,7 +164,6 @@ public class MasterKeys {
 				MasterKeys ret = new MasterKeys(clientCacheKey, databaseKey, tempfilesMasterSecret, flags);
 				clear(data);
 				clear(hash);
-				SHA256.returnMessageDigest(md);
 				System.err.println("Read old master keys file");
 				if(mustWrite) {
 				    ret.changePassword(masterKeysFile, password, hardRandom);
@@ -243,7 +242,6 @@ public class MasterKeys {
         MasterKeys ret = new MasterKeys(clientCacheKey, databaseKey, tempfilesMasterSecret, flags);
         clear(data);
         clear(hash);
-        SHA256.returnMessageDigest(md);
         return ret;
     }
 
@@ -303,7 +301,6 @@ public class MasterKeys {
 		
 		md.update(data, hashedStart, data.length-hashedStart);
 		byte[] hash = md.digest();
-        SHA256.returnMessageDigest(md); md = null;
 		baos.write(hash, 0, HASH_LENGTH);
 		data = baos.toByteArray();
 

--- a/src/freenet/node/updater/MainJarDependenciesChecker.java
+++ b/src/freenet/node/updater/MainJarDependenciesChecker.java
@@ -36,8 +36,6 @@ import java.util.regex.PatternSyntaxException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.tanukisoftware.wrapper.WrapperManager;
-
 import freenet.client.FetchException;
 import freenet.crypt.SHA256;
 import freenet.keys.FreenetURI;
@@ -53,6 +51,7 @@ import freenet.support.io.FileUtil;
 import freenet.support.io.FileUtil.CPUArchitecture;
 import freenet.support.io.FileUtil.OperatingSystem;
 import freenet.support.io.NativeThread;
+import org.tanukisoftware.wrapper.WrapperManager;
 
 /**
  * Parses the dependencies.properties file and ensures we have all the 
@@ -1665,7 +1664,6 @@ outer:	for(String propName : props.stringPropertyNames()) {
 			MessageDigest md = SHA256.getMessageDigest();
 			SHA256.hash(fis, md);
 			byte[] hash = md.digest();
-			SHA256.returnMessageDigest(md);
 			fis.close();
 			fis = null;
 			if(Arrays.equals(hash, expectedHash)) {

--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -32,8 +32,6 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
-import org.tanukisoftware.wrapper.WrapperManager;
-
 import freenet.client.HighLevelSimpleClient;
 import freenet.clients.fcp.ClientPut;
 import freenet.clients.http.PageMaker.THEME;
@@ -68,6 +66,7 @@ import freenet.support.api.StringArrCallback;
 import freenet.support.io.Closer;
 import freenet.support.io.FileUtil;
 import freenet.support.io.NativeThread.PriorityLevel;
+import org.tanukisoftware.wrapper.WrapperManager;
 
 public class PluginManager {
 
@@ -1337,13 +1336,11 @@ public class PluginManager {
 		MessageDigest hash = null;
 		FileInputStream fis = null;
 		BufferedInputStream bis = null;
-		boolean wasFromDigest256Pool = false;
 		String result;
 
 		try {
 			if ("SHA-256".equals(digest)) {
-				hash = SHA256.getMessageDigest(); // grab digest from pool
-				wasFromDigest256Pool = true;
+				hash = SHA256.getMessageDigest();
 			} else {
 				hash = MessageDigest.getInstance(digest);
 			}
@@ -1357,8 +1354,6 @@ public class PluginManager {
 				hash.update(buffer, 0, len);
 			}
 			result = HexUtil.bytesToHex(hash.digest());
-			if (wasFromDigest256Pool)
-				SHA256.returnMessageDigest(hash);
 		} catch(Exception e) {
 			throw new PluginNotFoundException("Error while computing hash '"+digest+"' of the downloaded plugin: " + e, e);
 		} finally {

--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -40,7 +40,7 @@ import freenet.clients.http.Toadlet;
 import freenet.config.InvalidConfigValueException;
 import freenet.config.NodeNeedRestartException;
 import freenet.config.SubConfig;
-import freenet.crypt.SHA256;
+import freenet.crypt.HashType;
 import freenet.keys.FreenetURI;
 import freenet.l10n.BaseL10n.LANGUAGE;
 import freenet.l10n.NodeL10n;
@@ -1180,7 +1180,7 @@ public class PluginManager {
 		if (digest == null) {
 			return;
 		}
-		String testsum = getFileDigest(pluginFile, "SHA-1");
+		String testsum = getFileDigest(pluginFile);
 		if (!(digest.equalsIgnoreCase(testsum))) {
 			Logger.error(this, "Checksum verification failed, should be " + digest + " but was " + testsum);
 			throw new PluginNotFoundException("Checksum verification failed, should be " + digest + " but was " + testsum);
@@ -1331,19 +1331,14 @@ public class PluginManager {
 		return cachedFiles;
 	}
 
-	private String getFileDigest(File file, String digest) throws PluginNotFoundException {
+	private String getFileDigest(File file) throws PluginNotFoundException {
 		final int BUFFERSIZE = 4096;
-		MessageDigest hash = null;
+		MessageDigest hash = HashType.SHA1.get();
 		FileInputStream fis = null;
 		BufferedInputStream bis = null;
 		String result;
 
 		try {
-			if ("SHA-256".equals(digest)) {
-				hash = SHA256.getMessageDigest();
-			} else {
-				hash = MessageDigest.getInstance(digest);
-			}
 			// We compute the hash
 			// http://java.sun.com/developer/TechTips/1998/tt0915.html#tip2
 			fis = new FileInputStream(file);
@@ -1355,7 +1350,7 @@ public class PluginManager {
 			}
 			result = HexUtil.bytesToHex(hash.digest());
 		} catch(Exception e) {
-			throw new PluginNotFoundException("Error while computing hash '"+digest+"' of the downloaded plugin: " + e, e);
+			throw new PluginNotFoundException("Error while computing hash of the downloaded plugin: " + e, e);
 		} finally {
 			Closer.close(bis);
 			Closer.close(fis);

--- a/src/freenet/store/saltedhash/CipherManager.java
+++ b/src/freenet/store/saltedhash/CipherManager.java
@@ -77,21 +77,17 @@ public class CipherManager {
 		}
 
 		MessageDigest digest = SHA256.getMessageDigest();
-		try {
-			digest.update(plainKey);
-			digest.update(salt);
+		digest.update(plainKey);
+		digest.update(salt);
 
-			byte[] hashedRoutingKey = digest.digest();
-			assert hashedRoutingKey.length == 0x20;
+		byte[] hashedRoutingKey = digest.digest();
+		assert hashedRoutingKey.length == 0x20;
 
-			synchronized (digestRoutingKeyCache) {
-				digestRoutingKeyCache.put(key, hashedRoutingKey);
-			}
-
-			return hashedRoutingKey;
-		} finally {
-			SHA256.returnMessageDigest(digest);
+		synchronized (digestRoutingKeyCache) {
+			digestRoutingKeyCache.put(key, hashedRoutingKey);
 		}
+
+		return hashedRoutingKey;
 	}
 
 	/**

--- a/src/freenet/support/io/BucketTools.java
+++ b/src/freenet/support/io/BucketTools.java
@@ -14,10 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import freenet.support.math.MersenneTwister;
-
 import freenet.crypt.AEADCryptBucket;
-
 import freenet.crypt.EncryptedRandomAccessBucket;
 import freenet.crypt.EncryptedRandomAccessBuffer;
 import freenet.crypt.MasterSecret;
@@ -30,6 +27,7 @@ import freenet.support.api.BucketFactory;
 import freenet.support.api.LockableRandomAccessBuffer;
 import freenet.support.api.RandomAccessBucket;
 import freenet.support.api.RandomAccessBuffer;
+import freenet.support.math.MersenneTwister;
 
 /**
  * Helper functions for working with Buckets.
@@ -276,27 +274,22 @@ public class BucketTools {
 		InputStream is = data.getInputStreamUnbuffered();
 		try {
 			MessageDigest md = SHA256.getMessageDigest();
-			try { 
-				long bucketLength = data.size();
-				long bytesRead = 0;
-				byte[] buf = new byte[BUFFER_SIZE];
-				while ((bytesRead < bucketLength) || (bucketLength == -1)) {
-					int readBytes = is.read(buf);
-					if (readBytes < 0)
-						break;
-					bytesRead += readBytes;
-					if (readBytes > 0)
-						md.update(buf, 0, readBytes);
-				}
-				if ((bytesRead < bucketLength) && (bucketLength > 0))
-					throw new EOFException();
-				if ((bytesRead != bucketLength) && (bucketLength > 0))
-					throw new IOException("Read " + bytesRead + " but bucket length " + bucketLength + " on " + data + '!');
-				byte[] retval = md.digest();
-				return retval;
-			} finally {
-				SHA256.returnMessageDigest(md);
+			long bucketLength = data.size();
+			long bytesRead = 0;
+			byte[] buf = new byte[BUFFER_SIZE];
+			while ((bytesRead < bucketLength) || (bucketLength == -1)) {
+				int readBytes = is.read(buf);
+				if (readBytes < 0)
+					break;
+				bytesRead += readBytes;
+				if (readBytes > 0)
+					md.update(buf, 0, readBytes);
 			}
+			if ((bytesRead < bucketLength) && (bucketLength > 0))
+				throw new EOFException();
+			if ((bytesRead != bucketLength) && (bucketLength > 0))
+				throw new IOException("Read " + bytesRead + " but bucket length " + bucketLength + " on " + data + '!');
+            return md.digest();
 		} finally {
 			if(is != null) is.close();
 		}

--- a/test/freenet/crypt/HMAC_legacy.java
+++ b/test/freenet/crypt/HMAC_legacy.java
@@ -129,26 +129,14 @@ public class HMAC_legacy {
 	}
 
 	public static byte[] macWithSHA256(byte[] K, byte[] text, int macbytes) {
-		MessageDigest sha256 = null;
-		try {
-			sha256 = SHA256.getMessageDigest();
-			HMAC_legacy hash = new HMAC_legacy(sha256);
-			return hash.mac(K, text, macbytes);
-		} finally {
-			if(sha256 != null)
-				SHA256.returnMessageDigest(sha256);
-		}
+		MessageDigest sha256 = SHA256.getMessageDigest();
+		HMAC_legacy hash = new HMAC_legacy(sha256);
+		return hash.mac(K, text, macbytes);
 	}
 
 	public static boolean verifyWithSHA256(byte[] K, byte[] text, byte[] mac) {
-		MessageDigest sha256 = null;
-		try {
-			sha256 = SHA256.getMessageDigest();
-			HMAC_legacy hash = new HMAC_legacy(sha256);
-			return hash.verify(K, text, mac);
-		} finally {
-			if(sha256 != null)
-				SHA256.returnMessageDigest(sha256);
-		}
+		MessageDigest sha256 = SHA256.getMessageDigest();
+		HMAC_legacy hash = new HMAC_legacy(sha256);
+		return hash.verify(K, text, mac);
 	}
 }


### PR DESCRIPTION
During review of #831 it was observed that the overhead of pooling outweights that of constructing new digest instances.
This PR removes the pooling mechanism from the SHA256 helper class. Because the return-to-pool method is now a no-op, its usages are removed. The method is now deprecated, but remains for backwards compatibility.

While cleaning up I encountered the HashType enum, which had a special case for pooling of SHA-256 too. This deprecates the related return-to-pool method, and removes the special handling of SHA-256 message digest creation in this class.