### PR TITLE
Official plugins visibility adjustment

### DIFF
--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -17,6 +17,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import freenet.client.HighLevelSimpleClient;
 import freenet.l10n.NodeL10n;
@@ -566,8 +567,10 @@ public class PproxyToadlet extends Toadlet {
 		p.addChild("#", l10n("loadOfficialPluginText"));
 		
 		for (Entry<String, List<OfficialPluginDescription>> groupPlugins : availablePlugins.entrySet()) {
-			List<OfficialPluginDescription> notLoadedPlugins = retainOnlySupportedPlugins(
-					getNotLoadedPlugins(pm, groupPlugins.getValue()));
+			List<OfficialPluginDescription> notLoadedPlugins = groupPlugins.getValue().stream()
+					.filter(plugin -> !pm.isPluginLoaded(plugin.name))
+					.filter(plugin -> !plugin.unsupported)
+					.collect(Collectors.toList());
 			if (notLoadedPlugins.isEmpty()) {
 				continue;
 			}
@@ -597,26 +600,6 @@ public class PproxyToadlet extends Toadlet {
 			}
 			option.addChild("#", " - " + pluginDescription.getLocalisedPluginDescription());
 		}
-	}
-
-	private List<OfficialPluginDescription> getNotLoadedPlugins(PluginManager pluginManager, List<OfficialPluginDescription> plugins) {
-		List<OfficialPluginDescription> notLoadedPlugins = new ArrayList<OfficialPluginDescription>();
-		for (OfficialPluginDescription plugin : plugins) {
-			if (!pluginManager.isPluginLoaded(plugin.name)) {
-				notLoadedPlugins.add(plugin);
-			}
-		}
-		return notLoadedPlugins;
-	}
-
-	private List<OfficialPluginDescription> retainOnlySupportedPlugins(List<OfficialPluginDescription> plugins) {
-		List<OfficialPluginDescription> supportedPlugins = new ArrayList<OfficialPluginDescription>();
-		for (OfficialPluginDescription plugin : plugins) {
-			if (!plugin.unsupported) {
-				supportedPlugins.add(plugin);
-			}
-		}
-		return supportedPlugins;
 	}
 
 	private void showUnofficialPluginLoader(ToadletContext toadletContext, HTMLNode contentNode) {

--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -566,7 +566,8 @@ public class PproxyToadlet extends Toadlet {
 		p.addChild("#", l10n("loadOfficialPluginText"));
 		
 		for (Entry<String, List<OfficialPluginDescription>> groupPlugins : availablePlugins.entrySet()) {
-			List<OfficialPluginDescription> notLoadedPlugins = getNotLoadedPlugins(pm, groupPlugins.getValue());
+			List<OfficialPluginDescription> notLoadedPlugins = retainOnlySupportedPlugins(
+					getNotLoadedPlugins(pm, groupPlugins.getValue()));
 			if (notLoadedPlugins.isEmpty()) {
 				continue;
 			}
@@ -579,9 +580,6 @@ public class PproxyToadlet extends Toadlet {
 		HTMLNode pluginGroupNode = addOfficialForm.addChild("div", "class", "plugin-group");
 		pluginGroupNode.addChild("div", "class", "plugin-group-title", l10n("pluginGroupTitle", "pluginGroup", groupPlugins.getKey()));
 		for (OfficialPluginDescription pluginDescription : notLoadedPlugins) {
-			if (pluginDescription.unsupported) {
-				continue;
-			}
 			HTMLNode pluginNode = pluginGroupNode.addChild("div", "class", "plugin");
 			HTMLNode option = pluginNode.addChild("input",
 					new String[] { "type", "name", "value", "id" },
@@ -609,6 +607,16 @@ public class PproxyToadlet extends Toadlet {
 			}
 		}
 		return notLoadedPlugins;
+	}
+
+	private List<OfficialPluginDescription> retainOnlySupportedPlugins(List<OfficialPluginDescription> plugins) {
+		List<OfficialPluginDescription> supportedPlugins = new ArrayList<OfficialPluginDescription>();
+		for (OfficialPluginDescription plugin : plugins) {
+			if (!plugin.unsupported) {
+				supportedPlugins.add(plugin);
+			}
+		}
+		return supportedPlugins;
 	}
 
 	private void showUnofficialPluginLoader(ToadletContext toadletContext, HTMLNode contentNode) {

--- a/src/freenet/pluginmanager/OfficialPlugins.java
+++ b/src/freenet/pluginmanager/OfficialPlugins.java
@@ -46,18 +46,19 @@ public class OfficialPlugins {
 					.advanced();
 			addPlugin("JSTUN")
 					.inGroup("connectivity")
+					.advanced()
 					.essential()
 					.minimumVersion(2)
 					.loadedFrom("CHK@Zgib8xrGxcEuix7AVB4eajton1FpNHbIJeQZgEbHMNU,BQekU261VLSDUBQPOHSMKUF5qxY1v0zjXa33RyoEbYk,AAMC--8/JSTUN.jar");
 			addPlugin("KeyUtils")
 					.inGroup("technical")
 					.minimumVersion(5028)
-					.loadedFrom("CHK@IQs-ssTnVh8ZuvYASea-O78hVA2y81FI7AVf2X5PXJI,J7yf0iM5Q1W4MppL0DlTyeKJMDdVQQiVlUFQAJvUzjs,AAMC--8/KeyUtils.jar")
-					.advanced();
+					.loadedFrom("CHK@IQs-ssTnVh8ZuvYASea-O78hVA2y81FI7AVf2X5PXJI,J7yf0iM5Q1W4MppL0DlTyeKJMDdVQQiVlUFQAJvUzjs,AAMC--8/KeyUtils.jar");
 			addPlugin("KeepAlive")
 					.inGroup("file-transfer")
 					.loadedFrom("CHK@mR-kJQNZYRaMRdO0D36NhLv8WnfF1sqsBe1ixKUg5lo,i-HExcBFiue3u4q5jooqRZUzRBGZJ0DSpd~~1T7fW6Q,AAMC--8/plugin-KeepAlive.jar");
 			addPlugin("MDNSDiscovery")
+					.advanced()
 					.inGroup("connectivity")
 					.minimumVersion(2)
 					.loadedFrom("CHK@wPyhY61bsDM3OW6arFlxYX8~mBKjo~XtOTIAbT0dk88,Vr3MTAzkW5J28SJs2dTxkj6D4GVNm3u8GFsxJgzTL1M,AAIC--8/MDNSDiscovery.jar");
@@ -72,12 +73,14 @@ public class OfficialPlugins {
 					.experimental();
 			addPlugin("ThawIndexBrowser")
 					.inGroup("file-transfer")
+					.advanced()
 					.minimumVersion(6)
 					.usesXml()
 					.loadedFrom("CHK@9bjNQtl7ndPKh~gi4woH0Xvb7uRunJ81deIlXwGE6qg,clwp0Bhx2LZxt2XCWeARqv24tBNmjlhXDZtwAJpzlIc,AAMC--8/ThawIndexBrowser-v6.jar");
 			addPlugin("UPnP")
 					.inGroup("connectivity")
 					.essential()
+					.advanced()
 					.recommendedVersion(10007)
 					.minimumVersion(10003)
 					.loadedFrom("CHK@ZiX8yeMHTUtNfJAgxpwH~jLRnnbb41BKEkAxOD~33tY,aBTvD3IoPKPLjnHOCNQ4-iRwqVED5kHgkmD4UhGdITk,AAMC--8/UPnP-10007.jar");


### PR DESCRIPTION
Make advanced:

- JSTUN contact external server ⇒ needs understanding of effects
- MDNSDiscovery announces in LAN ⇒ need understanding of effects
- ThawIndexBrowser: we have almost no Thaw indexes ⇒ hard to understand
- UPnP: should usually choose UPnP2 instead

Make simple:

- KeyUtils: may be technical, but is pretty easy to use