### PR TITLE
Remove code related to NLM load sending

### DIFF
--- a/src/freenet/io/comm/DMT.java
+++ b/src/freenet/io/comm/DMT.java
@@ -23,7 +23,6 @@ import freenet.crypt.DSAPublicKey;
 import freenet.keys.Key;
 import freenet.keys.NodeCHK;
 import freenet.keys.NodeSSK;
-import freenet.node.NodeStats.PeerLoadStats;
 import freenet.node.probe.Error;
 import freenet.node.probe.Type;
 import freenet.support.BitArray;
@@ -474,17 +473,19 @@ public class DMT {
 		addField(UID, Long.class);
 		addField(IS_LOCAL, Boolean.class);
 	}};
-	
+
+	/**
+	 * @deprecated last two NLM related arguments are ignored and can be omitted
+	 */
+	@Deprecated
 	public static Message createFNPRejectedOverload(long id, boolean isLocal, boolean needsLoad, boolean realTimeFlag) {
+		return createFNPRejectedOverload(id, isLocal);
+	}
+
+	public static Message createFNPRejectedOverload(long id, boolean isLocal) {
 		Message msg = new Message(FNPRejectedOverload);
 		msg.set(UID, id);
 		msg.set(IS_LOCAL, isLocal);
-		if(needsLoad) {
-			if(realTimeFlag)
-				msg.setNeedsLoadRT();
-			else
-				msg.setNeedsLoadBulk();
-		}
 		return msg;
 	}
 	
@@ -1722,60 +1723,6 @@ public class DMT {
 		addField(MAX_TRANSFERS_OUT_UPPER_LIMIT, Integer.class);
 		addField(REAL_TIME_FLAG, Boolean.class);
 	}};
-	
-	public static Message createFNPPeerLoadStatus(PeerLoadStats stats) {
-		Message msg;
-		if(stats.expectedTransfersInCHK < 256 && stats.expectedTransfersInSSK < 256 &&
-				stats.expectedTransfersOutCHK < 256 && stats.expectedTransfersOutSSK < 256 &&
-				stats.averageTransfersOutPerInsert < 256 && stats.maxTransfersOut < 256 && 
-				stats.maxTransfersOutLowerLimit < 256 && stats.maxTransfersOutPeerLimit < 256 &&
-				stats.maxTransfersOutUpperLimit < 256) {
-			msg = new Message(FNPPeerLoadStatusByte);
-			msg.set(OTHER_TRANSFERS_OUT_CHK, (byte)stats.expectedTransfersOutCHK);
-			msg.set(OTHER_TRANSFERS_IN_CHK, (byte)stats.expectedTransfersInCHK);
-			msg.set(OTHER_TRANSFERS_OUT_SSK, (byte)stats.expectedTransfersOutSSK);
-			msg.set(OTHER_TRANSFERS_IN_SSK, (byte)stats.expectedTransfersInSSK);
-			msg.set(AVERAGE_TRANSFERS_OUT_PER_INSERT, (byte)stats.averageTransfersOutPerInsert);
-			msg.set(MAX_TRANSFERS_OUT, (byte)stats.maxTransfersOut);
-			msg.set(MAX_TRANSFERS_OUT_PEER_LIMIT, (byte)stats.maxTransfersOutPeerLimit);
-			msg.set(MAX_TRANSFERS_OUT_LOWER_LIMIT, (byte)stats.maxTransfersOutLowerLimit);
-			msg.set(MAX_TRANSFERS_OUT_UPPER_LIMIT, (byte)stats.maxTransfersOutUpperLimit);
-		} else if(stats.expectedTransfersInCHK < 65536 && stats.expectedTransfersInSSK < 65536 &&
-				stats.expectedTransfersOutCHK < 65536 && stats.expectedTransfersOutSSK < 65536 &&
-				stats.averageTransfersOutPerInsert < 65536 && stats.maxTransfersOut < 65536 && 
-				stats.maxTransfersOutLowerLimit < 65536 && stats.maxTransfersOutPeerLimit < 65536 &&
-				stats.maxTransfersOutUpperLimit < 65536) {
-			msg = new Message(FNPPeerLoadStatusShort);
-			msg.set(OTHER_TRANSFERS_OUT_CHK, (short)stats.expectedTransfersOutCHK);
-			msg.set(OTHER_TRANSFERS_IN_CHK, (short)stats.expectedTransfersInCHK);
-			msg.set(OTHER_TRANSFERS_OUT_SSK, (short)stats.expectedTransfersOutSSK);
-			msg.set(OTHER_TRANSFERS_IN_SSK, (short)stats.expectedTransfersInSSK);
-			msg.set(AVERAGE_TRANSFERS_OUT_PER_INSERT, (short)stats.averageTransfersOutPerInsert);
-			msg.set(MAX_TRANSFERS_OUT, (short)stats.maxTransfersOut);
-			msg.set(MAX_TRANSFERS_OUT_PEER_LIMIT, (short)stats.maxTransfersOutPeerLimit);
-			msg.set(MAX_TRANSFERS_OUT_LOWER_LIMIT, (short)stats.maxTransfersOutLowerLimit);
-			msg.set(MAX_TRANSFERS_OUT_UPPER_LIMIT, (short)stats.maxTransfersOutUpperLimit);
-		} else {
-			msg = new Message(FNPPeerLoadStatusInt);
-			msg.set(OTHER_TRANSFERS_OUT_CHK, stats.expectedTransfersOutCHK);
-			msg.set(OTHER_TRANSFERS_IN_CHK, stats.expectedTransfersInCHK);
-			msg.set(OTHER_TRANSFERS_OUT_SSK, stats.expectedTransfersOutSSK);
-			msg.set(OTHER_TRANSFERS_IN_SSK, stats.expectedTransfersInSSK);
-			msg.set(AVERAGE_TRANSFERS_OUT_PER_INSERT, stats.averageTransfersOutPerInsert);
-			msg.set(MAX_TRANSFERS_OUT, stats.maxTransfersOut);
-			msg.set(MAX_TRANSFERS_OUT_PEER_LIMIT, stats.maxTransfersOutPeerLimit);
-			msg.set(MAX_TRANSFERS_OUT_LOWER_LIMIT, stats.maxTransfersOutLowerLimit);
-			msg.set(MAX_TRANSFERS_OUT_UPPER_LIMIT, stats.maxTransfersOutUpperLimit);
-		}
-		msg.set(OUTPUT_BANDWIDTH_LOWER_LIMIT, (int)stats.outputBandwidthLowerLimit);
-		msg.set(OUTPUT_BANDWIDTH_UPPER_LIMIT, (int)stats.outputBandwidthUpperLimit);
-		msg.set(OUTPUT_BANDWIDTH_PEER_LIMIT, (int)stats.outputBandwidthPeerLimit);
-		msg.set(INPUT_BANDWIDTH_LOWER_LIMIT, (int)stats.inputBandwidthLowerLimit);
-		msg.set(INPUT_BANDWIDTH_UPPER_LIMIT, (int)stats.inputBandwidthUpperLimit);
-		msg.set(INPUT_BANDWIDTH_PEER_LIMIT, (int)stats.inputBandwidthPeerLimit);
-		msg.set(REAL_TIME_FLAG, stats.realTime);
-		return msg;
-	}
 	
 	public static final String AVERAGE_TRANSFERS_OUT_PER_INSERT = "averageTransfersOutPerInsert";
 	

--- a/src/freenet/io/comm/Message.java
+++ b/src/freenet/io/comm/Message.java
@@ -33,9 +33,9 @@ import freenet.support.ByteBufferInputStream;
 import freenet.support.Fields;
 import freenet.support.LogThresholdCallback;
 import freenet.support.Logger;
+import freenet.support.Logger.LogLevel;
 import freenet.support.Serializer;
 import freenet.support.ShortBuffer;
-import freenet.support.Logger.LogLevel;
 
 /**
  * A Message which can be read from and written to a DatagramPacket.
@@ -75,9 +75,7 @@ public class Message {
 	public final long localInstantiationTime;
 	final int _receivedByteCount;
 	short priority;
-	private boolean needsLoadRT;
-	private boolean needsLoadBulk;
-	
+
 	public static Message decodeMessageFromPacket(byte[] buf, int offset, int length, PeerContext peer, int overhead) {
 		ByteBufferInputStream bb = new ByteBufferInputStream(buf, offset, length);
 		return decodeMessage(bb, peer, length + overhead, true, false, false);
@@ -179,8 +177,6 @@ public class Message {
 		localInstantiationTime = System.currentTimeMillis();
 		_receivedByteCount = 0;
 		priority = m.priority;
-		needsLoadRT = m.needsLoadRT;
-		needsLoadBulk = m.needsLoadBulk;
 	}
 
 	public boolean getBoolean(String key) {
@@ -404,22 +400,6 @@ public class Message {
 	
 	public void boostPriority() {
 		priority--;
-	}
-
-	public boolean needsLoadRT() {
-		return needsLoadRT;
-	}
-	
-	public boolean needsLoadBulk() {
-		return needsLoadBulk;
-	}
-	
-	public void setNeedsLoadRT() {
-		needsLoadRT = true;
-	}
-	
-	public void setNeedsLoadBulk() {
-		needsLoadBulk = true;
 	}
 
 	/** Clone the message, clear sub-messages and set originator to self. */

--- a/src/freenet/node/BasePeerNode.java
+++ b/src/freenet/node/BasePeerNode.java
@@ -60,20 +60,6 @@ public interface BasePeerNode extends PeerContext {
 
 	void handleMessage(Message msg);
 
-	/** Make a load stats message.
-	 * @param realtime True for the realtime load stats, false for the bulk load stats.
-	 * @param highPriority If true, boost the priority so it gets sent fast.
-	 * @param noRemember If true, generating it for a lossy message in a packet; don't 
-	 * remember that we sent it, since it might be lost, and generate it even if the last 
-	 * one was the same, since the last one might be delayed. */
-	MessageItem makeLoadStats(boolean realtime, boolean highPriority, boolean noRemember);
-	
-	boolean grabSendLoadStatsASAP(boolean realtime);
-
-	/** Set the load stats to be sent asap. E.g. if we grabbed it and can't actually 
-	 * execute the send for some reason. */
-	void setSendLoadStatsASAP(boolean realtime);
-
 	/** Average ping time incorporating variance, calculated like TCP SRTT, as with RFC 2988. */
 	double averagePingTimeCorrected();
 

--- a/src/freenet/node/MessageItem.java
+++ b/src/freenet/node/MessageItem.java
@@ -26,8 +26,6 @@ public class MessageItem {
 	private final short priority;
 	private long cachedID;
 	private boolean hasCachedID;
-	final boolean sendLoadRT;
-	final boolean sendLoadBulk;
 	private long deadline;
 
 	public MessageItem(Message msg2, AsyncMessageCallback[] cb2, ByteCounter ctr, short overridePriority) {
@@ -40,8 +38,6 @@ public class MessageItem {
 			priority = overridePriority;
 		else
 			priority = msg2.getPriority();
-		this.sendLoadRT = msg2.needsLoadRT();
-		this.sendLoadBulk = msg2.needsLoadBulk();
 		buf = msg.encodeToPacket();
 		if(buf.length > NewPacketFormat.MAX_MESSAGE_SIZE) {
 			// This is bad because fairness between UID's happens at the level of message queueing,
@@ -56,7 +52,7 @@ public class MessageItem {
 		this(msg2, cb2, ctr, (short)-1);
 	}
 
-	public MessageItem(byte[] data, AsyncMessageCallback[] cb2, boolean formatted, ByteCounter ctr, short priority, boolean sendLoadRT, boolean sendLoadBulk) {
+	public MessageItem(byte[] data, AsyncMessageCallback[] cb2, boolean formatted, ByteCounter ctr, short priority) {
 		this.cb = cb2;
 		this.msg = null;
 		this.buf = data;
@@ -66,8 +62,6 @@ public class MessageItem {
 		this.ctrCallback = ctr;
 		this.submitted = System.currentTimeMillis();
 		this.priority = priority;
-		this.sendLoadRT = sendLoadRT;
-		this.sendLoadBulk = sendLoadBulk;
 	}
 
 	/**

--- a/src/freenet/node/NewPacketFormat.java
+++ b/src/freenet/node/NewPacketFormat.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,8 +28,6 @@ import freenet.support.LogThresholdCallback;
 import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
 import freenet.support.SparseBitmap;
-
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class NewPacketFormat implements PacketFormat {
 
@@ -590,69 +590,26 @@ public class NewPacketFormat implements PacketFormat {
 			if(logDEBUG) Logger.debug(this, "Added acks for "+this+" for "+pn.shortToString());
 		}
 		
-		byte[] haveAddedStatsBulk = null;
-		byte[] haveAddedStatsRT = null;
-		
 		if(!ackOnly) {
 			
 			boolean addedFragments = false;
 			
-			while(true) {
-				
-				boolean addStatsBulk = false;
-				boolean addStatsRT = false;
-				
-				synchronized(sendBufferLock) {
-					// Always finish what we have started before considering sending more packets.
-					// Anything beyond this is beyond the scope of NPF and is PeerMessageQueue's job.
-addOldLoop:			for(Map<Integer, MessageWrapper> started : startedByPrio) {
-						//Try to finish messages that have been started
-						Iterator<MessageWrapper> it = started.values().iterator();
-						while(it.hasNext() && packet.getLength() < maxPacketSize) {
-							MessageWrapper wrapper = it.next();
-							while(packet.getLength() < maxPacketSize) {
-								MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
-								if(frag == null) break;
-								mustSend = true;
-								addedFragments = true;
-								packet.addMessageFragment(frag);
-								sentPacket.addFragment(frag);
-								if(wrapper.allSent()) {
-									if((haveAddedStatsBulk == null) && wrapper.getItem().sendLoadBulk) {
-										addStatsBulk = true;
-										// Add the lossy message outside the lock.
-										break addOldLoop;
-									}
-									if((haveAddedStatsRT == null) && wrapper.getItem().sendLoadRT) {
-										addStatsRT = true;
-										// Add the lossy message outside the lock.
-										break addOldLoop;
-									}
-								}
-							}
+			synchronized(sendBufferLock) {
+				// Always finish what we have started before considering sending more packets.
+				// Anything beyond this is beyond the scope of NPF and is PeerMessageQueue's job.
+				for (Map<Integer, MessageWrapper> started : startedByPrio) {
+					//Try to finish messages that have been started
+					Iterator<MessageWrapper> it = started.values().iterator();
+					while (it.hasNext() && packet.getLength() < maxPacketSize) {
+						MessageWrapper wrapper = it.next();
+						while (packet.getLength() < maxPacketSize) {
+							MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
+							if (frag == null) break;
+							mustSend = true;
+							addedFragments = true;
+							packet.addMessageFragment(frag);
+							sentPacket.addFragment(frag);
 						}
-					}
-				}
-				
-				if(!(addStatsBulk || addStatsRT)) break;
-				
-				if(addStatsBulk) {
-					MessageItem item = pn.makeLoadStats(false, false, true);
-					if(item != null) {
-						byte[] buf = item.getData();
-						haveAddedStatsBulk = buf;
-						// FIXME if this fails, drop some messages.
-						packet.addLossyMessage(buf, maxPacketSize);
-					}
-				}
-				
-				if(addStatsRT) {
-					MessageItem item = pn.makeLoadStats(true, false, true);
-					if(item != null) {
-						byte[] buf = item.getData();
-						haveAddedStatsRT = buf;
-						// FIXME if this fails, drop some messages.
-						packet.addLossyMessage(buf, maxPacketSize);
 					}
 				}
 			}
@@ -720,164 +677,78 @@ addOldLoop:			for(Map<Integer, MessageWrapper> started : startedByPrio) {
 			return null;
 		}
 		
-		boolean sendStatsBulk = false, sendStatsRT = false;
-		
-		if(!ackOnly) {
-			
-			sendStatsBulk = pn.grabSendLoadStatsASAP(false);
-			sendStatsRT = pn.grabSendLoadStatsASAP(true);
-			
-			if(sendStatsBulk || sendStatsRT) {
-				if(!checkedCanSend)
-					cantSend = !canSend(sessionKey);
-				checkedCanSend = true;
-				if(cantSend) {
-					if(sendStatsBulk)
-						pn.setSendLoadStatsASAP(false);
-					if(sendStatsRT)
-						pn.setSendLoadStatsASAP(true);
-				} else {
-					mustSend = true;
-				}
-			}
-		}
-		
 		if(ackOnly && numAcks == 0) return null;
 		
 		if((!ackOnly) && (!cantSend)) {
-			
-			if(sendStatsBulk) {
-				MessageItem item = pn.makeLoadStats(false, true, false);
-				if(item != null) {
-					if(haveAddedStatsBulk != null) {
-						packet.removeLossyMessage(haveAddedStatsBulk);
-					}
-					messageQueue.pushfrontPrioritizedMessageItem(item);
-					haveAddedStatsBulk = item.buf;
-				}
-			}
-			
-			if(sendStatsRT) {
-				MessageItem item = pn.makeLoadStats(true, true, false);
-				if(item != null) {
-					if(haveAddedStatsRT != null) {
-						packet.removeLossyMessage(haveAddedStatsRT);
-					}
-					messageQueue.pushfrontPrioritizedMessageItem(item);
-					haveAddedStatsRT = item.buf;
-				}
-			}
-			
+
 			fragments:
 				for(int i = 0; i < startedByPrio.size(); i++) {
+					//Add messages from the message queue
+					while ((packet.getLength() + 10) < maxPacketSize) { //Fragment header is max 9 bytes, allow min 1 byte data
 
-					prio:
-					while(true) {
-						
-						boolean addStatsBulk = false;
-						boolean addStatsRT = false;
-						
-						//Add messages from the message queue
-						while ((packet.getLength() + 10) < maxPacketSize) { //Fragment header is max 9 bytes, allow min 1 byte data
-							
-							if(!checkedCanSend) {
-								// Check in advance to avoid reordering message items.
-								cantSend = !canSend(sessionKey);
-							}
-							checkedCanSend = false;
-							if(cantSend) break;
-							boolean wasGeneratedPing = false;
-							
-							MessageItem item = messageQueue.grabQueuedMessageItem(i);
-							if(item == null) {
-								if(mustSendKeepalive && packet.noFragments()) {
-									// Create a ping for keepalive purposes.
-									// It will be acked, this ensures both sides don't timeout.
-									Message msg;
-									synchronized(this) {
-										msg = DMT.createFNPPing(pingCounter++);
-									}
-									item = new MessageItem(msg, null, null);
-									item.setDeadline(now + PacketSender.MAX_COALESCING_DELAY);
-									wasGeneratedPing = true;
-									// Should we report this on the PeerNode's stats? We'd need to run a job off-thread, so probably not worth it.
-								} else {
-									break prio;
+						if (!checkedCanSend) {
+							// Check in advance to avoid reordering message items.
+							cantSend = !canSend(sessionKey);
+						}
+						checkedCanSend = false;
+						if (cantSend) break;
+						boolean wasGeneratedPing = false;
+
+						MessageItem item = messageQueue.grabQueuedMessageItem(i);
+						if (item == null) {
+							if (mustSendKeepalive && packet.noFragments()) {
+								// Create a ping for keepalive purposes.
+								// It will be acked, this ensures both sides don't timeout.
+								Message msg;
+								synchronized (this) {
+									msg = DMT.createFNPPing(pingCounter++);
 								}
+								item = new MessageItem(msg, null, null);
+								item.setDeadline(now + PacketSender.MAX_COALESCING_DELAY);
+								wasGeneratedPing = true;
+								// Should we report this on the PeerNode's stats? We'd need to run a job off-thread, so probably not worth it.
+							} else {
+								break;
 							}
-							
-							int messageID = getMessageID();
-							if(messageID == -1) {
-								// CONCURRENCY: This will fail sometimes if we send messages to the same peer from different threads.
-								// This doesn't happen at the moment because we use a single PacketSender for all ports and all peers.
-								// We might in future split it across multiple threads but it'd be best to keep the same peer on the same thread.
-								Logger.error(this, "No availiable message ID, requeuing and sending packet (we already checked didn't we???)");
-								if(!wasGeneratedPing) {
-									messageQueue.pushfrontPrioritizedMessageItem(item);
-									// No point adding to queue if it's just a ping:
-									//  We will try again next time.
-									//  But odds are the connection is broken and the other side isn't responding...
-								}
-								break fragments;
-							}
-							
-							if(logDEBUG) Logger.debug(this, "Allocated "+messageID+" for "+item+" for "+this);
-							
-							MessageWrapper wrapper = new MessageWrapper(item, messageID);
-							MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
-							if(frag == null) {
+						}
+
+						int messageID = getMessageID();
+						if (messageID == -1) {
+							// CONCURRENCY: This will fail sometimes if we send messages to the same peer from different threads.
+							// This doesn't happen at the moment because we use a single PacketSender for all ports and all peers.
+							// We might in future split it across multiple threads but it'd be best to keep the same peer on the same thread.
+							Logger.error(this, "No availiable message ID, requeuing and sending packet (we already checked didn't we???)");
+							if (!wasGeneratedPing) {
 								messageQueue.pushfrontPrioritizedMessageItem(item);
-								break prio;
+								// No point adding to queue if it's just a ping:
+								//  We will try again next time.
+								//  But odds are the connection is broken and the other side isn't responding...
 							}
-							packet.addMessageFragment(frag);
-							sentPacket.addFragment(frag);
-							
-							//Priority of the one we grabbed might be higher than i
-							Map<Integer, MessageWrapper> queue = startedByPrio.get(item.getPriority());
-							synchronized(sendBufferLock) {
-								// CONCURRENCY: This could go over the limit if we allow createPacket() for the same node on two threads in parallel. That's probably a bad idea anyway.
-								sendBufferUsed += item.buf.length;
-								if(logDEBUG) Logger.debug(this, "Added " + item.buf.length + " to remote buffer. Total is now " + sendBufferUsed + " for "+pn.shortToString());
-								queue.put(messageID, wrapper);
-							}
-							
-							if(wrapper.allSent()) {
-								if((haveAddedStatsBulk == null) && wrapper.getItem().sendLoadBulk) {
-									addStatsBulk = true;
-									break;
-								}
-								if((haveAddedStatsRT == null) && wrapper.getItem().sendLoadRT) {
-									addStatsRT = true;
-									break;
-								}
-							}
+							break fragments;
+						}
 
+						if (logDEBUG)
+							Logger.debug(this, "Allocated " + messageID + " for " + item + " for " + this);
+
+						MessageWrapper wrapper = new MessageWrapper(item, messageID);
+						MessageFragment frag = wrapper.getMessageFragment(maxPacketSize - packet.getLength());
+						if (frag == null) {
+							messageQueue.pushfrontPrioritizedMessageItem(item);
+							break;
 						}
-						
-						if(!(addStatsBulk || addStatsRT)) break;
-						
-						if(addStatsBulk) {
-							MessageItem item = pn.makeLoadStats(false, false, true);
-							if(item != null) {
-								byte[] buf = item.getData();
-								haveAddedStatsBulk = item.buf;
-								// FIXME if this fails, drop some messages.
-								packet.addLossyMessage(buf, maxPacketSize);
-							}
+						packet.addMessageFragment(frag);
+						sentPacket.addFragment(frag);
+
+						//Priority of the one we grabbed might be higher than i
+						Map<Integer, MessageWrapper> queue = startedByPrio.get(item.getPriority());
+						synchronized (sendBufferLock) {
+							// CONCURRENCY: This could go over the limit if we allow createPacket() for the same node on two threads in parallel. That's probably a bad idea anyway.
+							sendBufferUsed += item.buf.length;
+							if (logDEBUG)
+								Logger.debug(this, "Added " + item.buf.length + " to remote buffer. Total is now " + sendBufferUsed + " for " + pn.shortToString());
+							queue.put(messageID, wrapper);
 						}
-						
-						if(addStatsRT) {
-							MessageItem item = pn.makeLoadStats(true, false, true);
-							if(item != null) {
-								byte[] buf = item.getData();
-								haveAddedStatsRT = item.buf;
-								// FIXME if this fails, drop some messages.
-								packet.addLossyMessage(buf, maxPacketSize);
-							}
-						}
-						
-						if(cantSend) break;
-					}						
+					}
 				}
 		
 		}

--- a/src/freenet/node/NodeDispatcher.java
+++ b/src/freenet/node/NodeDispatcher.java
@@ -289,9 +289,6 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 	private void rejectRequest(Message m, ByteCounter ctr) {
 		long uid = m.getLong(DMT.UID);
 		Message msg = DMT.createFNPRejectedOverload(uid, true, false, false);
-		// Send the load status anyway, hopefully this is a temporary problem.
-		msg.setNeedsLoadBulk();
-		msg.setNeedsLoadRT();
 		try {
 			m.getSource().sendAsync(msg, null, ctr);
 		} catch (NotConnectedException e) {

--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -1,5 +1,10 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Arrays;
@@ -39,11 +44,6 @@ import freenet.support.math.DecayingKeyspaceAverage;
 import freenet.support.math.RunningAverage;
 import freenet.support.math.TimeDecayingRunningAverage;
 import freenet.support.math.TrivialRunningAverage;
-
-import static java.util.concurrent.TimeUnit.DAYS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /** Node (as opposed to NodeClientCore) level statistics. Includes shouldRejectRequest(), but not limited
  * to stuff required to implement that. */
@@ -1430,15 +1430,6 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		
 		double thisAllocation = getPeerLimit(source, bandwidthAvailableOutputUpperLimit - bandwidthAvailableOutputLowerLimit, input, transfersPerInsert, realTimeFlag, peers, peerRequestsSnapshot.calculateSR(ignoreLocalVsRemoteBandwidthLiability, input));
 		
-		if(SEND_LOAD_STATS_NOTICES && source != null) {
-			// FIXME tell local as well somehow?
-			if(!input) {
-				source.onSetMaxOutputTransfers(realTimeFlag, maxOutputTransfers);
-				source.onSetMaxOutputTransfersPeerLimit(realTimeFlag, maxOutputTransfersPeerLimit);
-			}
-			source.onSetPeerAllocation(input, (int)thisAllocation, transfersPerInsert, maxOutputTransfers, realTimeFlag);
-		}
-		
 		// Ignore the upper limit.
 		// Because we reassignToSelf() in various tricky timeout conditions, it is possible to exceed it.
 		// Even if we do we still need to allow the guaranteed allocation for each peer.
@@ -1516,10 +1507,6 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		return "TooManyTransfers: Fair sharing between peers";
 	}
 
-
-
-	static final boolean SEND_LOAD_STATS_NOTICES = true;
-	
 	/**
 	 * @param source The peer.
 	 * @param totalGuaranteedBandwidth The difference between the upper and lower overall
@@ -3554,10 +3541,6 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 		Arrays.sort(entries);
 		return entries;
-	}
-
-	public PeerLoadStats createPeerLoadStats(PeerNode peer, int transfersPerInsert, boolean realTimeFlag) {
-		return new PeerLoadStats(peer, transfersPerInsert, realTimeFlag);
 	}
 
 	public PeerLoadStats parseLoadStats(PeerNode source, Message m) {

--- a/test/freenet/node/MessageWrapperTest.java
+++ b/test/freenet/node/MessageWrapperTest.java
@@ -1,13 +1,18 @@
 package freenet.node;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
 public class MessageWrapperTest {
 	@Test
 	public void testGetFragment() {
-		MessageItem item = new MessageItem(new byte[1024], null, false, null, (short) 0, false, false);
+		MessageItem item = new MessageItem(new byte[1024], null, false, null, (short) 0);
 		MessageWrapper wrapper = new MessageWrapper(item, 0);
 
 		MessageFragment frag = wrapper.getMessageFragment(128);
@@ -53,7 +58,7 @@ public class MessageWrapperTest {
 	
 	@Test
 	public void testGetFragmentWithLoss() {
-		MessageItem item = new MessageItem(new byte[363], null, false, null, (short) 0, false, false);
+		MessageItem item = new MessageItem(new byte[363], null, false, null, (short) 0);
 		MessageWrapper wrapper = new MessageWrapper(item, 0);
 
 		MessageFragment frag1 = wrapper.getMessageFragment(128);
@@ -107,7 +112,7 @@ public class MessageWrapperTest {
 
 	@Test
 	public void testLost() {
-		MessageItem item = new MessageItem(new byte[363], null, false, null, (short) 0, false, false);
+		MessageItem item = new MessageItem(new byte[363], null, false, null, (short) 0);
 		MessageWrapper wrapper = new MessageWrapper(item, 0);
 
 		MessageFragment frag = wrapper.getMessageFragment(128);

--- a/test/freenet/node/NullBasePeerNode.java
+++ b/test/freenet/node/NullBasePeerNode.java
@@ -9,9 +9,9 @@ import freenet.io.comm.ByteCounter;
 import freenet.io.comm.Message;
 import freenet.io.comm.NotConnectedException;
 import freenet.io.comm.Peer;
+import freenet.io.comm.Peer.LocalAddressException;
 import freenet.io.comm.PeerContext;
 import freenet.io.comm.SocketHandler;
-import freenet.io.comm.Peer.LocalAddressException;
 import freenet.io.xfer.PacketThrottle;
 
 /** Tests can override this to record specific events e.g. rekey */
@@ -220,22 +220,6 @@ public class NullBasePeerNode implements BasePeerNode {
 
 	@Override
 	public void handleMessage(Message msg) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public MessageItem makeLoadStats(boolean realtime, boolean highPriority, boolean lossy) {
-		// Don't send load stats.
-		return null;
-	}
-
-	@Override
-	public boolean grabSendLoadStatsASAP(boolean realtime) {
-		return false;
-	}
-
-	@Override
-	public void setSendLoadStatsASAP(boolean realtime) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/test/freenet/node/PeerMessageQueueTest.java
+++ b/test/freenet/node/PeerMessageQueueTest.java
@@ -3,7 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -22,7 +24,7 @@ public class PeerMessageQueueTest {
 
 		//Constructor might take some time, so grab a range
 		long start = System.currentTimeMillis();
-		MessageItem item = new MessageItem(new byte[1024], null, false, null, (short) 0, false, false);
+		MessageItem item = new MessageItem(new byte[1024], null, false, null, (short) 0);
 		long end = System.currentTimeMillis();
 
 		pmq.queueAndEstimateSize(item, 1024);
@@ -43,7 +45,7 @@ public class PeerMessageQueueTest {
 
 		//Constructor might take some time, so grab a range
 		long start = System.currentTimeMillis();
-		MessageItem itemUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0, false, false);
+		MessageItem itemUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0);
 		long end = System.currentTimeMillis();
 
 		//Sleep for a little while to get a later timeout
@@ -53,7 +55,7 @@ public class PeerMessageQueueTest {
 
 		}
 
-		MessageItem itemNonUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0, false, false);
+		MessageItem itemNonUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0);
 
 		//Queue the least urgent item first to get the wrong order
 		pmq.queueAndEstimateSize(itemNonUrgent, 1024);
@@ -71,7 +73,7 @@ public class PeerMessageQueueTest {
 	public void testGrabQueuedMessageItem() {
 		PeerMessageQueue pmq = new PeerMessageQueue(new DummyRandomSource(1234));
 
-		MessageItem itemUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0, false, false);
+		MessageItem itemUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0);
 
 		//Sleep for a little while to get a later timeout
 		try {
@@ -80,7 +82,7 @@ public class PeerMessageQueueTest {
 
 		}
 
-		MessageItem itemNonUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0, false, false);
+		MessageItem itemNonUrgent = new MessageItem(new byte[1024], null, false, null, (short) 0);
 
 		//Queue the least urgent item first to get the wrong order
 		pmq.queueAndEstimateSize(itemNonUrgent, 1024);


### PR DESCRIPTION
This code was effectively inactive since 2013 (which is when the FIXME in PeerNode.makeLoadStats was added: "re-enable when try NLM again").

Removing the related code not only gets rid of a few hundred lines of code, but also slightly reduces the (huge) number of things PeerNode needs to keep track of and simplifies the NPF logic substantially.

Note: this does not remove receiving of load stats from peer nodes.