### PR TITLE
Fix Translation Handling in Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,11 +202,8 @@ test {
     // no inner class
     include 'freenet/**/*Test.class'
     exclude 'freenet/**/*$*Test.class'
-    workingDir = layout.buildDirectory.dir("classes/java/test/")
     scanForTestClasses = false
     systemProperties += [
-        "test.l10npath_test": "freenet/l10n/",
-        "test.l10npath_main": "../main/freenet/l10n/"
 //	"test.extensive":
 //	"test.verbose":
 //	"test.benchmark":

--- a/src/freenet/client/filter/GenericReadFilterCallback.java
+++ b/src/freenet/client/filter/GenericReadFilterCallback.java
@@ -3,6 +3,7 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.filter;
 
+import freenet.l10n.BaseL10n;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -60,6 +61,8 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 			}
 		});
 	}
+
+	private static BaseL10n l10n = NodeL10n.getBase();
 
 	public GenericReadFilterCallback(URI uri, FoundURICallback cb,TagReplacerCallback trc, LinkFilterExceptionProvider linkFilterExceptionProvider) {
 		this.baseURI = uri;
@@ -303,11 +306,11 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 	}
 
 	private static String l10n(String key, String pattern, String value) {
-		return NodeL10n.getBase().getString("GenericReadFilterCallback."+key, pattern, value);
+		return l10n.getString("GenericReadFilterCallback." + key, pattern, value);
 	}
 
 	private static String l10n(String key) {
-		return NodeL10n.getBase().getString("GenericReadFilterCallback."+key);
+		return l10n.getString("GenericReadFilterCallback." + key);
 	}
 
 	private String finishProcess(HTTPRequest req, String overrideType, String path, URI u, boolean noRelative) {
@@ -487,4 +490,18 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 		if(cb != null)
 			cb.onFinishedPage();
 	}
+
+	/**
+	 * Sets the {@link BaseL10n l10n provider} to use for translating some
+	 * error messages. If this method is not called, {@link NodeL10n}’s
+	 * {@link NodeL10n#getBase() l10n provider} is used.
+	 * <p>
+	 * This method should only be called from tests.
+	 *
+	 * @param l10n The l10n provider to use
+	 */
+	static void setBaseL10n(BaseL10n l10n) {
+		GenericReadFilterCallback.l10n = l10n;
+	}
+
 }

--- a/src/freenet/clients/http/utils/L10nExtension.java
+++ b/src/freenet/clients/http/utils/L10nExtension.java
@@ -1,5 +1,6 @@
 package freenet.clients.http.utils;
 
+import freenet.l10n.BaseL10n;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,18 +10,26 @@ import com.mitchellbosecke.pebble.extension.Function;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 
-import freenet.l10n.NodeL10n;
-
 class L10nExtension extends AbstractExtension {
+
+  public L10nExtension(BaseL10n l10n) {
+    l10nFunction = new L10nFunction(l10n);
+  }
 
   @Override
   public Map<String, Function> getFunctions() {
     Map<String, Function> functions = new HashMap<>();
-    functions.put("l10n", new L10nFunction());
+    functions.put("l10n", l10nFunction);
     return functions;
   }
 
+    private final L10nFunction l10nFunction;
+
     static class L10nFunction implements Function {
+
+		public L10nFunction(BaseL10n l10n) {
+			this.l10n = l10n;
+		}
 
         @Override
         public Object execute(Map<String, Object> args, PebbleTemplate self, EvaluationContext context, int lineNumber) {
@@ -28,12 +37,15 @@ class L10nExtension extends AbstractExtension {
             if (key == null) {
                 return "null";
             }
-            return NodeL10n.getBase().getString(context.getVariable("l10nPrefix") + key.toString());
+            return l10n.getString(context.getVariable("l10nPrefix") + key.toString());
         }
 
         @Override
         public List<String> getArgumentNames() {
             return null;
         }
+
+        private final BaseL10n l10n;
+
     }
 }

--- a/src/freenet/clients/http/utils/PebbleUtils.java
+++ b/src/freenet/clients/http/utils/PebbleUtils.java
@@ -1,5 +1,8 @@
 package freenet.clients.http.utils;
 
+import freenet.clients.http.utils.L10nExtension.L10nFunction;
+import freenet.l10n.BaseL10n;
+import freenet.l10n.NodeL10n;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -22,7 +25,7 @@ public class PebbleUtils {
     loader.setPrefix(PebbleUtils.TEMPLATE_ROOT_PATH);
     loader.setSuffix(PebbleUtils.TEMPLATE_NAME_SUFFIX);
 
-    templateEngine = new PebbleEngine.Builder().loader(loader).extension(new L10nExtension()).build();
+    templateEngine = new PebbleEngine.Builder().loader(loader).extension(new L10nExtension(NodeL10n.getBase())).build();
   }
 
   public static void addChild(
@@ -39,4 +42,20 @@ public class PebbleUtils {
 
     parent.addChild("%", writer.toString());
   }
+
+  /**
+   * Sets the {@link BaseL10n l10n provider} to use with the
+   * {@link L10nFunction}. If this method is not called, {@link NodeL10n}’s
+   * {@link NodeL10n#getBase() l10n provider} is used.
+   * <p>
+   * This method should only be called from tests.
+   *
+   * @param l10n The l10n provider to use
+   */
+  static void setBaseL10n(BaseL10n l10n) {
+    // this will remove the old function from the registry, because the
+    // registry is a big Map, with the function name as key.
+    templateEngine.getExtensionRegistry().addExtension(new L10nExtension(l10n));
+  }
+
 }

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -3,10 +3,13 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.filter;
 
+import static freenet.l10n.BaseL10n.LANGUAGE.ENGLISH;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
+import freenet.l10n.BaseL10n;
+import freenet.l10n.BaseL10nTest;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -138,6 +141,10 @@ public class ContentFilterTest {
 			HTML_AUDIO_TAG,
 			HTML_VIDEO_TAG + HTML_AUDIO_TAG,
 			HTML_AUDIO_TAG + HTML_AUDIO_TAG);
+
+    static {
+        GenericReadFilterCallback.setBaseL10n(BaseL10nTest.createTestL10n(ENGLISH));
+    }
 
 	private static void testOneHTMLFilter(String html) throws Exception {
 		assertEquals(html, htmlFilter(html));

--- a/test/freenet/clients/http/utils/L10nExtensionTest.java
+++ b/test/freenet/clients/http/utils/L10nExtensionTest.java
@@ -1,5 +1,7 @@
 package freenet.clients.http.utils;
 
+import freenet.l10n.BaseL10n;
+import freenet.l10n.BaseL10nTest;
 import java.util.Locale;
 import java.util.Map;
 
@@ -7,6 +9,7 @@ import com.mitchellbosecke.pebble.extension.Function;
 import com.mitchellbosecke.pebble.template.EvaluationContext;
 import org.junit.Test;
 
+import static freenet.l10n.BaseL10n.LANGUAGE.ENGLISH;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,7 +60,8 @@ public class L10nExtensionTest {
 		};
 	}
 
-	private final L10nExtension l10nExtension = new L10nExtension();
+	private final BaseL10n l10n = BaseL10nTest.createTestL10n(ENGLISH);
+	private final L10nExtension l10nExtension = new L10nExtension(l10n);
 	private final Function l10nFunction = l10nExtension.getFunctions().get("l10n");
 
 }

--- a/test/freenet/clients/http/utils/PebbleUtilsTest.java
+++ b/test/freenet/clients/http/utils/PebbleUtilsTest.java
@@ -1,5 +1,7 @@
 package freenet.clients.http.utils;
 
+import freenet.l10n.BaseL10n;
+import freenet.l10n.BaseL10nTest;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -7,6 +9,7 @@ import java.util.Map;
 import freenet.support.HTMLNode;
 import org.junit.Test;
 
+import static freenet.l10n.BaseL10n.LANGUAGE.ENGLISH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -26,5 +29,9 @@ public class PebbleUtilsTest {
 
 	private final HTMLNode emptyParentNode = new HTMLNode("#");
 	private final Map<String, Object> model = new HashMap<>();
+
+	static {
+		PebbleUtils.setBaseL10n(BaseL10nTest.createTestL10n(ENGLISH));
+	}
 
 }

--- a/test/freenet/l10n/BaseL10nTest.java
+++ b/test/freenet/l10n/BaseL10nTest.java
@@ -251,13 +251,13 @@ public class BaseL10nTest {
 
     public static final BaseL10n createL10n(LANGUAGE lang) {
         File overrideFile = new File(TestProperty.L10nPath_main, "freenet.l10n.${lang}.override.properties");
-        return new BaseL10n(TestProperty.L10nPath_main, "freenet.l10n.${lang}.properties",
+        return new BaseL10n("freenet/l10n/", "freenet.l10n.${lang}.properties",
                 overrideFile.getPath(), lang);
     }
 
     public static final BaseL10n createTestL10n(LANGUAGE lang) {
         File overrideFile = new File(TestProperty.L10nPath_test, "freenet.l10n.${lang}.override.properties");
-        return new BaseL10n(TestProperty.L10nPath_test, "freenet.l10n.${lang}.properties",
+        return new BaseL10n("freenet/l10n/", "freenet.l10n.${lang}.test.properties",
                 overrideFile.getPath(), lang);
     }
 }

--- a/test/freenet/l10n/freenet.l10n.de.properties
+++ b/test/freenet/l10n/freenet.l10n.de.properties
@@ -1,2 +1,0 @@
-test.badSubstitutionFallback=Gebrochen ${tag
-End

--- a/test/freenet/l10n/freenet.l10n.de.test.properties
+++ b/test/freenet/l10n/freenet.l10n.de.test.properties
@@ -1,0 +1,3 @@
+# This file is used by the BaseL10n object created by BaseL10nTest.createTestL10n().
+test.badSubstitutionFallback=Gebrochen ${tag
+End

--- a/test/freenet/l10n/freenet.l10n.en.test.properties
+++ b/test/freenet/l10n/freenet.l10n.en.test.properties
@@ -1,3 +1,4 @@
+# This file is used by the BaseL10n object created by BaseL10nTest.createTestL10n().
 test.sanity=Sane
 test.override=Not overridden
 test.substitution=Text with ${bold}loud${/bold} string

--- a/test/freenet/support/TestProperty.java
+++ b/test/freenet/support/TestProperty.java
@@ -15,7 +15,7 @@ final public class TestProperty {
 	final public static boolean BENCHMARK = Boolean.getBoolean("test.benchmark");
 	final public static boolean VERBOSE = Boolean.getBoolean("test.verbose");
 	final public static boolean EXTENSIVE = Boolean.getBoolean("test.extensive");
-	final public static String L10nPath_test= System.getProperty("test.l10npath_test", "../test/freenet/l10n/");
-	final public static String L10nPath_main= System.getProperty("test.l10npath_main", "freenet/l10n/");
+	final public static String L10nPath_test= System.getProperty("test.l10npath_test", "test/freenet/l10n/");
+	final public static String L10nPath_main= System.getProperty("test.l10npath_main", "src/freenet/l10n/");
 
 }


### PR DESCRIPTION
Story Time!

I felt like working on a couple of tests, so I began with running all tests in IDEA, and behold, there were a bunch of tests that did not run. I started with `BaseL10nTest` and noticed that it ran on the command line with `./gradlew` (as it should!) but would only fail in the IDE. Some debugging later I found out that the IDE ran the tests from the project directory, but Gradle actually ran them from… 👀 within the classpath?! And there was a `TestProperty` class being used to provide relative paths for translation override files, but those were also overridden by Gradle? Apparently the reason for the overrides in Gradle is that what the methods in `TestProperty` did was so broken that changing `build.gradle` (and complicating the build) was the easier option; a large part of that might be that the first parameter of the `BaseL10n` constructors is called `l10nFilesBasePath` — but it’s not a path at all! It is a prefix for a resource name and has nothing to do with the filesystem, contrary to the `l10nOverrideFilesMask` parameter, which can (and should!) contain the path of the files. So, yeah, confusing naming, no clear instructions on how to use it, of course it’s going to be mishandled. 😄 

Most of that didn’t make sense, so I removed all those overrides from `build.gradle` and changed the constants in `TestProperty` to match what is actually happening. Tests are now running from the project directory, as one would expect, and the results of running the tests in IDEA now matched the results of running the tests on the command-line.

The next problem was that some tests wanted a special English translation (in order to test substitution and broken tags and what not), some tests want the “main” translation, and still other tests needed an empty translation, or at least a translation where a number of keys were not present so that the translated value was equal to the key, for verification purposes.

And then one of the tests (`BaseL10nTest.testStrings`) is actually subtly broken by the existence of a `freenet.l10n.en.properties` file in the test resource path, because now the test cannot verify that the English translation is syntactically correct, but if the file is empty enough (i.e. does not contain syntactically incorrect translations), or is actually missing, the test will pass nonetheless.

So, this PR fixes all these things and should make translations a bit better to work with in tests: call `BaseL10nTest.createTestL10n()` for an l10n provider that serves translations from the `freenet.l10n.${lang}.test.properties` files, put your changes in those files, and use the supplied l10n provider in whatever component you want to test.
