### PR TITLE
Don't synchronize on the class while writing in FileUtil.fill(...)

### DIFF
--- a/src/freenet/support/io/ZeroInputStream.java
+++ b/src/freenet/support/io/ZeroInputStream.java
@@ -1,7 +1,9 @@
 package freenet.support.io;
 
 import java.io.InputStream;
+import java.util.Arrays;
 
+@Deprecated
 public class ZeroInputStream extends InputStream {
     
     @Override
@@ -16,8 +18,7 @@ public class ZeroInputStream extends InputStream {
     
     @Override
     public int read(byte[] buf, int offset, int length) {
-        for(int i=offset;i<offset+length;i++)
-            buf[i] = 0;
+        Arrays.fill(buf, offset, offset + length, (byte) 0);
         return length;
     }
 


### PR DESCRIPTION
By substituting the CipherInputStream that is used as a random number source by a simple MersenneTwister, we no longer need to synchronize on the FileUtil class for each 32k bytes written. The MersenneTwister itself is sufficiently cheap to create on the fly.