### PR TITLE
reduce 10% chance for bulk to 2%

### DIFF
--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -852,8 +852,8 @@ public class PeerMessageQueue {
 				>= queuesByPriority[DMT.PRIORITY_REALTIME_DATA].getNextUrgentTime(Long.MAX_VALUE, 0)) {
 			tryRealtimeFirst = true;
 		} else {
-			// 10% chance to use bulk in case of a draw to avoid starving the bulk queue.
-			tryRealtimeFirst = this.fastWeakRandom.nextInt(10) > 0;
+			// 2% chance to use bulk in case of a draw to avoid starving the bulk queue.
+			tryRealtimeFirst = this.fastWeakRandom.nextInt(50) > 0;
 		}
 		
 		


### PR DESCRIPTION
over 5 hops that gives a 10% chance to delay a realtime packet. With 10% that was at 40%, severely impacting the time critical realtime routing.