### PR TITLE
Ask in first time wizard whether to donate disk space

### DIFF
--- a/src/freenet/clients/http/staticfiles/js/firsttimewizard.js
+++ b/src/freenet/clients/http/staticfiles/js/firsttimewizard.js
@@ -166,4 +166,5 @@ function initMonthlyLimit() {
 
 checkChange('knowSomeone', data = {'checked': 'checkDarknet', 'unchecked': 'noDarknet'});
 checkChange('setPassword', data = {'checked': 'givePassword', 'unchecked': ''});
+checkChange('donateDiskSpace', data = {'checked': 'chooseStoreSize', 'unchecked': ''});
 initMonthlyLimit();

--- a/src/freenet/clients/http/staticfiles/js/firsttimewizard.js
+++ b/src/freenet/clients/http/staticfiles/js/firsttimewizard.js
@@ -77,7 +77,7 @@ slideToggler = (function() {
             instance = (new Date).getTime() - init;
             step = start + disp * instance / time;
 
-            if (instance <= time) {
+            if (time > 1 && instance <= time) {
                 el.style.height = step + 'px';
             } else {
                 el.style.cssText = "display: " + (end === 0 ? 'none' : 'block');

--- a/src/freenet/clients/http/staticfiles/themes/winterfacey/script.js
+++ b/src/freenet/clients/http/staticfiles/themes/winterfacey/script.js
@@ -68,9 +68,11 @@ var mobileMenu = function() {
   }
 
   function attach() {
-    navbarDomElement.appendChild(hamburgerContent);
-    hamburgerDomElement = document.getElementById(hamburgerId);
-    customAddEventListener(hamburgerDomElement, 'click', toggleCssClasses);
+    if (navbarDomElement) {
+      navbarDomElement.appendChild(hamburgerContent);
+      hamburgerDomElement = document.getElementById(hamburgerId);
+      customAddEventListener(hamburgerDomElement, 'click', toggleCssClasses);
+    }
   }
 
   function detach() {
@@ -99,7 +101,9 @@ var toggleInnerMenu = function() {
   var notSelectedLinkList = document.querySelectorAll('#navlist > .navlist-not-selected > a');
 
   // add active class for selected element after load page
-  selectedList[0].className += " active";
+  if (selectedList.length > 0) {
+    selectedList[0].className += " active";
+  }
 
   // function toggle (add and remove active class)
   function toggle(selectedItem) {

--- a/src/freenet/clients/http/templates/first-time-wizard.html
+++ b/src/freenet/clients/http/templates/first-time-wizard.html
@@ -81,7 +81,10 @@
         </fieldset>
         <fieldset>
             <legend>{{ l10n("storage") }}</legend>
+            <input id="donateDiskSpace" name="donateDiskSpace" type="checkbox" {{ donateDiskSpace }}>
+            <label for="donateDiskSpace">{{ l10n("donateDiskSpace") }}</label>
             <p>
+              <div id="chooseStoreSize" hidden="hidden">
                 {% if errors.storageLimitError is not null %}
                     <div class="error">{{ errors.storageLimitError }}</div>
                 {% endif %}
@@ -90,6 +93,7 @@
                 <!-- TODO: Possibly attach this number with a slider of percentage of free space. -->
                 <input id="storage" value="{{ storageLimit }}" name="storage" type="number" min="{{ minStorageLimit }}" max="999999999" step=".01">
                 {{ l10n("storageLimitDescription") }}
+              </div>
             </p>
             {% if setPassword is not null %}
             <input id="setPassword" name="setPassword" type="checkbox" {{ setPassword }}>

--- a/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
+++ b/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
@@ -119,6 +119,10 @@ public class DATASTORE_SIZE implements Step {
 		_setDatastoreSize(selectedStoreSize, true, config, callback);
 	}
 
+	public static void setDatastoreSize(String selectedStoreSize, boolean chooseSaltHash, Config config, Object callback) {
+		_setDatastoreSize(selectedStoreSize, chooseSaltHash, config, callback);
+	}
+
 	private static void _setDatastoreSize(
 			String selectedStoreSize,
 			boolean chooseSaltHash,

--- a/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
+++ b/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
@@ -121,7 +121,7 @@ public class DATASTORE_SIZE implements Step {
 
 	private static void _setDatastoreSize(
 			String selectedStoreSize,
-			boolean firsttime,
+			boolean chooseSaltHash,
 			Config config,
 			Object callback) {
 		try {
@@ -154,10 +154,10 @@ public class DATASTORE_SIZE implements Step {
 
 			System.out.println("Setting datastore size to "+Fields.longToString(storeSize, true));
 			config.get("node").set("storeSize", Fields.longToString(storeSize, true));
-			if (firsttime) config.get("node").set("storeType", "salt-hash");
+			if (chooseSaltHash) config.get("node").set("storeType", "salt-hash");
 			System.out.println("Setting client cache size to "+Fields.longToString(clientCacheSize, true));
 			config.get("node").set("clientCacheSize", Fields.longToString(clientCacheSize, true));
-			if (firsttime) config.get("node").set("clientCacheType", "salt-hash");
+			if (chooseSaltHash) config.get("node").set("clientCacheType", "salt-hash");
 			System.out.println("Setting slashdot/ULPR/recent requests cache size to "+Fields.longToString(slashdotCacheSize, true));
 			config.get("node").set("slashdotCacheSize", Fields.longToString(slashdotCacheSize, true));
 

--- a/src/freenet/l10n/freenet.l10n.en.properties
+++ b/src/freenet/l10n/freenet.l10n.en.properties
@@ -562,6 +562,7 @@ FirstTimeWizardToadlet.bandwidthMonthlyNetTransfer=Monthly Net Transfer
 FirstTimeWizardToadlet.bandwidthCouldNotParse=Unable to parse limit "${limit}", please try again.
 FirstTimeWizardToadlet.bandwidthErrorSettingTitle=Error Setting Bandwidth Limit
 FirstTimeWizardToadlet.storage=Storage
+FirstTimeWizardToadlet.donateDiskSpace=Donate disk space to support the network?
 FirstTimeWizardToadlet.storageLimitDescription=GiB of storage space to Freenet.
 FirstTimeWizardToadlet.requirePassword=I want Freenet to require a password when it starts.
 FirstTimeWizardToadlet.password=Password:

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -370,10 +370,21 @@ public class Node implements TimeSkewDetectorCallback {
 				}
 			} else {
 				synchronized(Node.this) {
+					closeAllStores();
 					storeType = val;
 				}
 				throw new NodeNeedRestartException("Store type cannot be changed on the fly");
 			}
+		}
+
+		private void closeAllStores() {
+			// close the old stores so switching back to salt-hash doesn't run into locking trouble
+			closeOldStore(sskDatastore);
+			closeOldStore(pubKeyDatastore);
+			closeOldStore(chkDatastore);
+			closeOldStore(sskDatacache);
+			closeOldStore(pubKeyDatacache);
+			closeOldStore(chkDatacache);
 		}
 
 		@Override
@@ -427,8 +438,10 @@ public class Node implements TimeSkewDetectorCallback {
 						throw new InvalidConfigValueException("Unable to create new store: "+e);
 					}
 				} else if(val.equals("ram")) {
+					closeAllClientCaches();
 					initRAMClientCacheFS();
 				} else /*if(val.equals("none")) */{
+					closeAllClientCaches();
 					initNoClientCacheFS();
 				}
 				
@@ -436,6 +449,13 @@ public class Node implements TimeSkewDetectorCallback {
 					clientCacheType = val;
 				}
 			}
+		}
+
+		private void closeAllClientCaches() {
+			// close the old client caches so switching back to salt-hash doesn't run into locking trouble
+			closeOldStore(sskClientcache);
+			closeOldStore(pubKeyClientcache);
+			closeOldStore(chkClientcache);
 		}
 
 		@Override

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -268,10 +268,21 @@ public class Node implements TimeSkewDetectorCallback {
 
 	public <T extends StorableBlock> void closeOldStore(StoreCallback<T> old) {
 		FreenetStore<T> store = old.getStore();
+		_closeOldStore(store);
+	}
+
+	private static <T extends StorableBlock> void _closeOldStore(FreenetStore<T> store) {
 		if(store instanceof SaltedHashFreenetStore) {
 			SaltedHashFreenetStore<T> saltstore = (SaltedHashFreenetStore<T>) store;
 			saltstore.close();
 			saltstore.destruct();
+		} else if (store instanceof CachingFreenetStore) {
+			store.close();
+			FreenetStore<T> underlyingStore = store.getUnderlyingStore();
+			if (underlyingStore instanceof SaltedHashFreenetStore) {
+				SaltedHashFreenetStore<T> saltStore = (SaltedHashFreenetStore<T>) underlyingStore;
+				saltStore.destruct();
+			}
 		}
 	}
 


### PR DESCRIPTION
I’ve heard the argument "I don’t want stuff stored on my disk" so often now that if "it’s only in memory" suffices it may just be worth to have a checkbox "donate disk space?" and if toggled off use a RAM store and cache.

That may reduce the lifetime of files but if in exchange many more people use the network, that’s a net win.

Since at least half the nodes are only online 2 hours per day, it’s likely that caches already provide most of the data, so the effect of more RAM only nodes shouldn’t be too bad.

Besides adding the checkbox I fixed a nasty locking issue that prevented switching from salt-hash to ram and then back to salt-hash. This didn’t hit earlier, because switching to salt-hash required a node restart which masked the locking issue.

Also toggles in the first time wizard can now actually be instant.