### PR TITLE
Refactor TimeUtil: use Java 8 Date-Time API and improve time intervals

### DIFF
--- a/test/freenet/support/TimeUtilTest.java
+++ b/test/freenet/support/TimeUtilTest.java
@@ -218,10 +218,14 @@ public class TimeUtilTest {
 
 	@Test
 	public void testToMillis_unknownFormat() {
-		try {
-			TimeUtil.toMillis("15250284452w3q7h12m55.807s");
-		} catch (NumberFormatException e) {
-				assertNotNull(e);
-		}
+		assertThrows(NumberFormatException.class, () -> TimeUtil.toMillis("15250284452w3q7h12m55.807s"));
+	}
+
+	@Test
+	public void testToMillis_fractionalMillis() {
+		assertEquals(100, TimeUtil.toMillis("0.1s"));
+		assertEquals(10, TimeUtil.toMillis("0.01s"));
+		assertEquals(1, TimeUtil.toMillis("0.001s"));
+		assertEquals(0, TimeUtil.toMillis("0.0001s"));
 	}
 }


### PR DESCRIPTION
The time intervals were subtly broken:
* Parsing 0.1s would yield 1 ms instead of the correct 100 ms. Fix this by parsing the seconds.millis as fractional seconds.
* Formatting would format fractional seconds locale-sensitively where parsing would assume point as a decimal separator, so toMillis(fromMillis(...)) would fail depending on locale. Fix this by always formatting in the root locale (decimal point).

As a tiny bonus, time interval parsing is now approximately 3x faster.