### PR TITLE
refactor: split parsing peers into multiple steps

### DIFF
--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -209,7 +209,7 @@ public class PeerManager {
 			if(peersFile.exists())
 				if(readPeers(peersFile, crypto, opennet, oldOpennetPeers)) {
 					String msg;
-					if(oldOpennetPeers) {
+					if (oldOpennetPeers) {
 						msg = "Read " + opennet.countOldOpennetPeers() + " old-opennet-peers from " + peersFile;
 					} else if(isOpennet) {
 						msg = "Read " + getOpennetPeers().length + " opennet peers from " + peersFile;
@@ -221,7 +221,7 @@ public class PeerManager {
 					return;
 				}
 		}
-		if(!isOpennet) {
+		if (!isOpennet) {
 			System.out.println("No darknet peers file found.");
 		}
 		// The other cases are less important.
@@ -256,15 +256,15 @@ public class PeerManager {
 		for (SimpleFieldSet fs : peerEntries) {
 			try {
 				createdNodes.add(PeerNode.create(fs, node, crypto, opennet, this));
-			} catch(FSParseException e2) {
+			} catch (FSParseException e2) {
 				Logger.error(this, "Could not parse peer due to broken fieldset syntax: " + e2 + '\n' + fs.toString(), e2);
 				System.err.println("Cannot parse a friend from the peers file due to broken fieldset syntax: "+e2);
 				someBroken = true;
-			} catch(PeerParseException e2) {
+			} catch (PeerParseException e2) {
 				Logger.error(this, "Could not parse peer: " + e2 + '\n' + fs.toString(), e2);
 				System.err.println("Cannot parse a friend from the peers file: "+e2);
 				someBroken = true;
-			} catch(ReferenceSignatureVerificationException e2) {
+			} catch (ReferenceSignatureVerificationException e2) {
 				Logger.error(this, "Could not verify signature of peer: " + e2 + '\n' + fs.toString(), e2);
 				System.err.println("Cannot verify signature of a friend from the peers file: "+e2);
 				someBroken = true;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -242,7 +242,7 @@ public class PeerManager {
 		// read the peers file
 		try {
 			while (true) {
-			  peerEntries.add(new SimpleFieldSet(br, false, true));
+				peerEntries.add(new SimpleFieldSet(br, false, true));
 			}
 		} catch(EOFException e) {
 			// End of file, fine
@@ -311,13 +311,13 @@ public class PeerManager {
 			}
 		}
 		if(!droppedOldPeers.isEmpty()) {
-		    try {
-		        node.getClientCore().getAlerts().register(droppedOldPeers);
-		        Logger.error(this, droppedOldPeers.getText());
-		    } catch (Throwable t) {
-		        // Startup MUST complete, don't let client layer problems kill it.
-		        Logger.error(this, "Caught error telling user about dropped peers", t);
-		    }
+			try {
+				node.getClientCore().getAlerts().register(droppedOldPeers);
+				Logger.error(this, droppedOldPeers.getText());
+			} catch (Throwable t) {
+				// Startup MUST complete, don't let client layer problems kill it.
+				Logger.error(this, "Caught error telling user about dropped peers", t);
+			}
 		}
 		return !someBroken;
 	}

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -209,19 +209,21 @@ public class PeerManager {
 			if(peersFile.exists())
 				if(readPeers(peersFile, crypto, opennet, oldOpennetPeers)) {
 					String msg;
-					if(oldOpennetPeers)
+					if(oldOpennetPeers) {
 						msg = "Read " + opennet.countOldOpennetPeers() + " old-opennet-peers from " + peersFile;
-					else if(isOpennet)
+					} else if(isOpennet) {
 						msg = "Read " + getOpennetPeers().length + " opennet peers from " + peersFile;
-					else
+					} else {
 						msg = "Read " + getDarknetPeers().length + " darknet peers from " + peersFile;
+					}
 					Logger.normal(this, msg);
 					System.out.println(msg);
 					return;
 				}
 		}
-		if(!isOpennet)
+		if(!isOpennet) {
 			System.out.println("No darknet peers file found.");
+		}
 		// The other cases are less important.
 	}
 

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -285,12 +285,14 @@ public class PeerManager {
 
 		for (PeerNode pn : createdNodes) {
 				if(oldOpennetPeers) {
-					if(!(pn instanceof OpennetPeerNode))
+					if(!(pn instanceof OpennetPeerNode)) {
 						Logger.error(this, "Darknet node in old opennet peers?!: "+pn);
-					else
+                    } else {
 						opennet.addOldOpennetNode((OpennetPeerNode)pn);
-				} else
+                    }
+				} else {
 					addPeer(pn, true, false);
+                }
 		}
 		try {
 			br.close();

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -286,12 +286,12 @@ public class PeerManager {
 		}
 
 		for (PeerNode pn : createdNodes) {
-				if(oldOpennetPeers) {
+				if (oldOpennetPeers) {
 					if(!(pn instanceof OpennetPeerNode)) {
 						Logger.error(this, "Darknet node in old opennet peers?!: "+pn);
-                    } else {
+					} else {
 						opennet.addOldOpennetNode((OpennetPeerNode)pn);
-                    }
+					}
 				} else {
 					addPeer(pn, true, false);
                 }

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -275,7 +275,7 @@ public class PeerManager {
 				// FIXME tell the user???
 			}  catch (PeerTooOldException e) {
 				someBroken = true;
-				if(crypto.isOpennet()) {
+				if (crypto.isOpennet()) {
 					// Ignore.
 					Logger.error(this, "Dropping too-old opennet peer");
 				} else {

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -287,7 +287,7 @@ public class PeerManager {
 
 		for (PeerNode pn : createdNodes) {
 				if (oldOpennetPeers) {
-					if(!(pn instanceof OpennetPeerNode)) {
+					if (!(pn instanceof OpennetPeerNode)) {
 						Logger.error(this, "Darknet node in old opennet peers?!: "+pn);
 					} else {
 						opennet.addOldOpennetNode((OpennetPeerNode)pn);
@@ -301,7 +301,7 @@ public class PeerManager {
 		} catch(IOException e3) {
 			Logger.error(this, "Ignoring " + e3 + " caught reading " + peersFile, e3);
 		}
-		if(someBroken) {
+		if (someBroken) {
 			try {
 				brokenPeersFile.delete();
 				FileOutputStream fos = new FileOutputStream(brokenPeersFile);
@@ -314,7 +314,7 @@ public class PeerManager {
 				System.err.println("Unable to copy broken peers file.");
 			}
 		}
-		if(!droppedOldPeers.isEmpty()) {
+		if (!droppedOldPeers.isEmpty()) {
 			try {
 				node.getClientCore().getAlerts().register(droppedOldPeers);
 				Logger.error(this, droppedOldPeers.getText());


### PR DESCRIPTION
The previous code nested too much error handling even though many parts are independent.

This is a cleanup as sideeffect of trying to multi-thread the peer initialization. That multi-threading turned out to be unnecessary, but the cleanup is nice without it.