### PR TITLE
Use JCE AES implementation for AEAD when available

### DIFF
--- a/src/freenet/crypt/AEADInputStream.java
+++ b/src/freenet/crypt/AEADInputStream.java
@@ -7,8 +7,6 @@ import java.io.InputStream;
 
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.crypto.engines.AESEngine;
-import org.bouncycastle.crypto.engines.AESLightEngine;
 import org.bouncycastle.crypto.modes.AEADBlockCipher;
 import org.bouncycastle.crypto.params.AEADParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -190,8 +188,8 @@ public class AEADInputStream extends FilterInputStream {
     }
     
     public static AEADInputStream createAES(InputStream is, byte[] key) throws IOException {
-        AESEngine mainCipher = new AESEngine();
-        AESLightEngine hashCipher = new AESLightEngine();
+        BlockCipher mainCipher = BlockCiphers.aes();
+        BlockCipher hashCipher = BlockCiphers.aes();
         return new AEADInputStream(is, key, hashCipher, mainCipher);
     }
 

--- a/src/freenet/crypt/AEADOutputStream.java
+++ b/src/freenet/crypt/AEADOutputStream.java
@@ -8,8 +8,6 @@ import java.util.Random;
 
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.crypto.engines.AESEngine;
-import org.bouncycastle.crypto.engines.AESLightEngine;
 import org.bouncycastle.crypto.modes.AEADBlockCipher;
 import org.bouncycastle.crypto.params.AEADParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -84,8 +82,8 @@ public class AEADOutputStream extends FilterOutputStream {
     
     /** For unit tests only */
     static AEADOutputStream innerCreateAES(OutputStream os, byte[] key, Random random) throws IOException {
-        AESEngine mainCipher = new AESEngine();
-        AESLightEngine hashCipher = new AESLightEngine();
+        BlockCipher mainCipher = BlockCiphers.aes();
+        BlockCipher hashCipher = BlockCiphers.aes();
         byte[] nonce = new byte[mainCipher.getBlockSize()];
         random.nextBytes(nonce);
         nonce[0] &= 0x7F;

--- a/src/freenet/crypt/BlockCiphers.java
+++ b/src/freenet/crypt/BlockCiphers.java
@@ -1,0 +1,91 @@
+package freenet.crypt;
+
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+import org.bouncycastle.crypto.BlockCipher;
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.DataLengthException;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+class BlockCiphers {
+    private static final boolean USE_JCE_FOR_AES = checkJceSupported("AES", 16, 24, 32);
+
+    static BlockCipher aes() {
+        try {
+            return USE_JCE_FOR_AES ? new JceEcbBlockCipher("AES") : new AESEngine();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    static final class JceEcbBlockCipher implements BlockCipher {
+        private final String algorithm;
+        private final Cipher cipher;
+        private final int blockSize;
+        private final byte[] buf;
+
+        JceEcbBlockCipher(String algorithm) throws NoSuchPaddingException, NoSuchAlgorithmException {
+            this.algorithm = algorithm;
+            this.cipher = Cipher.getInstance(algorithm + "/ECB/NoPadding");
+            this.blockSize = cipher.getBlockSize();
+            this.buf = new byte[blockSize];
+        }
+
+        @Override
+        public void init(boolean forEncryption, CipherParameters params) throws IllegalArgumentException {
+            Key key = new SecretKeySpec(((KeyParameter) params).getKey(), "AES");
+            try {
+                cipher.init(forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE, key);
+            } catch (InvalidKeyException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        @Override
+        public String getAlgorithmName() {
+            return algorithm;
+        }
+
+        @Override
+        public int getBlockSize() {
+            return blockSize;
+        }
+
+        @Override
+        public int processBlock(byte[] in, int inOff, byte[] out, int outOff) throws DataLengthException {
+            try {
+                // BouncyCastle's OCB implementation provides in == out.
+                // Prevent JCE temp buffer allocation by passing buf as out, then copying the bytes.
+                cipher.update(in, inOff, blockSize, buf, 0);
+                System.arraycopy(buf, 0, out, outOff, blockSize);
+                return blockSize;
+            } catch (ShortBufferException e) {
+                throw new DataLengthException(e.getMessage());
+            }
+        }
+
+        @Override
+        public void reset() {
+            Arrays.fill(buf, (byte) 0);
+        }
+    }
+
+    private static boolean checkJceSupported(String algorithm, int... keySizes) {
+        try {
+            for (int keySize : keySizes) {
+                new JceEcbBlockCipher(algorithm).init(false, new KeyParameter(new byte[keySize]));
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/test/freenet/crypt/BlockCiphersTest.java
+++ b/test/freenet/crypt/BlockCiphersTest.java
@@ -1,0 +1,44 @@
+package freenet.crypt;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.BlockCipher;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BlockCiphersTest {
+    private final BlockCipher selected = BlockCiphers.aes();
+
+    @Before
+    public void skipIfJceNotSupported() {
+        Assume.assumeThat(selected, instanceOf(BlockCiphers.JceEcbBlockCipher.class));
+    }
+
+    @Test
+    public void isCompatibleWithBouncyCastle() {
+        BlockCipher bouncyCastle = new AESEngine();
+
+        assertEquals(bouncyCastle.getBlockSize(), selected.getBlockSize());
+        assertEquals(bouncyCastle.getAlgorithmName(), selected.getAlgorithmName());
+
+        KeyParameter key = new KeyParameter(SecureRandom.getSeed(16));
+        bouncyCastle.init(true, key);
+        selected.init(true, key);
+
+        byte[] block = SecureRandom.getSeed(24);
+        byte[] expectedOut = new byte[block.length];
+        byte[] actualOut = new byte[block.length];
+        assertEquals(
+                bouncyCastle.processBlock(block, 0, expectedOut, 0),
+                selected.processBlock(block, 0, actualOut, 0)
+        );
+        assertArrayEquals(expectedOut, actualOut);
+    }
+}


### PR DESCRIPTION
On modern Java, the JCE implementation is about twice as fast as BC.