### PR TITLE
Fix single-byte `read()` in various InputStream implementations

### DIFF
--- a/src/freenet/crypt/AEADInputStream.java
+++ b/src/freenet/crypt/AEADInputStream.java
@@ -48,18 +48,19 @@ public class AEADInputStream extends FilterInputStream {
     public final int getIVSize() {
         return cipher.getUnderlyingCipher().getBlockSize() / 8;
     }
-    
-    private final byte[] onebyte = new byte[1];
-    
+
     private final byte[] excess;
     private int excessEnd;
     private int excessPtr;
     
     @Override
     public int read() throws IOException {
-        int length = read(onebyte);
-        if(length <= 0) return -1;
-        else return onebyte[0];
+        byte[] buf = new byte[1];
+        int length = read(buf, 0, 1);
+        if (length > 0) {
+            return Byte.toUnsignedInt(buf[0]);
+        }
+        return -1;
     }
     
     @Override

--- a/src/freenet/crypt/EncryptedRandomAccessBucket.java
+++ b/src/freenet/crypt/EncryptedRandomAccessBucket.java
@@ -220,12 +220,9 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
             this.cipherWrite = cipher;
         }
         
-        private final byte[] one = new byte[1];
-        
         @Override
         public void write(int x) throws IOException {
-            one[0] = (byte)x;
-            write(one);
+            write(new byte[]{(byte) x}, 0, 1);
         }
         
         @Override
@@ -265,14 +262,15 @@ public class EncryptedRandomAccessBucket implements RandomAccessBucket, Serializ
             super(in);
             this.cipherRead = cipher;
         }
-        
-        private byte[] one = new byte[1];
-        
+
         @Override
         public int read() throws IOException {
-            int readBytes = read(one);
-            if(readBytes <= 0) return readBytes;
-            return one[0] & 0xFF;
+            byte[] buf = new byte[1];
+            int length = read(buf, 0, 1);
+            if (length > 0) {
+                return Byte.toUnsignedInt(buf[0]);
+            }
+            return -1;
         }
         
         @Override

--- a/src/freenet/support/ByteBufferInputStream.java
+++ b/src/freenet/support/ByteBufferInputStream.java
@@ -30,14 +30,21 @@ public class ByteBufferInputStream extends InputStream implements DataInput {
 
 	@Override
 	public int read() throws IOException {
-		try {
-			return buf.get() & Integer.MAX_VALUE;
-		} catch (BufferUnderflowException e) {
-			return -1;
+		byte[] buf = new byte[1];
+		int length = read(buf, 0, 1);
+		if (length > 0) {
+			return Byte.toUnsignedInt(buf[0]);
 		}
+		return -1;
 	}
-	
-	
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		int read = Math.min(len, buf.remaining());
+		buf.get(b, off, read);
+		return read;
+	}
+
 	public int remaining() {
 		return buf.remaining();
 	}

--- a/src/freenet/support/io/PaddedBucket.java
+++ b/src/freenet/support/io/PaddedBucket.java
@@ -164,14 +164,12 @@ public class PaddedBucket implements Bucket, Serializable {
         
         @Override
         public int read() throws IOException {
-            synchronized(PaddedBucket.this) {
-                if(counter >= size) return -1;
+            byte[] buf = new byte[1];
+            int length = read(buf, 0, 1);
+            if (length > 0) {
+                return Byte.toUnsignedInt(buf[0]);
             }
-            int ret = in.read();
-            synchronized(PaddedBucket.this) {
-                counter++;
-            }
-            return ret;
+            return -1;
         }
         
         @Override

--- a/src/freenet/support/io/PaddedRandomAccessBucket.java
+++ b/src/freenet/support/io/PaddedRandomAccessBucket.java
@@ -171,14 +171,12 @@ public class PaddedRandomAccessBucket implements RandomAccessBucket, Serializabl
         
         @Override
         public int read() throws IOException {
-            synchronized(PaddedRandomAccessBucket.this) {
-                if(counter >= size) return -1;
+            byte[] buf = new byte[1];
+            int length = read(buf, 0, 1);
+            if (length > 0) {
+                return Byte.toUnsignedInt(buf[0]);
             }
-            int ret = in.read();
-            synchronized(PaddedRandomAccessBucket.this) {
-                counter++;
-            }
-            return ret;
+            return -1;
         }
         
         @Override

--- a/src/freenet/support/io/RAFInputStream.java
+++ b/src/freenet/support/io/RAFInputStream.java
@@ -9,9 +9,9 @@ import freenet.support.api.RandomAccessBuffer;
 public class RAFInputStream extends InputStream {
     
     private final RandomAccessBuffer underlying;
+    private final long rafLength;
+
     private long rafOffset;
-    private long rafLength;
-    private final byte[] oneByte = new byte[1];
 
     public RAFInputStream(RandomAccessBuffer data, long offset, long size) {
         this.underlying = data;
@@ -21,8 +21,12 @@ public class RAFInputStream extends InputStream {
 
     @Override
     public int read() throws IOException {
-        read(oneByte);
-        return oneByte[0];
+        byte[] buf = new byte[1];
+        int length = read(buf, 0, 1);
+        if (length > 0) {
+            return Byte.toUnsignedInt(buf[0]);
+        }
+        return -1;
     }
     
     @Override


### PR DESCRIPTION
There are multiple places where the read byte is not correctly converted to unsigned int (leading to incorrect data being returned), or where the single-byte `read()` path differs from the multi-byte `read(byte[])` or `read(byte[], int, int)` path.

Additionally, do not fear creating short-lived single-byte buffers - their overhead is minimal and can likely be optimized away to some extent.