### PR TITLE
🐛 Allow Class Loader to Enumerate Directory Entries

### DIFF
--- a/src/freenet/support/JarClassLoader.java
+++ b/src/freenet/support/JarClassLoader.java
@@ -186,7 +186,7 @@ public class JarClassLoader extends ClassLoader implements Closeable {
 				}
 				while ((nextElement == null) && jarFileEntries.hasMoreElements()) {
 					JarEntry jarEntry = jarFileEntries.nextElement();
-					if (jarEntry.getName().equals(name)) {
+					if (jarEntry.getName().equals(name) || jarEntry.getName().equals(name + "/")) {
 						try {
 							nextElement = new URL("jar:" + new File(tempJarFile.getName()).toURI().toURL() + "!/" + name);
 						} catch (MalformedURLException e) {


### PR DESCRIPTION
JAR (ZIP) files are technically not required to have directory entries; it is absolutely fine for a JAR file to only have a `META-INF/MANIFEST.MF` entry, without a corresponding `META-INF` directory entry.

If a JAR file does have separate entries for directories, though, the `getResource()` and `getResources()` methods are expected to return URLs for these entries. Our `JarClassLoader` did not do that.

The problem occured when I was working with Flyway and its classpath scanning: it refused to locate the directory in the classpath that the migration scripts were stored in. After much debugging it was found that the name of the directory is handed in to `getResources()` without a trailing slash, but the `JarClassLoader` uses the `ZipEntry.getName()` method to get the name of the current entry, and that method will return a name ending with “/” if the entry is a directory.

The fix is to check for a name with an appended slash as well.