### PR TITLE
Fix NullPointerException when disabling and reenabling SSL

### DIFF
--- a/src/freenet/clients/http/ToadletContextImpl.java
+++ b/src/freenet/clients/http/ToadletContextImpl.java
@@ -440,11 +440,6 @@ public class ToadletContextImpl implements ToadletContext {
 		mvt.put("x-content-security-policy", contentSecurityPolicy);
 		mvt.put("x-webkit-csp", contentSecurityPolicy);
 		mvt.put("x-frame-options", allowFrames ? "SAMEORIGIN" : "DENY");
-		String HSTS = SSL.getHSTSHeader();
-		if(!HSTS.isEmpty() && !mvt.containsKey("strict-transport-security")) {
-			// SSL enabled, set strict-transport-security so that the user agent upgrade future requests to SSL.
-			mvt.put("strict-transport-security", HSTS);
-		}
 		StringBuilder buf = new StringBuilder(1024);
 		buf.append("HTTP/1.1 ");
 		buf.append(replyCode);

--- a/src/freenet/crypt/SSL.java
+++ b/src/freenet/crypt/SSL.java
@@ -86,7 +86,7 @@ public class SSL {
 	}
 
 	public static String getHSTSHeader() {
-		if(available() && HSTSMaxAge > 0)
+		if(enable && available() && HSTSMaxAge > 0)
 			return "max-age=" + HSTSMaxAge;
 		else
 			return "";
@@ -119,11 +119,16 @@ public class SSL {
 							} catch(Exception e) {
 								enable = false;
 								e.printStackTrace(System.out);
+								Logger.error(this, "SSL could not be enabled", e);
 								throwConfigError("SSL could not be enabled", e);
 							}
 						else {
 							ssf = null;
-							keyStore = null;
+							try {
+								keystore.load(null, keyStorePass.toCharArray());
+							} catch (Exception e) {
+								// Just clear the key store
+							}
 						}
 					}
 				}
@@ -147,6 +152,7 @@ public class SSL {
 						} catch(Exception e) {
 							keyStore = oldKeyStore;
 							e.printStackTrace(System.out);
+							Logger.error(this, "Keystore file could not be changed", e);
 							throwConfigError("Keystore file could not be changed", e);
 						}
 					}
@@ -171,6 +177,7 @@ public class SSL {
 						} catch(Exception e) {
 							keyStorePass = oldKeyStorePass;
 							e.printStackTrace(System.out);
+							Logger.error(this, "Keystore password could not be changed", e);
 							throwConfigError("Keystore password could not be changed", e);
 						}
 					}
@@ -198,6 +205,7 @@ public class SSL {
 						} catch(Exception e) {
 							keyPass = oldKeyPass;
 							e.printStackTrace(System.out);
+							Logger.error(this, "Private key password could not be changed", e);
 							throwConfigError("Private key password could not be changed", e);
 						}
 					}


### PR DESCRIPTION
Setting `keyStore` to `null` will result in `NullPointerException` when SSL is reenabled and `loadKeyStoreAndCreateCertificate` is executed. Load a null key store instead.
Avoid adding `strict-transport-security` header twice. The second addition of `strict-transport-security` header does not check whether fproxy SSL is enabled because `container` is not a static member. As a result, `strict-transport-security` header is sent when SSL is enabled but fproxy SSL is disabled.