### PR TITLE
Fix NPE and related issues in bookmark management

### DIFF
--- a/src/freenet/clients/http/staticfiles/themes/winterfacey/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/winterfacey/theme.css
@@ -674,8 +674,18 @@ table tbody tr.priority6:nth-child(2n) {
 /*** Bookmarks ***/
 #bookmarks,
 #bookmarks ul {
-  padding-left: 0;
+  padding: 0 1em;
   list-style-type: none;
+}
+
+#bookmarks .actions {
+  margin-left: .5ex;
+  vertical-align: middle;
+  line-height: 1.5;
+}
+
+#bookmarks .actions a {
+  margin-left: .25em;
 }
 
 #bookmarks table {


### PR DESCRIPTION
Fixes https://freenet.mantishub.io/view.php?id=6142 and https://freenet.mantishub.io/view.php?id=6087.
Additionally visually improves the bookmark management page under the Winterfacey theme that was hardly usable due to lack of indentation.

Before:
![image](https://github.com/user-attachments/assets/3a282782-9fbc-4132-833c-3c5d53d113df)

After:
![image](https://github.com/user-attachments/assets/f3f0f75d-efa9-4c7a-a89e-fb1958016446)
