### PR TITLE
Reduce pings and dns lookups

### DIFF
--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -102,9 +102,11 @@ public class DNSRequester implements Runnable {
         // Try new DNS lookup
         //Logger.minor(this, "Doing lookup on "+pn+" of "+nodesToCheck.length);
         pn.maybeUpdateHandshakeIPs(false);
+
+        int nextMaxWaitTime = 1000 + node.getFastWeakRandom().nextInt(60000);
         try {
             synchronized(this) {
-                wait(1000 + node.getFastWeakRandom().nextInt(60000));  // sleep 1-61s ...
+                wait(nextMaxWaitTime);  // sleep 1-61s ...
             }
         } catch (InterruptedException e) {
             // Ignore, just wake up. Just sleeping to not busy wait anyway

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -3,6 +3,12 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+
 import freenet.support.LogThresholdCallback;
 import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
@@ -16,6 +22,8 @@ public class DNSRequester implements Runnable {
 
     final Node node;
     private long lastLogTime;
+    private final Set<Double> recentNodeIdentitySet = new HashSet<>();
+    private final Deque<Double> recentNodeIdentityQueue = new ArrayDeque<>();
     // Only set when doing simulations.
     static boolean DISABLE = false;
 
@@ -54,23 +62,40 @@ public class DNSRequester implements Runnable {
     }
 
     private void realRun() {
-        PeerNode[] nodes = node.getPeers().myPeers();
-        long now = System.currentTimeMillis();
-        if((now - lastLogTime) > 100) {
-        	if(logMINOR) {
-        		Logger.minor(this, "Processing DNS Requests (log rate-limited)");
+        // run DNS requests for not recently checked, unconnected
+        // nodes to avoid the coupon collector's problem
+        PeerNode[] nodesToCheck = Arrays.stream(node.getPeers().myPeers())
+            .filter(peerNode -> !peerNode.isConnected())
+            // identify recent nodes by location, because the exact location cannot be used twice
+            // (that already triggers the simplest pitch black attack defenses)
+            // Double may not be comparable in general (floating point),
+            // but just checking for equality with itself is safe
+            .filter(peerNode -> !recentNodeIdentitySet.contains(peerNode.getLocation()))
+            .toArray(PeerNode[]::new);
+
+        if(logMINOR) {
+            long now = System.currentTimeMillis();
+            if((now - lastLogTime) > 100) {
+            		Logger.minor(this, "Processing DNS Requests (log rate-limited)");
             }
             lastLogTime = now;
         }
-        // check a randomly chosen node to avoid sending bursts of DNS requests
-        PeerNode pn = nodes[node.getFastWeakRandom().nextInt(nodes.length)];
-        //Logger.minor(this, "Node: "+pn);
-        if(!pn.isConnected()) {
-            // Not connected
-            // Try new DNS lookup
-            //Logger.minor(this, "Doing lookup on "+pn+" of "+nodes.length);
-            pn.maybeUpdateHandshakeIPs(false);
+        // check a randomly chosen node that has not been checked
+        // recently to avoid sending bursts of DNS requests
+        int unconnectedNodesLength = nodesToCheck.length;
+        PeerNode pn = nodesToCheck[node.getFastWeakRandom().nextInt(unconnectedNodesLength)];
+        // do not request this node again,
+        // until at least 80% of the other unconnected nodes have been checked
+        recentNodeIdentitySet.add(pn.getLocation());
+        recentNodeIdentityQueue.offerFirst(pn.getLocation());
+        while (unconnectedNodesLength > 5 && recentNodeIdentityQueue.size() > (0.81 * unconnectedNodesLength)) {
+          recentNodeIdentitySet.remove(recentNodeIdentityQueue.removeLast());
         }
+        //Logger.minor(this, "Node: "+pn);
+
+        // Try new DNS lookup
+        //Logger.minor(this, "Doing lookup on "+pn+" of "+nodesToCheck.length);
+        pn.maybeUpdateHandshakeIPs(false);
         try {
             synchronized(this) {
                 wait(1000);  // sleep 1s ...

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -56,23 +56,24 @@ public class DNSRequester implements Runnable {
     private void realRun() {
         PeerNode[] nodes = node.getPeers().myPeers();
         long now = System.currentTimeMillis();
-        if((now - lastLogTime) > 1000) {
-        	if(logMINOR)
+        if((now - lastLogTime) > 100) {
+        	if(logMINOR) {
         		Logger.minor(this, "Processing DNS Requests (log rate-limited)");
+            }
             lastLogTime = now;
         }
-        for(PeerNode pn: nodes) {
-            //Logger.minor(this, "Node: "+pn);
-            if(!pn.isConnected()) {
-                // Not connected
-                // Try new DNS lookup
-            	//Logger.minor(this, "Doing lookup on "+pn+" of "+nodes.length);
-                pn.maybeUpdateHandshakeIPs(false);
-            }
+        // check a randomly chosen node to avoid sending bursts of DNS requests
+        PeerNode pn = nodes[node.getFastWeakRandom().nextInt(nodes.length)];
+        //Logger.minor(this, "Node: "+pn);
+        if(!pn.isConnected()) {
+            // Not connected
+            // Try new DNS lookup
+            //Logger.minor(this, "Doing lookup on "+pn+" of "+nodes.length);
+            pn.maybeUpdateHandshakeIPs(false);
         }
         try {
             synchronized(this) {
-                wait(10000);  // sleep 10s ...
+                wait(1000);  // sleep 1s ...
             }
         } catch (InterruptedException e) {
             // Ignore, just wake up. Just sleeping to not busy wait anyway

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -84,12 +84,18 @@ public class DNSRequester implements Runnable {
         // recently to avoid sending bursts of DNS requests
         int unconnectedNodesLength = nodesToCheck.length;
         PeerNode pn = nodesToCheck[node.getFastWeakRandom().nextInt(unconnectedNodesLength)];
-        // do not request this node again,
-        // until at least 80% of the other unconnected nodes have been checked
-        recentNodeIdentitySet.add(pn.getLocation());
-        recentNodeIdentityQueue.offerFirst(pn.getLocation());
-        while (unconnectedNodesLength > 5 && recentNodeIdentityQueue.size() > (0.81 * unconnectedNodesLength)) {
-          recentNodeIdentitySet.remove(recentNodeIdentityQueue.removeLast());
+        if (unconnectedNodesLength < 5) {
+            // no need for optimizations: just clear all state
+            recentNodeIdentitySet.clear();
+            recentNodeIdentityQueue.clear();
+        } else {
+            // do not request this node again,
+            // until at least 80% of the other unconnected nodes have been checked
+            recentNodeIdentitySet.add(pn.getLocation());
+            recentNodeIdentityQueue.offerFirst(pn.getLocation());
+            while (recentNodeIdentityQueue.size() > (0.81 * unconnectedNodesLength)) {
+                recentNodeIdentitySet.remove(recentNodeIdentityQueue.removeLast());
+            }
         }
         //Logger.minor(this, "Node: "+pn);
 

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -104,7 +104,7 @@ public class DNSRequester implements Runnable {
         pn.maybeUpdateHandshakeIPs(false);
         try {
             synchronized(this) {
-                wait(1000);  // sleep 1s ...
+                wait(1000 + node.getFastWeakRandom().nextInt(60000));  // sleep 1-61s ...
             }
         } catch (InterruptedException e) {
             // Ignore, just wake up. Just sleeping to not busy wait anyway

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -80,9 +80,13 @@ public class DNSRequester implements Runnable {
             }
             lastLogTime = now;
         }
+
+        int unconnectedNodesLength = nodesToCheck.length;
+        if (unconnectedNodesLength == 0) {
+            return; // nothing to do
+        }
         // check a randomly chosen node that has not been checked
         // recently to avoid sending bursts of DNS requests
-        int unconnectedNodesLength = nodesToCheck.length;
         PeerNode pn = nodesToCheck[node.getFastWeakRandom().nextInt(unconnectedNodesLength)];
         if (unconnectedNodesLength < 5) {
             // no need for optimizations: just clear all state

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -94,7 +94,7 @@ public class DNSRequester implements Runnable {
             recentNodeIdentityQueue.clear();
         } else {
             // do not request this node again,
-            // until at least 80% of the other unconnected nodes have been checked
+            // until at least 81% of the other unconnected nodes have been checked
             recentNodeIdentitySet.add(pn.getLocation());
             recentNodeIdentityQueue.offerFirst(pn.getLocation());
             while (recentNodeIdentityQueue.size() > (0.81 * unconnectedNodesLength)) {

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -101,10 +101,8 @@ public class DNSRequester implements Runnable {
                 recentNodeIdentitySet.remove(recentNodeIdentityQueue.removeLast());
             }
         }
-        //Logger.minor(this, "Node: "+pn);
 
         // Try new DNS lookup
-        //Logger.minor(this, "Doing lookup on "+pn+" of "+nodesToCheck.length);
         pn.maybeUpdateHandshakeIPs(false);
 
         int nextMaxWaitTime = 1000 + node.getFastWeakRandom().nextInt(60000);

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -782,6 +782,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		if (detectedPeer == null && !nominalPeer.isEmpty()) {
 			sortNominalPeer();
 			detectedPeer = nominalPeer.get(0);
+			updateShortToString();
 		}
 		return detectedPeer;
 	}


### PR DESCRIPTION
Only sort the list nominalPeer when necessary.

That sorting can cause Pings to be sent. Now sorting is only done when
receiving a new noderef and at random intervals.

This should make the node less visible in DNS requests and Pings (more
typical pattern instead of requesting all peers at the same time).

Also it fixes the startup time regression by not doing a ping in the
PeerNode constructor.

The sorting result in the constructor was overwritten anyway …