### PR TITLE
Use NIO helpers in FileUtils for copy/move/rename

### DIFF
--- a/src/freenet/client/async/ClientGetter.java
+++ b/src/freenet/client/async/ClientGetter.java
@@ -454,7 +454,7 @@ implements WantsCooldownCallback, FileGetCompletionCallback, Serializable {
 
             // We are still here so it worked.
 
-            if(!FileUtil.renameTo(tempFile, completionFile))
+            if(!FileUtil.moveTo(tempFile, completionFile))
                 throw new FetchException(FetchExceptionMode.BUCKET_ERROR, "Failed to rename from temp file "+tempFile);
 
             // Success!

--- a/src/freenet/client/async/ClientLayerPersister.java
+++ b/src/freenet/client/async/ClientLayerPersister.java
@@ -558,7 +558,7 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     protected void save(boolean shutdown) {
         if(writeToFilename == null) return;
         if(writeToFilename.exists()) {
-            FileUtil.renameTo(writeToFilename, writeToBackupFilename);
+            FileUtil.moveTo(writeToFilename, writeToBackupFilename);
         }
         if(innerSave(shutdown)) {
             if(deleteAfterSuccessfulWrite != null) {

--- a/src/freenet/clients/http/bookmark/BookmarkManager.java
+++ b/src/freenet/clients/http/bookmark/BookmarkManager.java
@@ -373,7 +373,7 @@ public class BookmarkManager implements RequestClient {
 			sfs.writeToBigBuffer(fos);
 			fos.close();
 			fos = null;
-			if(!FileUtil.renameTo(backupBookmarksFile, bookmarksFile))
+			if(!FileUtil.moveTo(backupBookmarksFile, bookmarksFile))
 				Logger.error(this, "Unable to rename " + backupBookmarksFile.toString() + " to " + bookmarksFile.toString());
 		} catch(IOException ioe) {
 			Logger.error(this, "An error has occured saving the bookmark file :" + ioe.getMessage(), ioe);

--- a/src/freenet/config/FilePersistentConfig.java
+++ b/src/freenet/config/FilePersistentConfig.java
@@ -169,7 +169,7 @@ public class FilePersistentConfig extends PersistentConfig {
 			}
 			fos.close();
 			fos = null;
-			FileUtil.renameTo(tempFilename, filename);
+			FileUtil.moveTo(tempFilename, filename);
 		}
 		finally {
 			Closer.close(fos);

--- a/src/freenet/io/AddressTracker.java
+++ b/src/freenet/io/AddressTracker.java
@@ -307,7 +307,7 @@ public class AddressTracker {
 			bw.flush();
 			bw.close();
 			fos = null;
-			FileUtil.renameTo(dataBak, data);
+			FileUtil.moveTo(dataBak, data);
 		} catch (IOException e) {
 			Logger.error(this, "Cannot store packet tracker to disk");
 			return;

--- a/src/freenet/l10n/BaseL10n.java
+++ b/src/freenet/l10n/BaseL10n.java
@@ -433,7 +433,7 @@ public class BaseL10n {
 			fos.close();
 			fos = null;
 
-			FileUtil.renameTo(tempFile, finalFile);
+			FileUtil.moveTo(tempFile, finalFile);
 			Logger.normal(this.getClass(), "Override file saved successfully!");
 		} catch (IOException e) {
 			Logger.error(this.getClass(), "Error while saving the translation override: " + e.getMessage(), e);

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -1158,7 +1158,7 @@ public class Node implements TimeSkewDetectorCallback {
 			fs.writeTo(fos);
 			fos.close();
 			fos = null;
-			FileUtil.renameTo(backup, orig);
+			FileUtil.moveTo(backup, orig);
 		} catch (IOException ioe) {
 			Logger.error(this, "IOE :"+ioe.getMessage(), ioe);
 			return;

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -338,7 +338,7 @@ public class OpennetManager {
 			fs.writeTo(bw);
 
 			bw.close();
-			FileUtil.renameTo(backup, orig);
+			FileUtil.moveTo(backup, orig);
 		} catch (IOException e) {
 			Closer.close(bw);
 			Closer.close(osr);

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1534,14 +1534,14 @@ public class PeerManager {
 							thisFile.delete();
 						} else {
 							if(thisFile.exists()) {
-								FileUtil.renameTo(thisFile, prevFile);
+								FileUtil.moveTo(thisFile, prevFile);
 							}
 						}
 						prevFile = thisFile;
 					}
-					FileUtil.renameTo(f, prevFile);
+					FileUtil.moveTo(f, prevFile);
 				} else {
-					FileUtil.renameTo(f, getBackupFilename(filename, 0));
+					FileUtil.moveTo(f, getBackupFilename(filename, 0));
 				}
 			} catch(IOException e) {
 				try {

--- a/src/freenet/node/Persister.java
+++ b/src/freenet/node/Persister.java
@@ -70,7 +70,7 @@ class Persister implements Runnable {
 			fos = new FileOutputStream(persistTemp);
 			fs.writeToBigBuffer(fos);
 			fos.close();
-			FileUtil.renameTo(persistTemp, persistTarget);
+			FileUtil.moveTo(persistTemp, persistTarget);
 		} catch (FileNotFoundException e) {
 			Logger.error(this, "Could not store throttle data to disk: " + e, e);
 		} catch (IOException e) {

--- a/src/freenet/node/updater/LegacyJarFetcher.java
+++ b/src/freenet/node/updater/LegacyJarFetcher.java
@@ -135,7 +135,7 @@ class LegacyJarFetcher implements ClientGetCallback {
 	@Override
 	public void onSuccess(FetchResult result, ClientGetter state) {
 		result.asBucket().free();
-		if(!FileUtil.renameTo(tempFile, saveTo)) {
+		if(!FileUtil.moveTo(tempFile, saveTo)) {
 			Logger.error(this, "Fetched file but unable to rename temp file "+tempFile+" to "+saveTo+" : UOM FROM OLD NODES WILL NOT WORK!");
 		} else {
 			synchronized(this) {

--- a/src/freenet/node/updater/MainJarUpdater.java
+++ b/src/freenet/node/updater/MainJarUpdater.java
@@ -191,7 +191,7 @@ public class MainJarUpdater extends NodeUpdater implements Deployer {
                 tempFile.delete();
                 return;
             }
-			if(!FileUtil.renameTo(tempFile, filename)) {
+			if(!FileUtil.moveTo(tempFile, filename)) {
 				Logger.error(this, "Unable to rename temp file "+tempFile+" to "+filename);
 				System.err.println("Download of "+filename+" for update failed because cannot rename from "+tempFile);
 				if(cb != null)

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -462,7 +462,7 @@ public class NodeUpdateManager {
 				fos = null;
 				for (int i = 0; i < 10; i++) {
 					// FIXME add a callback in case it's being used on Windows.
-					if (FileUtil.renameTo(temp, directory.file(filename))) {
+					if (FileUtil.moveTo(temp, directory.file(filename))) {
 						System.out.println("Successfully fetched " + filename
 								+ " for version " + Version.buildNumber());
 						break;

--- a/src/freenet/node/updater/UpdateOverMandatoryManager.java
+++ b/src/freenet/node/updater/UpdateOverMandatoryManager.java
@@ -1943,7 +1943,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
 						if(!failed) {
 							// Check the hash.
 							if(MainJarDependenciesChecker.validFile(tmp, expectedHash, size, executable)) {
-								if(FileUtil.renameTo(tmp, saveTo)) {
+								if(FileUtil.moveTo(tmp, saveTo)) {
 									synchronized(UOMDependencyFetcher.this) {
 										if(completed) return;
 										completed = true;

--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -1169,7 +1169,7 @@ public class PluginManager {
 		if (tempPluginFile.length() == 0) {
 			throw new PluginNotFoundException("downloaded zero length file");
 		}
-		if (!FileUtil.renameTo(tempPluginFile, pluginFile)) {
+		if (!FileUtil.moveTo(tempPluginFile, pluginFile)) {
 			Logger.error(this, "could not rename temp file to plugin file");
 			throw new PluginNotFoundException("could not rename temp file to plugin file");
 		}

--- a/src/freenet/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/freenet/store/saltedhash/SaltedHashFreenetStore.java
@@ -1266,7 +1266,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 				raf.close();
 		}
 
-		FileUtil.renameTo(tempConfig, configFile);
+		FileUtil.moveTo(tempConfig, configFile);
 	} catch (IOException ioe) {
 		Logger.error(this, "error writing config file for " + name, ioe);
 	} finally {

--- a/src/freenet/support/FileLoggerHook.java
+++ b/src/freenet/support/FileLoggerHook.java
@@ -452,7 +452,7 @@ public class FileLoggerHook extends LoggerHook implements Closeable {
 	        				"Closing alt on change caught " + e);
 	        	}
 	        	if(previousFile != null && latestFile.exists())
-	        		FileUtil.renameTo(latestFile, previousFile);
+	        		FileUtil.moveTo(latestFile, previousFile);
 	        	latestFile.delete();
 	        	altLogStream = openNewLogFile(latestFile, false);
 	        }
@@ -620,7 +620,7 @@ public class FileLoggerHook extends LoggerHook implements Closeable {
 		long lastStartTime = -1;
 		File oldFile = null;
         if(latestFile.exists())
-        	FileUtil.renameTo(latestFile, previousFile);
+        	FileUtil.moveTo(latestFile, previousFile);
 
 		for(File f: files) {
 			String name = f.getName();
@@ -693,7 +693,7 @@ public class FileLoggerHook extends LoggerHook implements Closeable {
 				if(numericSameDateFilename == null || !numericSameDateFilename.exists()) {
 					if(numericSameDateFilename != null) {
 						System.out.println("Renaming to: "+numericSameDateFilename);
-						FileUtil.renameTo(currentFilename, numericSameDateFilename);
+						FileUtil.moveTo(currentFilename, numericSameDateFilename);
 					}
 					break;
 				}

--- a/src/freenet/support/io/BaseFileBucket.java
+++ b/src/freenet/support/io/BaseFileBucket.java
@@ -248,7 +248,7 @@ public abstract class BaseFileBucket implements RandomAccessBucket {
 			if(renaming) {
 			    // getOutputStream() creates the file as a marker, so DON'T check for its existence, 
 			    // even if createFileOnly() is true.
-			    if(!FileUtil.renameTo(tempfile, file)) {
+			    if(!FileUtil.moveTo(tempfile, file)) {
 			        tempfile.delete();
 			        if(logMINOR)
 			            Logger.minor(this, "Deleted, cannot rename file for "+this);

--- a/src/freenet/support/io/FileUtil.java
+++ b/src/freenet/support/io/FileUtil.java
@@ -19,6 +19,10 @@ import java.lang.reflect.Method;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Random;
@@ -775,22 +779,21 @@ final public class FileUtil {
 		return File.createTempFile(prefix, suffix, directory);
 	}
 
+	/**
+	 * Copies the file from the source to the target location, including its attributes.
+	 *
+	 * @param copyFrom the source filename
+	 * @param copyTo the target filename
+	 * @return whether the file was copied successfully
+	 */
 	public static boolean copyFile(File copyFrom, File copyTo) {
-		copyTo.delete();
-		boolean executable = copyFrom.canExecute();
-		FileBucket outBucket = new FileBucket(copyTo, false, true, false, false);
-		FileBucket inBucket = new FileBucket(copyFrom, true, false, false, false);
 		try {
-			BucketTools.copy(inBucket, outBucket);
-			if(executable) {
-			    if(!(copyTo.setExecutable(true) || copyTo.canExecute())) {
-			        System.err.println("Unable to preserve executable bit when copying "+copyFrom+" to "+copyTo+" - you may need to make it executable!");
-			        // return false; ??? FIXME debatable.
-			    }
-			}
+			Path source = copyFrom.toPath();
+			Path target = copyTo.toPath();
+			Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 			return true;
-		} catch (IOException e) {
-			System.err.println("Unable to copy from "+copyFrom+" to "+copyTo);
+		} catch (IOException | InvalidPathException e) {
+			System.err.println("Unable to copy from " + copyFrom + " to " + copyTo);
 			return false;
 		}
 	}


### PR DESCRIPTION
Copy was implemented through InputStream/OutputStream. The OS will be perfectly capable of doing this, no need to read and write the individual bytes. Use NIO's `Files.copy` to perform the copy instead.

Rename and move had two separate implementations without a compelling difference (apart from `renameTo` being unable to move across filesystem boundaries). Unify the two implementations and use the NIO's `Files.move` to move the file atomically, or if that fails, non-atomically.