### PR TITLE
Remove Logger.OSThread-based PID logging that was always disabled

### DIFF
--- a/src/freenet/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/freenet/clients/fcp/FCPConnectionInputHandler.java
@@ -45,7 +45,6 @@ public class FCPConnectionInputHandler implements Runnable {
 
 	@Override
 	public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
 		try {
 			realRun();
 		} catch (TooLongException e) {

--- a/src/freenet/clients/fcp/FCPConnectionOutputHandler.java
+++ b/src/freenet/clients/fcp/FCPConnectionOutputHandler.java
@@ -46,7 +46,6 @@ public class FCPConnectionOutputHandler implements Runnable {
 	
 	@Override
 	public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
 		try {
 			realRun();
 		} catch (IOException e) {

--- a/src/freenet/clients/fcp/FCPServer.java
+++ b/src/freenet/clients/fcp/FCPServer.java
@@ -192,7 +192,6 @@ public class FCPServer implements Runnable, DownloadCache {
 
 	@Override
 	public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
 		while(true) {
 			try {
 				networkInterface.waitBound();

--- a/src/freenet/clients/http/SimpleToadletServer.java
+++ b/src/freenet/clients/http/SimpleToadletServer.java
@@ -1070,7 +1070,6 @@ public final class SimpleToadletServer implements ToadletContainer, Runnable, Li
 		
 		@Override
 		public void run() {
-		    freenet.support.Logger.OSThread.logPID(this);
 			if(logMINOR) Logger.minor(this, "Handling connection");
 			try {
 				ToadletContextImpl.handle(sock, SimpleToadletServer.this, pageMaker, getUserAlertManager(), bookmarkManager);

--- a/src/freenet/io/NetworkInterface.java
+++ b/src/freenet/io/NetworkInterface.java
@@ -383,7 +383,6 @@ public class NetworkInterface implements Closeable {
 		 */
 		@Override
 		public void run() {
-		    freenet.support.Logger.OSThread.logPID(this);
 			while (!closed) {
 				try {
 					Socket clientSocket = serverSocket.accept();

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -90,7 +90,6 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
     
     @Override
     public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
         try {
             realRun();
         } catch (Throwable t) {
@@ -573,7 +572,6 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
 
         @Override
         public void run() {
-		    freenet.support.Logger.OSThread.logPID(this);
         	if(logMINOR) Logger.minor(this, "Receiving data for "+CHKInsertHandler.this);
         	// Don't log whether the transfer succeeded or failed as the transfer was initiated by the source therefore could be unreliable evidence.
         	br.receive(new BlockReceiverCompletion() {

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -116,7 +116,6 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 		
 		@Override
 		public void run() {
-			freenet.support.Logger.OSThread.logPID(this);
 			try {
 				this.realRun();
 			} catch (Throwable t) {
@@ -395,7 +394,6 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
     
     @Override
     public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
     	origTag.startedSender();
         try {
             routeRequests();
@@ -917,7 +915,6 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 		
 		private void waitForBackgroundTransferCompletions() {
 			try {
-				freenet.support.Logger.OSThread.logPID(this);
 				if(logMINOR) Logger.minor(this, "Waiting for background transfer completions: "+this);
 				
 				// We must presently be at such a stage that no more background transfers will be added.

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -51,7 +51,6 @@ public class DNSRequester implements Runnable {
 
     @Override
     public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
         while(true) {
             try {
                 realRun();

--- a/src/freenet/node/IPDetectorPluginManager.java
+++ b/src/freenet/node/IPDetectorPluginManager.java
@@ -372,7 +372,6 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 		node.getTicker().queueTimedJob(new Runnable() {
 			@Override
 			public void run() {
-				freenet.support.Logger.OSThread.logPID(this);
 				tryMaybeRun();
 			}
 		}, MINUTES.toMillis(1));
@@ -718,7 +717,6 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 
 		@Override
 		public void run() {
-			freenet.support.Logger.OSThread.logPID(this);
 			try {
 				realRun();
 			} catch (Throwable t) {

--- a/src/freenet/node/LocationManager.java
+++ b/src/freenet/node/LocationManager.java
@@ -428,7 +428,6 @@ public class LocationManager implements ByteCounter {
 
         @Override
         public void run() {
-            freenet.support.Logger.OSThread.logPID(this);
 		    Thread.currentThread().setName("SwapRequestSender");
             while(true) {
                 try {
@@ -556,7 +555,6 @@ public class LocationManager implements ByteCounter {
 
         @Override
         public void run() {
-		    freenet.support.Logger.OSThread.logPID(this);
             MessageDigest md = SHA256.getMessageDigest();
 
             boolean reachedEnd = false;
@@ -716,7 +714,6 @@ public class LocationManager implements ByteCounter {
 
         @Override
         public void run() {
-		    freenet.support.Logger.OSThread.logPID(this);
             long uid = r.nextLong();
             if(!lock()) return;
             boolean reachedEnd = false;

--- a/src/freenet/node/LoggingConfigHandler.java
+++ b/src/freenet/node/LoggingConfigHandler.java
@@ -357,7 +357,6 @@ public class LoggingConfigHandler {
 		
 		@Override
 		public void run() {
-		    freenet.support.Logger.OSThread.logPID(this);
 			fileLoggerHook.waitForSwitch();
 			delete(logDir);
 		}

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -3438,7 +3438,6 @@ public class Node implements TimeSkewDetectorCallback {
 
 				@Override
 				public void run() {
-					freenet.support.Logger.OSThread.logPID(this);
 					for(PeerNode pn: peers.myPeers()) {
 						pn.updateVersionRoutablity();
 					}

--- a/src/freenet/node/PacketSender.java
+++ b/src/freenet/node/PacketSender.java
@@ -112,7 +112,6 @@ public class PacketSender implements Runnable {
 	@Override
 	public void run() {
 		if(logMINOR) Logger.minor(this, "In PacketSender.run()");
-		freenet.support.Logger.OSThread.logPID(this);
 
                 schedulePeriodicJob();
 		/*

--- a/src/freenet/node/Persister.java
+++ b/src/freenet/node/Persister.java
@@ -48,7 +48,6 @@ class Persister implements Runnable {
 
 	@Override
 	public void run() {
-		freenet.support.Logger.OSThread.logPID(this);
 		try {
 			persistThrottle();
 		} catch (Throwable t) {

--- a/src/freenet/node/RequestHandler.java
+++ b/src/freenet/node/RequestHandler.java
@@ -102,7 +102,6 @@ public class RequestHandler implements PrioRunnable, ByteCounter, RequestSenderL
 
 	@Override
 	public void run() {
-		freenet.support.Logger.OSThread.logPID(this);
 		try {
 			realRun();
 		//The last thing that realRun() does is register as a request-sender listener, so any exception here is the end.

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -228,7 +228,6 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	static final int MAX_HIGH_HTL_FAILURES = 5;
 	
     private void realRun() {
-	    freenet.support.Logger.OSThread.logPID(this);
         if(isSSK && (pubKey == null)) {
         	pubKey = ((NodeSSK)key).getPubKey();
         }

--- a/src/freenet/node/RequestStarter.java
+++ b/src/freenet/node/RequestStarter.java
@@ -226,7 +226,6 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 
 	@Override
 	public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
             while(true) {
                 try {
                     realRun();
@@ -248,7 +247,6 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 
 		@Override
 		public void run() {
-		    freenet.support.Logger.OSThread.logPID(this);
 		    // FIXME ? key is not known for inserts here
 		    if (key != null)
 		    	stats.reportOutgoingLocalRequestLocation(key.toNormalizedDouble());

--- a/src/freenet/node/SSKInsertHandler.java
+++ b/src/freenet/node/SSKInsertHandler.java
@@ -81,7 +81,6 @@ public class SSKInsertHandler implements PrioRunnable, ByteCounter {
     
     @Override
     public void run() {
-        freenet.support.Logger.OSThread.logPID(this);
         try {
             realRun();
         } catch (Throwable t) {

--- a/src/freenet/node/SSKInsertSender.java
+++ b/src/freenet/node/SSKInsertSender.java
@@ -107,7 +107,6 @@ public class SSKInsertSender extends BaseSender implements PrioRunnable, AnyInse
     
 	@Override
 	public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
         origTag.startedSender();
         try {
             routeRequests();

--- a/src/freenet/node/TextModeClientInterface.java
+++ b/src/freenet/node/TextModeClientInterface.java
@@ -116,7 +116,6 @@ public class TextModeClientInterface implements Runnable {
 
     @Override
     public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
     	try {
     		realRun();
     	} catch (IOException e) {
@@ -426,7 +425,6 @@ public class TextModeClientInterface implements Runnable {
     	n.getTicker().queueTimedJob(new Runnable() {
     		@Override
     		public void run() {
-    		    freenet.support.Logger.OSThread.logPID(this);
     			n.getNodeUpdater().arm();
     		}
     	}, 0);

--- a/src/freenet/node/TextModeClientInterfaceServer.java
+++ b/src/freenet/node/TextModeClientInterfaceServer.java
@@ -267,7 +267,6 @@ public class TextModeClientInterfaceServer implements Runnable {
      */
     @Override
     public void run() {
-	    freenet.support.Logger.OSThread.logPID(this);
     	while(true) {
     		int curPort = port;
     		String tempBindTo = this.bindTo;

--- a/src/freenet/support/Logger.java
+++ b/src/freenet/support/Logger.java
@@ -1,204 +1,73 @@
 package freenet.support;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.nio.charset.StandardCharsets;
-import java.util.regex.PatternSyntaxException;
 
 import freenet.support.FileLoggerHook.IntervalParseException;
 import freenet.support.LoggerHook.InvalidThresholdException;
-import freenet.support.io.Closer;
 
 /**
  * @author Iakin
 
 */
 public abstract class Logger {
+	@Deprecated
 	public final static class OSThread {
-		
-		private static boolean getPIDEnabled = false;
-		private static boolean getPPIDEnabled = false;
-		private static boolean logToFileEnabled = false;
-		private static LogLevel logToFileVerbosity = LogLevel.DEBUG;
-		private static boolean logToStdOutEnabled = false;
-		private static boolean procSelfStatEnabled = false;
-	
 		/**
-		 * Get the thread's process ID or return -1 if it's unavailable for some reason
+		 * @deprecated always returns -1
 		 */
-		public synchronized static int getPID(Object o) {
-			if (!getPIDEnabled) {
-				return -1;
-			}
-			return getPIDFromProcSelfStat(o);
+		@Deprecated
+		public static int getPID(Object o) {
+			return -1;
 		}
-	
+
 		/**
-		 * Get the thread's parent process ID or return -1 if it's unavailable for some reason
+		 * @deprecated always returns -1
 		 */
-		public synchronized static int getPPID(Object o) {
-			if (!getPPIDEnabled) {
-				return -1;
-			}
-			return getPPIDFromProcSelfStat(o);
+		@Deprecated
+		public static int getPPID(Object o) {
+			return -1;
 		}
-	
+
 		/**
-		 * Get a specified field from /proc/self/stat or return null if
-		 * it's unavailable for some reason.
+		 * @deprecated always returns null
 		 */
-		public synchronized static String getFieldFromProcSelfStat(int fieldNumber, Object o) {
-			String readLine = null;
-	
-			if (!procSelfStatEnabled) {
-				return null;
-			}
-	
-			// read /proc/self/stat and parse for the specified field
-			InputStream is = null;
-			BufferedReader br = null;
-			File procFile = new File("/proc/self/stat");
-			if (procFile.exists()) {
-				try {
-					is = new FileInputStream(procFile);
-					br = new BufferedReader(new InputStreamReader(is, StandardCharsets.ISO_8859_1 /* ASCII */));
-				} catch (FileNotFoundException e1) {
-					logStatic(o, "'/proc/self/stat' not found", logToFileVerbosity);
-					procSelfStatEnabled = false;
-					br = null;
-				}
-				if (null != br) {
-					try {
-						readLine = br.readLine();
-					} catch (IOException e) {
-						error(o, "Caught IOException in br.readLine() of OSThread.getFieldFromProcSelfStat()", e);
-						readLine = null;
-					} finally {
-						Closer.close(br);
-					}
-					if (null != readLine) {
-						try {
-							String[] procFields = readLine.trim().split(" ");
-							if (4 <= procFields.length) {
-								return procFields[ fieldNumber ];
-							}
-						} catch (PatternSyntaxException e) {
-							error(o, "Caught PatternSyntaxException in readLine.trim().split(\" \") of OSThread.getFieldFromProcSelfStat() while parsing '"+readLine+"'", e);
-						}
-					}
-				} else {
-					Closer.close(is);
-				}
-			}
+		@Deprecated
+		public static String getFieldFromProcSelfStat(int fieldNumber, Object o) {
 			return null;
 		}
-	
+
 		/**
-		 * Get the thread's process ID using the /proc/self/stat method or
-		 * return -1 if it's unavailable for some reason.  This is an ugly
-		 * hack required by Java to get the OS process ID of a thread on
-		 * Linux without using JNI.
+		 * @deprecated always returns -1
 		 */
-		public synchronized static int getPIDFromProcSelfStat(Object o) {
-			int pid = -1;
-	
-			if (!getPIDEnabled) {
-				return -1;
-			}
-			if (!procSelfStatEnabled) {
-				return -1;
-			}
-			String pidString = getFieldFromProcSelfStat(0, o);
-			if (null == pidString) {
-				return -1;
-			}
-			try {
-				pid = Integer.parseInt( pidString.trim() );
-			} catch (NumberFormatException e) {
-				error(o, "Caught NumberFormatException in Integer.parseInt() of OSThread.getPIDFromProcSelfStat() while parsing '"+pidString+"'", e);
-			}
-			return pid;
+		@Deprecated
+		public static int getPIDFromProcSelfStat(Object o) {
+			return -1;
 		}
-	
+
 		/**
-		 * Get the thread's parent process ID using the /proc/self/stat
-		 * method or return -1 if it's unavailable for some reason.  This
-		 * is ugly hack required by Java to get the OS parent process ID of
-		 * a thread on Linux without using JNI.
+		 * @deprecated always returns -1
 		 */
-		public synchronized static int getPPIDFromProcSelfStat(Object o) {
-			int ppid = -1;
-	
-			if (!getPPIDEnabled) {
-				return -1;
-			}
-			if (!procSelfStatEnabled) {
-				return -1;
-			}
-			String ppidString = getFieldFromProcSelfStat(3, o);
-			if (null == ppidString) {
-				return -1;
-			}
-			try {
-				ppid = Integer.parseInt( ppidString.trim() );
-			} catch (NumberFormatException e) {
-				error(o, "Caught NumberFormatException in Integer.parseInt() of OSThread.getPPIDFromProcSelfStat() while parsing '"+ppidString+"'", e);
-			}
-			return ppid;
+		@Deprecated
+		public static int getPPIDFromProcSelfStat(Object o) {
+			return -1;
 		}
-	
+
 		/**
-		 * Log the thread's process ID or return -1 if it's unavailable for some reason
+		 * @deprecated always returns -1
 		 */
-		public synchronized static int logPID(Object o) {
-			if (!getPIDEnabled) {
-				return -1;
-			}
-			int pid = getPID(o);
-			String msg;
-			if (-1 != pid) {
-				msg = "This thread's OS PID is " + pid;
-			} else {
-				msg = "This thread's OS PID could not be determined";
-			}
-			if (logToStdOutEnabled) {
-				System.out.println(msg + ": " + o);
-			}
-			if (logToFileEnabled) {
-				logStatic(o, msg, logToFileVerbosity);
-			}
-			return pid;
+		@Deprecated
+		public static int logPID(Object o) {
+			return -1;
 		}
-	
+
 		/**
-		 * Log the thread's process ID or return -1 if it's unavailable for some reason
+		 * @deprecated always returns -1
 		 */
-		public synchronized static int logPPID(Object o) {
-			if (!getPPIDEnabled) {
-				return -1;
-			}
-			int ppid = getPPID(o);
-			String msg;
-			if (-1 != ppid) {
-				msg = "This thread's OS PPID is " + ppid;
-			} else {
-				msg = "This thread's OS PPID could not be determined";
-			}
-			if (logToStdOutEnabled) {
-				System.out.println(msg + ": " + o);
-			}
-			if (logToFileEnabled) {
-				logStatic(o, msg, logToFileVerbosity);
-			}
-			return ppid;
+		@Deprecated
+		public static int logPPID(Object o) {
+			return -1;
 		}
 	}
 

--- a/src/freenet/support/PrioritizedTicker.java
+++ b/src/freenet/support/PrioritizedTicker.java
@@ -68,7 +68,6 @@ public class PrioritizedTicker implements Ticker, Runnable {
 	@Override
 	public void run() {
 		if(logMINOR) Logger.minor(this, "In Ticker.run()");
-		freenet.support.Logger.OSThread.logPID(this);
 		while(true) {
 			try {
 				realRun();

--- a/src/freenet/support/compress/RealCompressor.java
+++ b/src/freenet/support/compress/RealCompressor.java
@@ -44,7 +44,6 @@ public class RealCompressor {
                     task = executorService.submit(new PrioRunnable() {
                     @Override
                     public void run() {
-                        freenet.support.Logger.OSThread.logPID(this);
                         try {
                             try {
                                 j.tryCompress(context);

--- a/src/freenet/support/transport/ip/IPAddressDetector.java
+++ b/src/freenet/support/transport/ip/IPAddressDetector.java
@@ -279,7 +279,6 @@ public class IPAddressDetector implements Runnable {
 
 	@Override
 	public void run() {
-		freenet.support.Logger.OSThread.logPID(this);
 		while(true) {
 			try {
 				Thread.sleep(interval);


### PR DESCRIPTION
The PID logging is always disabled and there is no API for enabling it. Remove the entire class and all the calls to its logPID method.