### PR TITLE
Fix request distribution stats

### DIFF
--- a/src/freenet/clients/http/StatisticsToadlet.java
+++ b/src/freenet/clients/http/StatisticsToadlet.java
@@ -16,15 +16,15 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import freenet.client.async.ClientRequester;
 import freenet.client.HighLevelSimpleClient;
+import freenet.client.async.ClientRequester;
 import freenet.config.SubConfig;
 import freenet.crypt.ciphers.Rijndael;
 import freenet.io.comm.IncomingPacketFilterImpl;
 import freenet.io.xfer.BlockReceiver;
 import freenet.io.xfer.BlockTransmitter;
-import freenet.l10n.NodeL10n;
 import freenet.keys.FreenetURI;
+import freenet.l10n.NodeL10n;
 import freenet.node.Location;
 import freenet.node.Node;
 import freenet.node.NodeClientCore;
@@ -482,9 +482,8 @@ public class StatisticsToadlet extends Toadlet {
 			overviewTableRow = overviewTable.addChild("tr");
 			nextTableCell = overviewTableRow.addChild("td", "class", "first");
 			// specialisation box
-			int[] incomingRequestCountArray = new int[1];
-			int[] incomingRequestLocation = stats.getIncomingRequestLocation(incomingRequestCountArray);
-			int incomingRequestsCount = incomingRequestCountArray[0];
+			int[] incomingRequestLocation = stats.getIncomingRequestLocation();
+			int incomingRequestsCount = Arrays.stream(incomingRequestLocation).sum();
 			
 			if(incomingRequestsCount > 0) {
 				HTMLNode nodeSpecialisationInfobox = nextTableCell.addChild("div", "class", "infobox");
@@ -494,12 +493,10 @@ public class StatisticsToadlet extends Toadlet {
 			}
 			
 			nextTableCell = overviewTableRow.addChild("td");
-			int[] outgoingLocalRequestCountArray = new int[1];
-			int[] outgoingLocalRequestLocation = stats.getOutgoingLocalRequestLocation(outgoingLocalRequestCountArray);
-			int outgoingLocalRequestsCount = outgoingLocalRequestCountArray[0];
-			int[] outgoingRequestCountArray = new int[1];
-			int[] outgoingRequestLocation = stats.getOutgoingRequestLocation(outgoingRequestCountArray);
-			int outgoingRequestsCount = outgoingRequestCountArray[0];
+			int[] outgoingLocalRequestLocation = stats.getOutgoingLocalRequestLocation();
+			int outgoingLocalRequestsCount = Arrays.stream(outgoingLocalRequestLocation).sum();
+			int[] outgoingRequestLocation = stats.getOutgoingRequestLocation();
+			int outgoingRequestsCount = Arrays.stream(outgoingRequestLocation).sum();
 			
 			if(outgoingLocalRequestsCount > 0 && outgoingRequestsCount > 0) {
 				HTMLNode nodeSpecialisationInfobox = nextTableCell.addChild("div", "class", "infobox");


### PR DESCRIPTION
Turns out I broke this 9 years ago, so let's fix it :smile: 
For those who don't have a memory of these statistics panels, it's these two:
![image](https://github.com/user-attachments/assets/ece7fcc1-9dc3-42d7-bed4-e755a1752d4a)


---

The `count` was never incremented, and consequently the Incoming Request Distribution and Outgoing Request Distribution panels would no longer show up on the statistics page.

Instead of keeping track of the total count independent of the bins, just sum the bins when we need a total count for display purposes.

While we're at it, let's get rid of the synchronization too.