### PR TITLE
Make fproxy cross origin isolated

### DIFF
--- a/src/freenet/clients/http/ToadletContextImpl.java
+++ b/src/freenet/clients/http/ToadletContextImpl.java
@@ -435,6 +435,8 @@ public class ToadletContextImpl implements ToadletContext {
 		} else {
 			mvt.put("connection", "keep-alive");
 		}
+		mvt.put("cross-origin-embedder-policy", "require-corp");
+		mvt.put("cross-origin-opener-policy", "same-origin");
 		String contentSecurityPolicy = generateCSP(allowScripts, allowFrames);
 		mvt.put("content-security-policy", contentSecurityPolicy);
 		mvt.put("x-content-security-policy", contentSecurityPolicy);


### PR DESCRIPTION
Added recommended headers by https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated. This allows freenet tabs to be hosted in separate OS process to mitigate some risks.