### PR TITLE
Always include the source code in the freenet.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ task compileVersion (type: JavaCompile) {
 task buildJar(type: Jar) {
     dependsOn compileVersion, processResources
     from(processResources)
+    from(sourceSets.main.java)
     from(compileJava.destinationDirectory) {
         exclude 'freenet/node/Version.class'
         exclude 'freenet/node/Version$1.class'


### PR DESCRIPTION
This would enable to switch to AGPL as license which requires providing all who can connect to the node the sources on request. With the sources in freenet.jar, they are automatically offered via UOM, so however users patch their nodes, they are always automatically complying with the license.