### PR TITLE
Do not show download to disk for large file page on public gateway

### DIFF
--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -320,11 +320,9 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				        netLevel == NETWORK_THREAT_LEVEL.MAXIMUM))
 				filterChecked = false;
 		}
-		boolean downloadDisabled = !core.isDownloadDisabled()
-			&& (!ctx.getContainer().publicGatewayMode() || ctx.isAllowedFullAccess());
 		//Display FProxy option to download to disk if the user isn't at maximum physical threat level
 		//and hasn't disabled downloading to disk.
-		if (threatLevel != PHYSICAL_THREAT_LEVEL.MAXIMUM && !downloadDisabled) {
+		if (threatLevel != PHYSICAL_THREAT_LEVEL.MAXIMUM && !isDownloadDisabledOrUnsafe(ctx, core)) {
 			HTMLNode option = optionList.addChild("li");
 			HTMLNode optionForm = ctx.addFormChild(option, "/downloads/", "tooBigQueueForm");
 			optionForm.addChild("input",
@@ -414,6 +412,14 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				filterControl.addChild("div", l10n("filterDataMessage"));
 			}
 		}
+	}
+
+	static boolean isDownloadDisabledOrUnsafe(ToadletContext ctx, NodeClientCore core) {
+		return
+			// download is either disabled fully on this node
+			core.isDownloadDisabled()
+			// or we're accessing in public gateway mode and do not have full access
+			|| (ctx.getContainer().publicGatewayMode() && !ctx.isAllowedFullAccess());
 	}
 
 	public static String l10n(String msg) {

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -320,9 +320,11 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				        netLevel == NETWORK_THREAT_LEVEL.MAXIMUM))
 				filterChecked = false;
 		}
+		boolean downloadDisabled = !core.isDownloadDisabled()
+			&& (!ctx.getContainer().publicGatewayMode() || ctx.isAllowedFullAccess());
 		//Display FProxy option to download to disk if the user isn't at maximum physical threat level
 		//and hasn't disabled downloading to disk.
-		if (threatLevel != PHYSICAL_THREAT_LEVEL.MAXIMUM && !core.isDownloadDisabled()) {
+		if (threatLevel != PHYSICAL_THREAT_LEVEL.MAXIMUM && !downloadDisabled) {
 			HTMLNode option = optionList.addChild("li");
 			HTMLNode optionForm = ctx.addFormChild(option, "/downloads/", "tooBigQueueForm");
 			optionForm.addChild("input",

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -381,7 +381,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 		}
 
 		//Display fetch option if not at low physical security or the user has disabled downloading to disk.
-		if (threatLevel != PHYSICAL_THREAT_LEVEL.LOW || core.isDownloadDisabled()) {
+		if (threatLevel != PHYSICAL_THREAT_LEVEL.LOW || isDownloadDisabledOrUnsafe(ctx, core)) {
 			HTMLNode option = optionList.addChild("li");
 			HTMLNode optionForm = ctx.addFormChild(option, "/downloads/", "tooBigQueueForm");
 			optionForm.addChild("input",

--- a/src/freenet/clients/http/QueueToadlet.java
+++ b/src/freenet/clients/http/QueueToadlet.java
@@ -435,7 +435,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				String downloadPath;
 				File downloadsDir = null;
 				//Download to disk disabled and initialized.
-				if (request.isPartSet("path") && !core.isDownloadDisabled()) {
+				if (request.isPartSet("path") && !FProxyToadlet.isDownloadDisabledOrUnsafe(ctx, core)) {
 					downloadPath = request.getPartAsStringFailsafe("path", MAX_FILENAME_LENGTH);
 					try {
 						downloadsDir = getDownloadsDir(downloadPath);
@@ -469,7 +469,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				if(target == null) target = "direct";
 				String downloadPath;
 				File downloadsDir = null;
-				if (request.isPartSet("path") && !core.isDownloadDisabled()) {
+				if (request.isPartSet("path") && !FProxyToadlet.isDownloadDisabledOrUnsafe(ctx, core)) {
 					downloadPath = request.getPartAsStringFailsafe("path", MAX_FILENAME_LENGTH);
 					try {
 						downloadsDir = getDownloadsDir(downloadPath);
@@ -2008,7 +2008,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 		//Force downloading to encrypted space if high/maximum threat level or if the user has disabled
 		//downloading to disk.
 		if(threatLevel == PHYSICAL_THREAT_LEVEL.HIGH || threatLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM ||
-			core.isDownloadDisabled()) {
+			FProxyToadlet.isDownloadDisabledOrUnsafe(ctx, core)) {
 			downloadForm.addChild("input",
 				new String[] { "type", "name", "value" },
 				new String[] { "hidden", "target", "direct" });


### PR DESCRIPTION
This leaked the username — thank you for the report!

Currently there are no known public gateway nodes running, so exposing the fix here is safe.

There may also be leaked IP values that still need to be fixed: patches welcome (to speed this up).