### PR TITLE
Reduce minimum retransmission timeout (RTO)

### DIFF
--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -3190,7 +3190,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	/** Calculated as per RFC 2988 */
 	@Override
 	public synchronized double averagePingTimeCorrected() {
-		return RTO; 
+		return RTO;
 	}
 
 	@Override


### PR DESCRIPTION
Maximum ping times between Frankfurt consistently stay below 50ms, so since most friend nodes will be in the same country, a minimum RTO of 1 second likely inflated latency unnecessarily.

Lots of old constants …