### PR TITLE
Improve safety around byte[] handling

### DIFF
--- a/src/freenet/keys/ClientCHK.java
+++ b/src/freenet/keys/ClientCHK.java
@@ -163,9 +163,7 @@ public class ClientCHK extends ClientKey implements Serializable {
 		dos.write(routingKey);
 		dos.write(cryptoKey);
 	}
-    
-	static byte[] lastExtra;
-	
+
 	public byte[] getExtra() {
 		return getExtra(cryptoAlgorithm, compressionAlgorithm, controlDocument);
 	}
@@ -177,32 +175,19 @@ public class ClientCHK extends ClientKey implements Serializable {
 		extra[2] = (byte) (controlDocument ? 2 : 0);
 		extra[3] = (byte) (compressionAlgorithm >> 8);
 		extra[4] = (byte) compressionAlgorithm;
-		byte[] last = lastExtra;
-		// No synchronization required IMHO
-		if(Arrays.equals(last, extra)) return last;
-		assert(extra.length == EXTRA_LENGTH);
-		lastExtra = extra;
 		return extra;
 	}
 	
 	public static byte getCryptoAlgorithmFromExtra(byte[] extra) {
 		return extra[1];
 	}
-	
-	static HashSet<ByteArrayWrapper> standardExtras = new HashSet<ByteArrayWrapper>();
-	static {
-		for(byte cryptoAlgorithm = Key.ALGO_AES_PCFB_256_SHA256; cryptoAlgorithm <= Key.ALGO_AES_CTR_256_SHA256; cryptoAlgorithm++) {
-			for(short compressionAlgorithm = -1; compressionAlgorithm <= (short)(COMPRESSOR_TYPE.countCompressors()); compressionAlgorithm++) {
-				standardExtras.add(new ByteArrayWrapper(getExtra(cryptoAlgorithm, compressionAlgorithm, true)));
-				standardExtras.add(new ByteArrayWrapper(getExtra(cryptoAlgorithm, compressionAlgorithm, false)));
-			}
-		}
-	}
-	
+
+	/**
+	 * @return the provided argument
+	 * @deprecated mutable data cannot safely be interned
+	 */
+	@Deprecated
 	public static byte[] internExtra(byte[] extra) {
-		for(ByteArrayWrapper baw : standardExtras) {
-			if(Arrays.equals(baw.get(), extra)) return baw.get();
-		}
 		return extra;
 	}
 	

--- a/src/freenet/keys/ClientSSK.java
+++ b/src/freenet/keys/ClientSSK.java
@@ -143,11 +143,12 @@ public class ClientSSK extends ClientKey {
 		extra[4] = (byte) KeyBlock.HASH_SHA256;
 		return extra;
 	}
-	
-	static final byte[] STANDARD_EXTRA = getExtraBytes(Key.ALGO_AES_PCFB_256_SHA256);
-	
+
+	/**
+	 * @return the provided argument
+	 * @deprecated mutable data cannot safely be interned
+	 */
 	public static byte[] internExtra(byte[] buf) {
-		if(Arrays.equals(buf, STANDARD_EXTRA)) return STANDARD_EXTRA;
 		return buf;
 	}
 

--- a/src/freenet/keys/FreenetURI.java
+++ b/src/freenet/keys/FreenetURI.java
@@ -223,35 +223,14 @@ public class FreenetURI implements Cloneable, Comparable<FreenetURI>, Serializab
 		this.suggestedEdition = uri.suggestedEdition;
 		if(logDEBUG) Logger.debug(this, "Copied: "+toString()+" from "+uri.toString(), new Exception("debug"));
 	}
-	
-	boolean noCacheURI = false;
-	
-	/** Optimize for memory. */
+
+	/**
+	 * @return this FreenetURI instance
+	 * @deprecated mutable data cannot safely be interned
+	 */
+	@Deprecated
 	public FreenetURI intern() {
-		boolean changedAnything = false;
-		byte[] x = extra;
-		if(keyType.equals("CHK"))
-			x = ClientCHK.internExtra(x);
-		else
-			x = ClientSSK.internExtra(x);
-		if(x != extra) changedAnything = true;
-		String[] newMetaStr = null;
-		if(metaStr != null) {
-			newMetaStr = new String[metaStr.length];
-			for(int i=0;i<metaStr.length;i++) {
-				newMetaStr[i] = metaStr[i].intern();
-				if(metaStr[i] != newMetaStr[i]) changedAnything = true;
-			}
-		}
-		String dn = docName == null ? null : docName.intern();
-		if(dn != docName) changedAnything = true;
-		if(!changedAnything) {
-			noCacheURI = true;
-			return this;
-		}
-		FreenetURI u = new FreenetURI(keyType, dn, newMetaStr, routingKey, cryptoKey, extra, suggestedEdition);
-		u.noCacheURI = true;
-		return u;
+		return this;
 	}
 
 	public FreenetURI(String keyType, String docName) {

--- a/src/freenet/support/ByteArrayWrapper.java
+++ b/src/freenet/support/ByteArrayWrapper.java
@@ -12,31 +12,24 @@ import java.util.Comparator;
  */
 public class ByteArrayWrapper implements Comparable<ByteArrayWrapper> {
 	
-	private final byte[] buf;
-	private int hashCode;
+	private final byte[] data;
+	private final int hashCode;
 	
-	public static final Comparator<ByteArrayWrapper> FAST_COMPARATOR = new Comparator<ByteArrayWrapper>() {
-
-		@Override
-		public int compare(ByteArrayWrapper o1, ByteArrayWrapper o2) {
-			if(o1.hashCode > o2.hashCode) return 1;
-			if(o1.hashCode < o2.hashCode) return -1;
-			return o1.compareTo(o2);
-		}
-		
-	};
+	public static final Comparator<ByteArrayWrapper> FAST_COMPARATOR = Comparator
+			.comparingInt(ByteArrayWrapper::hashCode)
+			.thenComparing(Comparator.naturalOrder());
 	
 	public ByteArrayWrapper(byte[] data) {
-		buf = data;
-		hashCode = Fields.hashCode(buf);
+		this.data = Arrays.copyOf(data, data.length);
+		this.hashCode = Arrays.hashCode(this.data);
 	}
 	
 	@Override
-	public boolean equals(Object o) {
-		if(o instanceof ByteArrayWrapper) {
-			ByteArrayWrapper b = (ByteArrayWrapper) o;
-			if(b.buf == buf) return true;
-			return Arrays.equals(b.buf, buf);
+	public boolean equals(Object other) {
+		if (this == other) return true;
+		if (other instanceof ByteArrayWrapper) {
+			ByteArrayWrapper b = (ByteArrayWrapper) other;
+			return this.hashCode == b.hashCode && Arrays.equals(this.data, b.data);
 		}
 		return false;
 	}
@@ -46,14 +39,15 @@ public class ByteArrayWrapper implements Comparable<ByteArrayWrapper> {
 		return hashCode;
 	}
 	
-	/** DO NOT MODIFY THE RETURNED DATA! */
 	public byte[] get() {
-		return buf;
+		return Arrays.copyOf(data, data.length);
 	}
 
 	@Override
-	public int compareTo(ByteArrayWrapper arg) {
-		if(this == arg) return 0;
-		return Fields.compareBytes(buf, arg.buf);
+	public int compareTo(ByteArrayWrapper other) {
+		if (this == other) {
+			return 0;
+		}
+		return Fields.compareBytes(this.data, other.data);
 	}
 }


### PR DESCRIPTION
Unsafe patterns regarding caching and reuse of mutable values are used throughout fred's code.

This fixes some of the most obvious ones by preventing byte[] instances from being shared.