### PR TITLE
Return valid length from RandomShortReadInputStream.read

### DIFF
--- a/test/freenet/crypt/RandomShortReadInputStream.java
+++ b/test/freenet/crypt/RandomShortReadInputStream.java
@@ -29,9 +29,9 @@ public class RandomShortReadInputStream extends FilterInputStream {
     public int read(byte[] buf, int offset, int length) throws IOException {
         if(length > 3 && random.nextBoolean()) {
             if(length > 16 && random.nextBoolean()) {
-                length = random.nextInt(16);
+                length = random.nextInt(15) + 1;
             } else {
-                length = random.nextInt(length);
+                length = random.nextInt(length - 1) + 1;
             }
         }
         return in.read(buf, offset, length);


### PR DESCRIPTION
Returning 0 bytes in `InputStream` is only allowed when 0 bytes are requested (by setting the `length` parameter to 0). Otherwise, an `InputStream` is expected to block until at least one byte is available (yielding that byte) or until the end of the stream is reached (returning -1 as the return value).

This class is only used for testing, but still nice to have it conformant.