### PR TITLE
Remove dangerous Logger.fatal(...) method

### DIFF
--- a/src/freenet/support/Logger.java
+++ b/src/freenet/support/Logger.java
@@ -619,17 +619,6 @@ public abstract class Logger {
 
 		registerLogThresholdCallback(ltc);
 	}
-	
-	/**
-	 * Report a fatal error and exit.
-	 * @param cause the object or class involved
-	 * @param retcode the return code
-	 * @param message the reason why
-	 */
-	public static void fatal(Object cause, int retcode, String message) {
-		error(cause, message);
-		System.exit(retcode);
-	}
 
 	/** Add a logger hook to the global logger hook chain. Messages which
 	 * are not filtered out by the global logger hook chain's thresholds


### PR DESCRIPTION
No sane logger method has System.exit() as a side effect. Fortunately this log method is never used anywhere in Fred. Let's assume it is not used in plugins either and remove it.