### PR TITLE
Add Server-Timing header for performance profiling

### DIFF
--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -305,7 +305,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				overviewList.addChild("li", "backedOffPercent:\u00a0" + fix1.format(backedOffPercent));
 				overviewList.addChild("li", "pInstantReject:\u00a0" + fix1.format(stats.pRejectIncomingInstantly()));
 				nextTableCell = overviewTableRow.addChild("td");
-				
+
+				ctx.reportServerTiming("NodeStatusOverview");
 				// Activity box
 				int numARKFetchers = node.getNumARKFetchers();
 				
@@ -321,6 +322,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				}
 				
 				nextTableCell = overviewTableRow.addChild("td", "class", "last");
+				ctx.reportServerTiming("Activity");
 				
 				// Peer statistics box
 				HTMLNode peerStatsInfobox = nextTableCell.addChild("div", "class", "infobox");
@@ -367,6 +369,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 					if(total > 0)
 						title.addChild("#", ": "+total);
 				}
+				ctx.reportServerTiming("PeerStatistics");
 				// END OVERVIEW TABLE
 			}
 			
@@ -484,6 +487,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				if(peerForm != null) {
 					drawPeerActionSelectBox(peerForm, advancedMode);
 				}
+				ctx.reportServerTiming("PeerTable");
 			}
 			// END PEER TABLE
 
@@ -577,6 +581,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				if (transitiveCount>0) {
 					peerTableInfoboxContent.addChild("i", l10n("secondDegreeAlsoOurs", "count", Integer.toString(transitiveCount)));
 				}
+				ctx.reportServerTiming("FOAFTable");
 			}
 			// END FOAF TABLE
 

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -151,6 +151,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 	}
 
 	private void handleDownload(ToadletContext context, Bucket data, BucketFactory bucketFactory, String mimeType, String requestedMimeType, String forceString, boolean forceDownload, String basePath, FreenetURI key, String extras, String referrer, boolean downloadLink, ToadletContext ctx, NodeClientCore core, boolean dontFreeData, String maybeCharset) throws ToadletContextClosedException, IOException {
+		context.reportServerTiming("handleDownload");
 		if(logMINOR)
 			Logger.minor(FProxyToadlet.class, "handleDownload(data.size="+data.size()+", mimeType="+mimeType+", requestedMimeType="+requestedMimeType+", forceDownload="+forceDownload+", basePath="+basePath+", key="+key);
 		String extrasNoMime = extras; // extras will not include MIME type to start with - REDFLAG maybe it should be an array
@@ -679,6 +680,9 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			} catch (FetchException e) {
             fe = e;
 			}
+
+			ctx.reportServerTiming("FProxyFetchWaiterCreated");
+
 			if(fetch != null)
 			while(true) {
 			fr = fetch.getResult(!canSendProgress);
@@ -699,6 +703,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				}
 
 				if(logMINOR) Logger.minor(this, "Found data");
+				ctx.reportServerTiming("FoundData");
 				data = new NoFreeBucket(fr.data);
 				mimeType = fr.mimeType;
 				fetch.close(); // Not waiting any more, but still locked the results until sent

--- a/src/freenet/clients/http/ToadletContext.java
+++ b/src/freenet/clients/http/ToadletContext.java
@@ -223,5 +223,9 @@ public interface ToadletContext {
 	/** What to do when we find cached data on the global queue but it's already been 
 	 * filtered, and we want a filtered copy. */
 	REFILTER_POLICY getReFilterPolicy();
-}
 
+	/** Report a server timing event has happened.
+	 * @param name name of the metric that is sent to the client, cannot contain "," ";" or space.
+	 */
+	void reportServerTiming(String name);
+}


### PR DESCRIPTION
I wonder why opening http://localhost:8888/strangers/ takes up to 10 seconds and also slows down other freenet network traffic like hitting the brake pedal. The Server-Timing header is integrated into browser's debugging tool, providing an excellent tool to understand performance of each freenet page load.

This header is only enabled for clients with full access to the node.