### PR TITLE
Do not synchronize on Rijndael cipher initialization or use

### DIFF
--- a/src/freenet/crypt/ciphers/Rijndael.java
+++ b/src/freenet/crypt/ciphers/Rijndael.java
@@ -1,17 +1,16 @@
 package freenet.crypt.ciphers;
 
-import java.security.InvalidKeyException;
 import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
 import java.security.Provider;
-
-import javax.crypto.Cipher;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 
 import freenet.crypt.BlockCipher;
 import freenet.crypt.JceLoader;
 import freenet.crypt.UnsupportedCipherException;
 import freenet.support.Logger;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 /*
   This code is part of the Java Adaptive Network Client by Ian Clarke. 
@@ -165,14 +164,14 @@ public class Rijndael implements BlockCipher {
 	}
 
 	@Override
-	public synchronized final void encipher(byte[] block, byte[] result) {
+	public final void encipher(byte[] block, byte[] result) {
 		if(block.length != blocksize/8)
 			throw new IllegalArgumentException();
 		Rijndael_Algorithm.blockEncrypt(block, result, 0, sessionKey, blocksize/8);
 	}
 
 	@Override
-	public synchronized final void decipher(byte[] block, byte[] result) {
+	public final void decipher(byte[] block, byte[] result) {
 		if(block.length != blocksize/8)
 			throw new IllegalArgumentException();
 		Rijndael_Algorithm.blockDecrypt(block, result, 0, sessionKey, blocksize/8);

--- a/src/freenet/crypt/ciphers/Rijndael_Algorithm.java
+++ b/src/freenet/crypt/ciphers/Rijndael_Algorithm.java
@@ -822,18 +822,7 @@ final class Rijndael_Algorithm // implicit no-argument constructor
 	 * @param blockSize  The block size in bytes of this Rijndael.
 	 * @exception  InvalidKeyException  If the key is invalid.
 	 */
-	//TODO: This method doesn't really need synchronization. The only reason
-	//I can see for it to be synchronized is that it will consume 100% CPU (due to
-	//heavy calculations) when called. Probably should be unsynchronized if we
-	//want better support for dual+ CPU machines. /Iakin 2003-10-12
-	//Concur:  the class has no fields which are not final, and does
-	//not reference fields of any other classes.  Control over how
-	//many simultaneous makeKey invocations should be allowed is
-	//a problem the callers should resolve among themselves.
-	//It is a fact that allowing no more than one makeKey on any given
-	//CPU will result in fewer cache misses.  -- ejhuff 2003-10-12
-	static synchronized Object makeKey(byte[] k, int blockSize)
-	throws InvalidKeyException {
+	static Object makeKey(byte[] k, int blockSize) throws InvalidKeyException {
 		if (RDEBUG) trace(IN, "makeKey("+k+", "+blockSize+ ')');
 		if (k == null)
 			throw new InvalidKeyException("Empty key");


### PR DESCRIPTION
The synchronization appears to have been added at some point to limit overall crypto concurrency assuming a single-core processor, but in today's world, we'd rather get rid of such limits.