### PR TITLE
Simplify MultiHashInputStream and MultiHashOutputStream

### DIFF
--- a/src/freenet/crypt/MultiHashDigester.java
+++ b/src/freenet/crypt/MultiHashDigester.java
@@ -2,25 +2,26 @@ package freenet.crypt;
 
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 final class MultiHashDigester {
 
-    private final Digester[] digesters;
+    private final Collection<Digester> digesters;
 
-    private MultiHashDigester(Digester[] digesters) {
+    private MultiHashDigester(Collection<Digester> digesters) {
         this.digesters = digesters;
     }
 
     void update(byte[] input, int offset, int len) {
-        for (Digester digester : digesters) {
-            digester.update(input, offset, len);
-        }
+        digesters.forEach(digester -> digester.update(input, offset, len));
     }
 
-    HashResult[] getResults() {
-        return Arrays.stream(digesters)
+    List<HashResult> getResults() {
+        return digesters.stream()
                 .map(Digester::getResult)
-                .toArray(HashResult[]::new);
+                .collect(Collectors.toList());
     }
 
     /**
@@ -29,10 +30,10 @@ final class MultiHashDigester {
      * @see HashType#bitmask
      */
     static MultiHashDigester fromBitmask(long bitmask) {
-        Digester[] digesters = Arrays.stream(HashType.values())
+        List<Digester> digesters = Arrays.stream(HashType.values())
                 .filter(hashType -> (bitmask & hashType.bitmask) == hashType.bitmask)
                 .map(Digester::new)
-                .toArray(Digester[]::new);
+                .collect(Collectors.toList());
 
         return new MultiHashDigester(digesters);
     }

--- a/src/freenet/crypt/MultiHashDigester.java
+++ b/src/freenet/crypt/MultiHashDigester.java
@@ -1,0 +1,57 @@
+package freenet.crypt;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+final class MultiHashDigester {
+
+    private final Digester[] digesters;
+
+    private MultiHashDigester(Digester[] digesters) {
+        this.digesters = digesters;
+    }
+
+    void update(byte[] input, int offset, int len) {
+        for (Digester digester : digesters) {
+            digester.update(input, offset, len);
+        }
+    }
+
+    HashResult[] getResults() {
+        return Arrays.stream(digesters)
+                .map(Digester::getResult)
+                .toArray(HashResult[]::new);
+    }
+
+    /**
+     * Create a digester for the hash types indicated by the bitmask.
+     *
+     * @see HashType#bitmask
+     */
+    static MultiHashDigester fromBitmask(long bitmask) {
+        Digester[] digesters = Arrays.stream(HashType.values())
+                .filter(hashType -> (bitmask & hashType.bitmask) == hashType.bitmask)
+                .map(Digester::new)
+                .toArray(Digester[]::new);
+
+        return new MultiHashDigester(digesters);
+    }
+
+    private static class Digester {
+        private final HashType hashType;
+        private final MessageDigest digest;
+
+        Digester(HashType hashType) {
+            this.hashType = hashType;
+            digest = hashType.get();
+        }
+
+        HashResult getResult() {
+            return new HashResult(hashType, digest.digest());
+        }
+
+        void update(byte[] input, int offset, int len) {
+            digest.update(input, offset, len);
+        }
+    }
+}

--- a/src/freenet/crypt/MultiHashInputStream.java
+++ b/src/freenet/crypt/MultiHashInputStream.java
@@ -1,64 +1,27 @@
 package freenet.crypt;
 
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 
-import freenet.support.Logger;
+import freenet.support.io.SkipShieldingInputStream;
 
-public class MultiHashInputStream extends FilterInputStream {
+public class MultiHashInputStream extends SkipShieldingInputStream {
 
-	private Digester[] digesters;
+	private final MultiHashDigester digester;
 	private long readBytes;
-	
-	class Digester {
-		HashType hashType;
-		MessageDigest digest;
-
-		Digester(HashType hashType) throws NoSuchAlgorithmException {
-			this.hashType= hashType;
-			digest = hashType.get();
-		}
-
-		HashResult getResult() {
-			HashResult result = new HashResult(hashType, digest.digest());
-			hashType.recycle(digest);
-			digest = null;
-			return result;
-		}
-	}
 
 	public MultiHashInputStream(InputStream proxy, long generateHashes) {
 		super(proxy);
-		ArrayList<Digester> digesters = new ArrayList<Digester>();
-		for(HashType type : HashType.values()) {
-			if((generateHashes & type.bitmask) == type.bitmask) {
-				try {
-					digesters.add(new Digester(type));
-				} catch (NoSuchAlgorithmException e) {
-					Logger.error(this, "Algorithm not available: "+type);
-				}
-			}
-		}
-		this.digesters = digesters.toArray(new Digester[digesters.size()]);
+		this.digester = MultiHashDigester.fromBitmask(generateHashes);
 	}
 	
 	@Override
 	public int read(byte[] buf, int off, int len) throws IOException {
 		int ret = in.read(buf, off, len);
 		if(ret <= 0) return ret;
-		for(Digester d : digesters)
-			d.digest.update(buf, off, ret);
+		digester.update(buf, off, ret);
 		readBytes += ret;
 		return ret;
-	}
-
-	@Override
-	public int read(byte[] buf) throws IOException {
-		return read(buf, 0, buf.length);
 	}
 
 	/** Slow, you should buffer the stream to avoid this! */
@@ -67,23 +30,9 @@ public class MultiHashInputStream extends FilterInputStream {
 		int ret = in.read();
 		if(ret < 0) return ret;
 		byte[] b = new byte[] { (byte)ret };
-		for(Digester d : digesters)
-			d.digest.update(b, 0, 1);
+		digester.update(b, 0, 1);
 		readBytes++;
 		return ret;
-	}
-
-	@Override
-	public long skip(long length) throws IOException {
-		byte[] buf = new byte[(int)Math.min(32768, length)];
-		long skipped = 0;
-		while(length > 0) {
-			int x = read(buf, 0, (int)Math.min(buf.length, length));
-			if(x == -1) return skipped;
-			skipped += x;
-			length -= x;
-		}
-		return skipped;
 	}
 
 	@Override
@@ -101,11 +50,7 @@ public class MultiHashInputStream extends FilterInputStream {
 	}
 
 	public HashResult[] getResults() {
-		HashResult[] results = new HashResult[digesters.length];
-		for(int i=0;i<digesters.length;i++)
-			results[i] = digesters[i].getResult();
-		digesters = null;
-		return results;
+		return digester.getResults();
 	}
 	
 	public long getReadBytes() {

--- a/src/freenet/crypt/MultiHashInputStream.java
+++ b/src/freenet/crypt/MultiHashInputStream.java
@@ -50,7 +50,7 @@ public class MultiHashInputStream extends SkipShieldingInputStream {
 	}
 
 	public HashResult[] getResults() {
-		return digester.getResults();
+		return digester.getResults().toArray(new HashResult[0]);
 	}
 	
 	public long getReadBytes() {

--- a/src/freenet/crypt/MultiHashInputStream.java
+++ b/src/freenet/crypt/MultiHashInputStream.java
@@ -11,19 +11,18 @@ import freenet.support.Logger;
 
 public class MultiHashInputStream extends FilterInputStream {
 
-	// Bit flags for generateHashes
 	private Digester[] digesters;
 	private long readBytes;
 	
 	class Digester {
 		HashType hashType;
 		MessageDigest digest;
-		
+
 		Digester(HashType hashType) throws NoSuchAlgorithmException {
 			this.hashType= hashType;
 			digest = hashType.get();
 		}
-		
+
 		HashResult getResult() {
 			HashResult result = new HashResult(hashType, digest.digest());
 			hashType.recycle(digest);
@@ -31,7 +30,7 @@ public class MultiHashInputStream extends FilterInputStream {
 			return result;
 		}
 	}
-	
+
 	public MultiHashInputStream(InputStream proxy, long generateHashes) {
 		super(proxy);
 		ArrayList<Digester> digesters = new ArrayList<Digester>();
@@ -56,7 +55,7 @@ public class MultiHashInputStream extends FilterInputStream {
 		readBytes += ret;
 		return ret;
 	}
-	
+
 	@Override
 	public int read(byte[] buf) throws IOException {
 		return read(buf, 0, buf.length);
@@ -73,7 +72,7 @@ public class MultiHashInputStream extends FilterInputStream {
 		readBytes++;
 		return ret;
 	}
-	
+
 	@Override
 	public long skip(long length) throws IOException {
 		byte[] buf = new byte[(int)Math.min(32768, length)];
@@ -86,7 +85,21 @@ public class MultiHashInputStream extends FilterInputStream {
 		}
 		return skipped;
 	}
-	
+
+	@Override
+	public boolean markSupported() {
+		return false;
+	}
+
+	@Override
+	public void reset() throws IOException {
+		throw new IOException("mark/reset not supported");
+	}
+
+	@Override
+	public void mark(int readlimit) {
+	}
+
 	public HashResult[] getResults() {
 		HashResult[] results = new HashResult[digesters.length];
 		for(int i=0;i<digesters.length;i++)

--- a/src/freenet/crypt/MultiHashOutputStream.java
+++ b/src/freenet/crypt/MultiHashOutputStream.java
@@ -26,6 +26,6 @@ public class MultiHashOutputStream extends FilterOutputStream {
 	}
 	
 	public HashResult[] getResults() {
-		return digester.getResults();
+		return digester.getResults().toArray(new HashResult[0]);
 	}
 }

--- a/src/freenet/crypt/MultiHashOutputStream.java
+++ b/src/freenet/crypt/MultiHashOutputStream.java
@@ -1,76 +1,31 @@
 package freenet.crypt;
 
 import java.io.FilterOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-
-import freenet.support.Logger;
 
 public class MultiHashOutputStream extends FilterOutputStream {
 
-	// Bit flags for generateHashes
-	private Digester[] digesters;
-	
-	class Digester {
-		HashType hashType;
-		MessageDigest digest;
-		
-		Digester(HashType hashType) throws NoSuchAlgorithmException {
-			this.hashType= hashType;
-			digest = hashType.get();
-		}
-		
-		HashResult getResult() {
-			HashResult result = new HashResult(hashType, digest.digest());
-			hashType.recycle(digest);
-			digest = null;
-			return result;
-		}
-	}
+	private final MultiHashDigester digester;
 	
 	public MultiHashOutputStream(OutputStream proxy, long generateHashes) {
 		super(proxy);
-		ArrayList<Digester> digesters = new ArrayList<Digester>();
-		for(HashType type : HashType.values()) {
-			if((generateHashes & type.bitmask) == type.bitmask) {
-				try {
-					digesters.add(new Digester(type));
-				} catch (NoSuchAlgorithmException e) {
-					Logger.error(this, "Algorithm not available: "+type);
-				}
-			}
-		}
-		this.digesters = digesters.toArray(new Digester[digesters.size()]);
+		this.digester = MultiHashDigester.fromBitmask(generateHashes);
 	}
 	
 	@Override
-	public void write(int arg0) throws java.io.IOException {
-		out.write(arg0);
-		for(Digester d : digesters)
-			d.digest.update(new byte[] { (byte)arg0 });
-	}
-
-	@Override
-	public void write(byte[] arg0) throws java.io.IOException {
-		out.write(arg0);
-		for(Digester d : digesters)
-			d.digest.update(arg0);
+	public void write(int b) throws IOException {
+		out.write(b);
+		digester.update(new byte[] { (byte) b }, 0, 1);
 	}
 	
 	@Override
-	public void write(byte[] arg0, int arg1, int arg2) throws java.io.IOException {
-		out.write(arg0, arg1, arg2);
-		for(Digester d : digesters)
-			d.digest.update(arg0, arg1, arg2);
+	public void write(byte[] buf, int off, int len) throws IOException {
+		out.write(buf, off, len);
+		digester.update(buf, off, len);
 	}
 	
 	public HashResult[] getResults() {
-		HashResult[] results = new HashResult[digesters.length];
-		for(int i=0;i<digesters.length;i++)
-			results[i] = digesters[i].getResult();
-		digesters = null;
-		return results;
+		return digester.getResults();
 	}
 }

--- a/test/freenet/crypt/MultiHashDigesterTest.java
+++ b/test/freenet/crypt/MultiHashDigesterTest.java
@@ -3,6 +3,7 @@ package freenet.crypt;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -12,19 +13,19 @@ public class MultiHashDigesterTest {
     public void createFromBitmask() {
         for (HashType hashType : HashType.values()) {
             MultiHashDigester digester = MultiHashDigester.fromBitmask(hashType.bitmask);
-            HashResult[] results = digester.getResults();
+            List<HashResult> results = digester.getResults();
 
-            assertEquals(1, results.length);
-            assertEquals(hashType, results[0].type);
+            assertEquals(1, results.size());
+            assertEquals(hashType, results.get(0).type);
         }
     }
 
     @Test
     public void noHash() {
         MultiHashDigester digester = MultiHashDigester.fromBitmask(0);
-        HashResult[] results = digester.getResults();
+        List<HashResult> results = digester.getResults();
 
-        assertEquals(0, results.length);
+        assertEquals(0, results.size());
     }
 
     @Test
@@ -32,12 +33,12 @@ public class MultiHashDigesterTest {
         MultiHashDigester digester = MultiHashDigester.fromBitmask(
                 HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask
         );
-        HashResult[] results = digester.getResults();
+        List<HashResult> results = digester.getResults();
 
-        assertEquals(3, results.length);
-        assertEquals(HashType.SHA1, results[0].type);
-        assertEquals(HashType.MD5, results[1].type);
-        assertEquals(HashType.SHA256, results[2].type);
+        assertEquals(3, results.size());
+        assertEquals(HashType.SHA1, results.get(0).type);
+        assertEquals(HashType.MD5, results.get(1).type);
+        assertEquals(HashType.SHA256, results.get(2).type);
     }
 
     @Test
@@ -46,10 +47,10 @@ public class MultiHashDigesterTest {
                 HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask
         );
 
-        HashResult[] results = digester.getResults();
-        assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", results[0].hashAsHex());
-        assertEquals("d41d8cd98f00b204e9800998ecf8427e", results[1].hashAsHex());
-        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", results[2].hashAsHex());
+        List<HashResult> results = digester.getResults();
+        assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", results.get(0).hashAsHex());
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", results.get(1).hashAsHex());
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", results.get(2).hashAsHex());
     }
 
     @Test
@@ -59,9 +60,9 @@ public class MultiHashDigesterTest {
         );
         digester.update("$".getBytes(StandardCharsets.UTF_8), 0, 1);
 
-        HashResult[] results = digester.getResults();
-        assertEquals("3cdf2936da2fc556bfa533ab1eb59ce710ac80e5", results[0].hashAsHex());
-        assertEquals("c3e97dd6e97fb5125688c97f36720cbe", results[1].hashAsHex());
-        assertEquals("09fc96082d34c2dfc1295d92073b5ea1dc8ef8da95f14dfded011ffb96d3e54b", results[2].hashAsHex());
+        List<HashResult> results = digester.getResults();
+        assertEquals("3cdf2936da2fc556bfa533ab1eb59ce710ac80e5", results.get(0).hashAsHex());
+        assertEquals("c3e97dd6e97fb5125688c97f36720cbe", results.get(1).hashAsHex());
+        assertEquals("09fc96082d34c2dfc1295d92073b5ea1dc8ef8da95f14dfded011ffb96d3e54b", results.get(2).hashAsHex());
     }
 }

--- a/test/freenet/crypt/MultiHashDigesterTest.java
+++ b/test/freenet/crypt/MultiHashDigesterTest.java
@@ -1,0 +1,67 @@
+package freenet.crypt;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class MultiHashDigesterTest {
+
+    @Test
+    public void createFromBitmask() {
+        for (HashType hashType : HashType.values()) {
+            MultiHashDigester digester = MultiHashDigester.fromBitmask(hashType.bitmask);
+            HashResult[] results = digester.getResults();
+
+            assertEquals(1, results.length);
+            assertEquals(hashType, results[0].type);
+        }
+    }
+
+    @Test
+    public void noHash() {
+        MultiHashDigester digester = MultiHashDigester.fromBitmask(0);
+        HashResult[] results = digester.getResults();
+
+        assertEquals(0, results.length);
+    }
+
+    @Test
+    public void multiHash() {
+        MultiHashDigester digester = MultiHashDigester.fromBitmask(
+                HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask
+        );
+        HashResult[] results = digester.getResults();
+
+        assertEquals(3, results.length);
+        assertEquals(HashType.SHA1, results[0].type);
+        assertEquals(HashType.MD5, results[1].type);
+        assertEquals(HashType.SHA256, results[2].type);
+    }
+
+    @Test
+    public void digestEmpty() {
+        MultiHashDigester digester = MultiHashDigester.fromBitmask(
+                HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask
+        );
+
+        HashResult[] results = digester.getResults();
+        assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", results[0].hashAsHex());
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", results[1].hashAsHex());
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", results[2].hashAsHex());
+    }
+
+    @Test
+    public void updateAndDigest() {
+        MultiHashDigester digester = MultiHashDigester.fromBitmask(
+                HashType.SHA1.bitmask | HashType.MD5.bitmask | HashType.SHA256.bitmask
+        );
+        digester.update("$".getBytes(StandardCharsets.UTF_8), 0, 1);
+
+        HashResult[] results = digester.getResults();
+        assertEquals("3cdf2936da2fc556bfa533ab1eb59ce710ac80e5", results[0].hashAsHex());
+        assertEquals("c3e97dd6e97fb5125688c97f36720cbe", results[1].hashAsHex());
+        assertEquals("09fc96082d34c2dfc1295d92073b5ea1dc8ef8da95f14dfded011ffb96d3e54b", results[2].hashAsHex());
+    }
+}

--- a/test/freenet/crypt/MultiHashInputStreamTest.java
+++ b/test/freenet/crypt/MultiHashInputStreamTest.java
@@ -1,0 +1,41 @@
+package freenet.crypt;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class MultiHashInputStreamTest {
+    private static final byte[] MESSAGE = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    private static final String MESSAGE_MD5 = "65a8e27d8879283831b664bd8b7f0ad4";
+
+    private final ByteArrayInputStream input = new ByteArrayInputStream(MESSAGE);
+    private final MultiHashInputStream hash = new MultiHashInputStream(input, HashType.MD5.bitmask);
+
+    @Test
+    public void read() throws IOException {
+        byte[] buf = new byte[MESSAGE.length];
+        buf[0] = (byte) hash.read();
+        assertEquals(buf.length - 1, hash.read(buf, 1, buf.length - 1));
+        assertEquals(-1, hash.read());
+        assertEquals(MESSAGE.length, hash.getReadBytes());
+        assertArrayEquals(MESSAGE, buf);
+
+        HashResult[] results = hash.getResults();
+        assertEquals(1, results.length);
+        assertEquals(HashType.MD5, results[0].type);
+        assertEquals(MESSAGE_MD5, results[0].hashAsHex());
+    }
+
+    @Test
+    public void markResetNotSupported() {
+        assertFalse(hash.markSupported());
+        assertThrows(IOException.class, hash::reset);
+    }
+}

--- a/test/freenet/crypt/MultiHashOutputStreamTest.java
+++ b/test/freenet/crypt/MultiHashOutputStreamTest.java
@@ -1,0 +1,30 @@
+package freenet.crypt;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class MultiHashOutputStreamTest {
+    private static final byte[] MESSAGE = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    private static final String MESSAGE_MD5 = "65a8e27d8879283831b664bd8b7f0ad4";
+
+    private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private final MultiHashOutputStream hash = new MultiHashOutputStream(output, HashType.MD5.bitmask);
+
+    @Test
+    public void write() throws IOException {
+        hash.write(MESSAGE[0]);
+        hash.write(MESSAGE, 1, MESSAGE.length - 1);
+        assertArrayEquals(MESSAGE, output.toByteArray());
+
+        HashResult[] results = hash.getResults();
+        assertEquals(1, results.length);
+        assertEquals(HashType.MD5, results[0].type);
+        assertEquals(MESSAGE_MD5, results[0].hashAsHex());
+    }
+}


### PR DESCRIPTION
Simplify MultiHashInputStream and MultiHashOutputStream by extracting their common multi-digest hashing code into a separate class.

Additionally, ensure that MultiHashInputStream does not advertise or implement mark/reset support (default delegated to the underlying InputStream by FilterInputStream), as this could lead to digesting the same bytes multiple times.