### PR TITLE
Do not synchronize on global variable in crypt Util.makeKey

### DIFF
--- a/src/freenet/crypt/Util.java
+++ b/src/freenet/crypt/Util.java
@@ -190,9 +190,6 @@ public class Util {
 		return freenet.support.Fields.byteArrayEqual(a, b, offset, offset, length);
 	}
 
-	private static final MessageDigest ctx;
-	private static final int ctx_length;
-
 	public static final Map<String, Provider> mdProviders;
 
 	static private long benchmark(MessageDigest md) throws GeneralSecurityException
@@ -262,9 +259,6 @@ public class Util {
 				mdProviders_internal.put(algo, mdProvider);
 			}
 			mdProviders = Collections.unmodifiableMap(mdProviders_internal);
-
-			ctx = MessageDigest.getInstance("SHA1", mdProviders.get("SHA1"));
-			ctx_length = ctx.getDigestLength();
 		} catch(NoSuchAlgorithmException e) {
 			// impossible
 			throw new Error(e);
@@ -277,8 +271,8 @@ public class Util {
 		int offset,
 		int len) {
 		try {
-		synchronized (ctx) {
-			ctx.digest(); // reinitialize
+			MessageDigest ctx = HashType.SHA1.get();
+			int ctx_length = ctx.getDigestLength();
 
 			int ic = 0;
 			while (len > 0) {
@@ -298,8 +292,7 @@ public class Util {
 				offset += bc;
 				len -= bc;
 			}
-		}
-		Arrays.fill(entropy, (byte) 0);
+			Arrays.fill(entropy, (byte) 0);
 		} catch(DigestException e) {
 			// impossible
 			throw new Error(e);
@@ -355,13 +348,12 @@ public class Util {
 			makeKey(entropy, key, 0, key.length);
 			System.err.println(HexUtil.bytesToHex(key, 0, key.length));
 		} else if (args[0].equals("shatest")) {
-			synchronized (ctx) {
-				ctx.digest();
-				ctx.update((byte) 'a');
-				ctx.update((byte) 'b');
-				ctx.update((byte) 'c');
-				System.err.println(HexUtil.bytesToHex(ctx.digest()));
-			}
+			MessageDigest ctx = HashType.SHA1.get();
+			ctx.digest();
+			ctx.update((byte) 'a');
+			ctx.update((byte) 'b');
+			ctx.update((byte) 'c');
+			System.err.println(HexUtil.bytesToHex(ctx.digest()));
 		}
 	}
 


### PR DESCRIPTION
This method is used by Yarrow (our random number generator) for seeding, which is used in many places. We'd better not have a global bottleneck for its uses.

Instead of sharing a digest globally, just obtain a fresh one when in need.