### PR TITLE
Fix unhandled UnsupportedOperationException in Fallocate

### DIFF
--- a/src/freenet/support/io/Fallocate.java
+++ b/src/freenet/support/io/Fallocate.java
@@ -45,15 +45,21 @@ public final class Fallocate {
     return new Fallocate(channel, getDescriptor(fd), final_filesize);
   }
 
-  public Fallocate fromOffset(long offset) throws IllegalArgumentException {
+  /**
+   * @throws IllegalArgumentException
+   */
+  public Fallocate fromOffset(long offset) {
     if(offset < 0 || offset > final_filesize) throw new IllegalArgumentException();
     this.offset = offset;
     return this;
   }
 
-  // This method only works for Linux, do not use it.
+  /**
+   * This method only works for Linux, do not use it.
+   * @throws UnsupportedOperationException
+   */
   @Deprecated
-  public Fallocate keepSize() throws UnsupportedOperationException {
+  public Fallocate keepSize() {
 	if (!IS_LINUX) {
 	  throw new UnsupportedOperationException("fallocate keep size is not supported on this file system");
 	}
@@ -64,7 +70,7 @@ public final class Fallocate {
   public void execute() throws IOException {
     int errno = 0;
     boolean isUnsupported = false;
-    if (fd != 0) {
+    if (fd > 2) {
       if (IS_LINUX) {
         final int result = FallocateHolder.fallocate(fd, mode, offset, final_filesize-offset);
         errno = result == 0 ? 0 : Native.getLastError();


### PR DESCRIPTION
Sorry, there were some issues that GitHub does not let me to update the branch with changes to GitHub actions, so I recreated #1008. Original indentation style is restored. fd with the value 0 is never actually used. I'm not sure what is unsafe to write a byte at the end of a file on Windows. The data written is not going to be used other than to allocate disk space, and filling the file with random data instead of zeros can shorten SSD life time. I have run this code on Windows.