### PR TITLE
Add Accessors for PageNode’s Member Fields

### DIFF
--- a/src/freenet/clients/http/BookmarkEditorToadlet.java
+++ b/src/freenet/clients/http/BookmarkEditorToadlet.java
@@ -178,7 +178,6 @@ public class BookmarkEditorToadlet extends Toadlet {
 		String editorTitle = NodeL10n.getBase().getString("BookmarkEditorToadlet.title");
 		String error = NodeL10n.getBase().getString("BookmarkEditorToadlet.error");
 		PageNode page = pageMaker.getPageNode(editorTitle, ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode content = page.getContentNode();
 		String originalBookmark = req.getParam("bookmark");
 		if(!req.getParam("action").isEmpty() && !originalBookmark.isEmpty()) {
@@ -189,7 +188,7 @@ public class BookmarkEditorToadlet extends Toadlet {
 			} catch(URLEncodedFormatException e) {
 				pageMaker.getInfobox("infobox-error", error, content, "bookmark-url-decode-error", false).
 					addChild("#", NodeL10n.getBase().getString("BookmarkEditorToadlet.urlDecodeError"));
-				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			}
 			Bookmark bookmark;
@@ -202,7 +201,7 @@ public class BookmarkEditorToadlet extends Toadlet {
 			if(bookmark == null) {
 				pageMaker.getInfobox("infobox-error", error, content, "bookmark-does-not-exist", false).
 					addChild("#", NodeL10n.getBase().getString("BookmarkEditorToadlet.bookmarkDoesNotExist", new String[]{"bookmark"}, new String[]{bookmarkPath}));
-				this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				this.writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			} else
 				if("del".equals(action)) {
@@ -328,9 +327,9 @@ public class BookmarkEditorToadlet extends Toadlet {
 		addDefaultBookmarksForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "AddDefaultBookmarks", NodeL10n.getBase().getString("BookmarkEditorToadlet.addDefaultBookmarks")});
 
 		if(logDEBUG)
-			Logger.debug(this, "Returning:\n"+pageNode.generate());
+			Logger.debug(this, "Returning:\n"+page.generate());
 		
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	public void handleMethodPOST(URI uri, HTTPRequest req, ToadletContext ctx)
@@ -338,7 +337,6 @@ public class BookmarkEditorToadlet extends Toadlet {
 		PageMaker pageMaker = ctx.getPageMaker();
 		BookmarkManager bookmarkManager = ctx.getBookmarkManager();
 		PageNode page = pageMaker.getPageNode(NodeL10n.getBase().getString("BookmarkEditorToadlet.title"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode content = page.getContentNode();
 
 		if(req.isPartSet("AddDefaultBookmarks")) {
@@ -358,7 +356,7 @@ public class BookmarkEditorToadlet extends Toadlet {
 			if(bookmark == null && !req.isPartSet("cancelCut")) {
 				pageMaker.getInfobox("infobox-error", NodeL10n.getBase().getString("BookmarkEditorToadlet.error"), content, "bookmark-error", false).
 					addChild("#", NodeL10n.getBase().getString("BookmarkEditorToadlet.bookmarkDoesNotExist", new String[]{"bookmark"}, new String[]{bookmarkPath}));
-				this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				this.writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			}
 
@@ -436,7 +434,7 @@ public class BookmarkEditorToadlet extends Toadlet {
 		HTMLNode addDefaultBookmarksForm = ctx.addFormChild(content, "", "AddDefaultBookmarks");
 		addDefaultBookmarksForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "AddDefaultBookmarks", NodeL10n.getBase().getString("BookmarkEditorToadlet.addDefaultBookmarks")});
 
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	@Override

--- a/src/freenet/clients/http/BookmarkEditorToadlet.java
+++ b/src/freenet/clients/http/BookmarkEditorToadlet.java
@@ -178,8 +178,8 @@ public class BookmarkEditorToadlet extends Toadlet {
 		String editorTitle = NodeL10n.getBase().getString("BookmarkEditorToadlet.title");
 		String error = NodeL10n.getBase().getString("BookmarkEditorToadlet.error");
 		PageNode page = pageMaker.getPageNode(editorTitle, ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode content = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode content = page.getContentNode();
 		String originalBookmark = req.getParam("bookmark");
 		if(!req.getParam("action").isEmpty() && !originalBookmark.isEmpty()) {
 			String action = req.getParam("action");
@@ -338,8 +338,8 @@ public class BookmarkEditorToadlet extends Toadlet {
 		PageMaker pageMaker = ctx.getPageMaker();
 		BookmarkManager bookmarkManager = ctx.getBookmarkManager();
 		PageNode page = pageMaker.getPageNode(NodeL10n.getBase().getString("BookmarkEditorToadlet.title"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode content = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode content = page.getContentNode();
 
 		if(req.isPartSet("AddDefaultBookmarks")) {
 			bookmarkManager.reAddDefaultBookmarks();

--- a/src/freenet/clients/http/BrowserTestToadlet.java
+++ b/src/freenet/clients/http/BrowserTestToadlet.java
@@ -181,7 +181,6 @@ public class BrowserTestToadlet extends Toadlet {
 		if (request.isParameterSet("wontload")) return;
 
 		PageNode page = ctx.getPageMaker().getPageNode("Freenet browser testing tool", ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		if(ctx.isAllowedFullAccess())
@@ -211,7 +210,7 @@ public class BrowserTestToadlet extends Toadlet {
 			 .addChild("script", "type", "text/javascript")
 			 .addChild("%", "document.getElementById('JSTEST').src = '/static/themes/clean/warning.png';");
 
-		this.writeHTMLReply(ctx, 200, "OK", null,pageNode.generate(), true);
+		this.writeHTMLReply(ctx, 200, "OK", null, page.generate(), true);
 	}
 
 	@Override

--- a/src/freenet/clients/http/BrowserTestToadlet.java
+++ b/src/freenet/clients/http/BrowserTestToadlet.java
@@ -181,8 +181,8 @@ public class BrowserTestToadlet extends Toadlet {
 		if (request.isParameterSet("wontload")) return;
 
 		PageNode page = ctx.getPageMaker().getPageNode("Freenet browser testing tool", ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		if(ctx.isAllowedFullAccess())
 			contentNode.addChild(ctx.getAlertManager().createSummary());

--- a/src/freenet/clients/http/ChatForumsToadlet.java
+++ b/src/freenet/clients/http/ChatForumsToadlet.java
@@ -20,7 +20,6 @@ public class ChatForumsToadlet extends Toadlet implements LinkEnabledCallback {
 
 	public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		
 		contentNode.addChild(ctx.getAlertManager().createSummary());
@@ -45,7 +44,7 @@ public class ChatForumsToadlet extends Toadlet implements LinkEnabledCallback {
 				   HTMLNode.link("/USK@nwa8lHa271k2QvJ8aa0Ov7IHAV-DFOCFgmDt3X6BpCI,DuQSUZiI~agF8c-6tjsFFGuZ8eICrzWCILB60nT8KKo,AQACAAE/sone/-72/")});
 		contentBox.addChild("p", l10n("content2"));
 		
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private static String l10n(String string) {

--- a/src/freenet/clients/http/ChatForumsToadlet.java
+++ b/src/freenet/clients/http/ChatForumsToadlet.java
@@ -20,8 +20,8 @@ public class ChatForumsToadlet extends Toadlet implements LinkEnabledCallback {
 
 	public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		
 		contentNode.addChild(ctx.getAlertManager().createSummary());
 		

--- a/src/freenet/clients/http/ConfigToadlet.java
+++ b/src/freenet/clients/http/ConfigToadlet.java
@@ -193,8 +193,8 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 		if (request.isPartSet("confirm-reset-to-defaults")) {
 			PageNode page = ctx.getPageMaker().getPageNode(
 					l10n("confirmResetTitle"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode content = ctx.getPageMaker().getInfobox("infobox-warning",
 					l10n("confirmResetTitle"), contentNode, "reset-confirm",
@@ -363,8 +363,8 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("appliedTitle"),
 				ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		if (errbuf.length() == 0) {
 			HTMLNode content = ctx.getPageMaker().getInfobox("infobox-success",
@@ -431,8 +431,8 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 
 		PageNode page = ctx.getPageMaker().getPageNode(
 				NodeL10n.getBase().getString("ConfigToadlet.fullTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		contentNode.addChild(ctx.getAlertManager().createSummary());
 

--- a/src/freenet/clients/http/ConfigToadlet.java
+++ b/src/freenet/clients/http/ConfigToadlet.java
@@ -193,7 +193,6 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 		if (request.isPartSet("confirm-reset-to-defaults")) {
 			PageNode page = ctx.getPageMaker().getPageNode(
 					l10n("confirmResetTitle"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode content = ctx.getPageMaker().getInfobox("infobox-warning",
@@ -232,7 +231,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 					new String[] { "type", "name", "value" }, new String[] {
 							"submit", "decline-default-reset",
 							NodeL10n.getBase().getString("Toadlet.no") });
-			writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+			writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		}
 
@@ -363,7 +362,6 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("appliedTitle"),
 				ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		if (errbuf.length() == 0) {
@@ -413,7 +411,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 		content.addChild("br");
 		addHomepageLink(content);
 
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 
 	}
 
@@ -431,7 +429,6 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 
 		PageNode page = ctx.getPageMaker().getPageNode(
 				NodeL10n.getBase().getString("ConfigToadlet.fullTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		contentNode.addChild(ctx.getAlertManager().createSummary());
@@ -656,7 +653,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 							l10n("resetToDefaults") });
 		}
 
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	/**

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -250,8 +250,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 
 		PageNode page = ctx.getPageMaker().getPageNode(getPageTitle(titleCountString), ctx);
 		final boolean advancedMode = ctx.isAdvancedModeEnabled();
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		
 		// FIXME! We need some nice images
 		long now = System.currentTimeMillis();
@@ -743,8 +743,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			}
 			
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("reportOfNodeAddition"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 			
 			//We create a table to show the results
 			HTMLNode detailedStatusBox=new HTMLNode("table");
@@ -1210,8 +1210,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 	 */
 	protected void sendErrorPage(ToadletContext ctx, int code, String desc, String message, boolean returnToAddFriends) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(desc, ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		
 		HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", desc, contentNode, null, true);
 		infoboxContent.addChild("#", message);

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -250,7 +250,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
 
 		PageNode page = ctx.getPageMaker().getPageNode(getPageTitle(titleCountString), ctx);
 		final boolean advancedMode = ctx.isAdvancedModeEnabled();
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		
 		// FIXME! We need some nice images
@@ -596,7 +595,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			drawNoderefBox(contentNode, getNoderef());
 		}
 		
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	protected abstract boolean acceptRefPosts();
@@ -743,7 +742,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			}
 			
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("reportOfNodeAddition"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 			
 			//We create a table to show the results
@@ -766,7 +764,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			infoboxContent.addChild("p").addChild("a", "href", path(), l10n("goFriendConnectionStatus"));
 			addHomepageLink(infoboxContent.addChild("p"));
 			
-			writeHTMLReply(ctx, 500, l10n("reportOfNodeAddition"), pageNode.generate());
+			writeHTMLReply(ctx, 500, l10n("reportOfNodeAddition"), page.generate());
 		} else handleAltPost(uri, request, ctx, logMINOR);
 		
 		
@@ -1210,7 +1208,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
 	 */
 	protected void sendErrorPage(ToadletContext ctx, int code, String desc, String message, boolean returnToAddFriends) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(desc, ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		
 		HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", desc, contentNode, null, true);
@@ -1226,7 +1223,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 		}
 		addHomepageLink(infoboxContent);
 		
-		writeHTMLReply(ctx, code, desc, pageNode.generate());
+		writeHTMLReply(ctx, code, desc, page.generate());
 	}
 
 }

--- a/src/freenet/clients/http/ConnectivityToadlet.java
+++ b/src/freenet/clients/http/ConnectivityToadlet.java
@@ -53,7 +53,6 @@ public class ConnectivityToadlet extends Toadlet {
 		PageMaker pageMaker = ctx.getPageMaker();
 		
 		PageNode page = pageMaker.getPageNode(NodeL10n.getBase().getString("ConnectivityToadlet.title"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		/* add alert summary box */
@@ -190,7 +189,7 @@ public class ConnectivityToadlet extends Toadlet {
 		
 		}
 		
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 	
 	private String l10nConn(String string) {

--- a/src/freenet/clients/http/ConnectivityToadlet.java
+++ b/src/freenet/clients/http/ConnectivityToadlet.java
@@ -53,8 +53,8 @@ public class ConnectivityToadlet extends Toadlet {
 		PageMaker pageMaker = ctx.getPageMaker();
 		
 		PageNode page = pageMaker.getPageNode(NodeL10n.getBase().getString("ConnectivityToadlet.title"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		/* add alert summary box */
 		if(ctx.isAllowedFullAccess())

--- a/src/freenet/clients/http/ContentFilterToadlet.java
+++ b/src/freenet/clients/http/ContentFilterToadlet.java
@@ -67,8 +67,8 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
         PageMaker pageMaker = ctx.getPageMaker();
 
         PageNode page = pageMaker.getPageNode(l10n("pageTitle"), ctx);
-        HTMLNode pageNode = page.outer;
-        HTMLNode contentNode = page.content;
+        HTMLNode pageNode = page.getOuterNode();
+        HTMLNode contentNode = page.getContentNode();
 
         contentNode.addChild(ctx.getAlertManager().createSummary());
 
@@ -123,8 +123,8 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
 
     private HTMLNode createContent(PageMaker pageMaker, ToadletContext ctx) {
         InfoboxNode infobox = pageMaker.getInfobox(l10n("filterFile"), "filter-file", true);
-        HTMLNode filterBox = infobox.outer;
-        HTMLNode filterContent = infobox.content;
+        HTMLNode filterBox = infobox.getOuterNode();
+        HTMLNode filterContent = infobox.getContentNode();
 
         HTMLNode filterForm = ctx.addFormChild(filterContent, PATH, "filterForm");
 
@@ -188,8 +188,8 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
             throws ToadletContextClosedException, IOException {
         PageMaker pageMaker = context.getPageMaker();
         PageNode page = pageMaker.getPageNode(header, context);
-        HTMLNode pageNode = page.outer;
-        HTMLNode contentNode = page.content;
+        HTMLNode pageNode = page.getOuterNode();
+        HTMLNode contentNode = page.getContentNode();
         if (context.isAllowedFullAccess()) {
             contentNode.addChild(context.getAlertManager().createSummary());
         }

--- a/src/freenet/clients/http/ContentFilterToadlet.java
+++ b/src/freenet/clients/http/ContentFilterToadlet.java
@@ -67,14 +67,13 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
         PageMaker pageMaker = ctx.getPageMaker();
 
         PageNode page = pageMaker.getPageNode(l10n("pageTitle"), ctx);
-        HTMLNode pageNode = page.getOuterNode();
         HTMLNode contentNode = page.getContentNode();
 
         contentNode.addChild(ctx.getAlertManager().createSummary());
 
         contentNode.addChild(createContent(pageMaker, ctx));
 
-        writeHTMLReply(ctx, 200, "OK", null, pageNode.generate());
+        writeHTMLReply(ctx, 200, "OK", null, page.generate());
     }
 
     public void handleMethodPOST(URI uri, final HTTPRequest request, final ToadletContext ctx)
@@ -188,7 +187,6 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
             throws ToadletContextClosedException, IOException {
         PageMaker pageMaker = context.getPageMaker();
         PageNode page = pageMaker.getPageNode(header, context);
-        HTMLNode pageNode = page.getOuterNode();
         HTMLNode contentNode = page.getContentNode();
         if (context.isAllowedFullAccess()) {
             contentNode.addChild(context.getAlertManager().createSummary());
@@ -200,7 +198,7 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
                     "ContentFilterToadlet.tryAgainFilterFilePage", new String[] { "link" },
                     new HTMLNode[] { HTMLNode.link(ContentFilterToadlet.PATH) });
         }
-        writeHTMLReply(context, 400, "Bad request", pageNode.generate());
+        writeHTMLReply(context, 400, "Bad request", page.generate());
     }
 
     /**

--- a/src/freenet/clients/http/DarknetAddRefToadlet.java
+++ b/src/freenet/clients/http/DarknetAddRefToadlet.java
@@ -50,7 +50,6 @@ public class DarknetAddRefToadlet extends Toadlet {
 		PageMaker pageMaker = ctx.getPageMaker();
 		
 		PageNode page = pageMaker.getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		
 		contentNode.addChild(ctx.getAlertManager().createSummary());
@@ -88,7 +87,7 @@ public class DarknetAddRefToadlet extends Toadlet {
 		
 		friendsToadlet.drawNoderefBox(contentNode, getNoderef());
 		
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	protected SimpleFieldSet getNoderef() {

--- a/src/freenet/clients/http/DarknetAddRefToadlet.java
+++ b/src/freenet/clients/http/DarknetAddRefToadlet.java
@@ -50,8 +50,8 @@ public class DarknetAddRefToadlet extends Toadlet {
 		PageMaker pageMaker = ctx.getPageMaker();
 		
 		PageNode page = pageMaker.getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		
 		contentNode.addChild(ctx.getAlertManager().createSummary());
 		

--- a/src/freenet/clients/http/DarknetConnectionsToadlet.java
+++ b/src/freenet/clients/http/DarknetConnectionsToadlet.java
@@ -218,7 +218,6 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 	protected void handleAltPost(URI uri, HTTPRequest request, ToadletContext ctx, boolean logMINOR) throws ToadletContextClosedException, IOException, RedirectException {
 		if (request.isPartSet("doSendMessageToPeers")) {
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessageTitle"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 			DarknetPeerNode[] peerNodes = node.getDarknetConnections();
 			HashMap<String, String> peers = new HashMap<String, String>();
@@ -231,7 +230,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 					}
 				}
 			}
-			N2NTMToadlet.createN2NTMSendForm( pageNode, ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
+			N2NTMToadlet.createN2NTMSendForm(ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
 			writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		} else if (request.isPartSet("doAction") && request.getPartAsStringFailsafe("action",25).equals("update_notes")) {

--- a/src/freenet/clients/http/DarknetConnectionsToadlet.java
+++ b/src/freenet/clients/http/DarknetConnectionsToadlet.java
@@ -218,8 +218,8 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 	protected void handleAltPost(URI uri, HTTPRequest request, ToadletContext ctx, boolean logMINOR) throws ToadletContextClosedException, IOException, RedirectException {
 		if (request.isPartSet("doSendMessageToPeers")) {
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessageTitle"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 			DarknetPeerNode[] peerNodes = node.getDarknetConnections();
 			HashMap<String, String> peers = new HashMap<String, String>();
 			for(DarknetPeerNode pn : peerNodes) {
@@ -407,8 +407,8 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 					}else{
 						if(logMINOR) Logger.minor(this, "Refusing to remove : node_"+pn.hashCode()+" (trying to prevent network churn) : let's display the warning message.");
 						PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmRemoveNodeTitle"), ctx);
-						HTMLNode pageNode = page.outer;
-						HTMLNode contentNode = page.content;
+						HTMLNode pageNode = page.getOuterNode();
+						HTMLNode contentNode = page.getContentNode();
 						HTMLNode content =ctx.getPageMaker().getInfobox("infobox-warning", l10n("confirmRemoveNodeWarningTitle"), contentNode, "darknet-remove-node", true);
 						content.addChild("p").addChild("#",
 								NodeL10n.getBase().getString("DarknetConnectionsToadlet.confirmRemoveNode", new String[] { "name" }, new String[] { pn.getName() }));

--- a/src/freenet/clients/http/DarknetConnectionsToadlet.java
+++ b/src/freenet/clients/http/DarknetConnectionsToadlet.java
@@ -232,7 +232,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 				}
 			}
 			N2NTMToadlet.createN2NTMSendForm( pageNode, ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
-			writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+			writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		} else if (request.isPartSet("doAction") && request.getPartAsStringFailsafe("action",25).equals("update_notes")) {
 			//int hashcode = Integer.decode(request.getParam("node")).intValue();
@@ -407,7 +407,6 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 					}else{
 						if(logMINOR) Logger.minor(this, "Refusing to remove : node_"+pn.hashCode()+" (trying to prevent network churn) : let's display the warning message.");
 						PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmRemoveNodeTitle"), ctx);
-						HTMLNode pageNode = page.getOuterNode();
 						HTMLNode contentNode = page.getContentNode();
 						HTMLNode content =ctx.getPageMaker().getInfobox("infobox-warning", l10n("confirmRemoveNodeWarningTitle"), contentNode, "darknet-remove-node", true);
 						content.addChild("p").addChild("#",
@@ -418,7 +417,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
 						removeForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "remove", l10n("remove") });
 						removeForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "hidden", "forceit", l10n("forceRemove") });
 
-						writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+						writeHTMLReply(ctx, 200, "OK", page.generate());
 						return; // FIXME: maybe it breaks multi-node removing
 					}				
 				} else {

--- a/src/freenet/clients/http/DecodeToadlet.java
+++ b/src/freenet/clients/http/DecodeToadlet.java
@@ -24,8 +24,8 @@ public class DecodeToadlet extends Toadlet {
 	public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 	    
 		PageNode page = ctx.getPageMaker().getPageNode("Redirect to Decoded link", ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		
 		if(ctx.isAllowedFullAccess())
 			contentNode.addChild(ctx.getAlertManager().createSummary());

--- a/src/freenet/clients/http/DecodeToadlet.java
+++ b/src/freenet/clients/http/DecodeToadlet.java
@@ -24,7 +24,6 @@ public class DecodeToadlet extends Toadlet {
 	public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 	    
 		PageNode page = ctx.getPageMaker().getPageNode("Redirect to Decoded link", ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		
 		if(ctx.isAllowedFullAccess())
@@ -39,7 +38,7 @@ public class DecodeToadlet extends Toadlet {
 		ctx.getPageMaker().getInfobox("infobox-warning", "Decode Link", contentNode, "decode-not-redirected", true).
 		    addChild("a", "href", keyToFetch, "Click Here to be re-directed");
 
-		this.writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: "+ keyToFetch, pageNode.generate());
+		this.writeHTMLReply(ctx, 301, "Moved Permanently\nLocation: "+ keyToFetch, page.generate());
 	}
 
 	@Override

--- a/src/freenet/clients/http/ExternalLinkToadlet.java
+++ b/src/freenet/clients/http/ExternalLinkToadlet.java
@@ -57,8 +57,8 @@ public class ExternalLinkToadlet extends Toadlet {
 		//Only render status and navigation bars if the user has completed the wizard.
 		boolean renderBars = node.getClientCore().getToadletContainer().fproxyHasCompletedWizard();
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmExternalLinkTitle"), ctx, new RenderParameters().renderNavigationLinks(renderBars).renderStatus(renderBars));
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		HTMLNode warnboxContent = ctx.getPageMaker().getInfobox("infobox-warning",
 			l10n("confirmExternalLinkSubTitle"), contentNode, "confirm-external-link", true);
 		HTMLNode externalLinkForm = ctx.addFormChild(warnboxContent, PATH, "confirmExternalLinkForm");

--- a/src/freenet/clients/http/ExternalLinkToadlet.java
+++ b/src/freenet/clients/http/ExternalLinkToadlet.java
@@ -57,7 +57,6 @@ public class ExternalLinkToadlet extends Toadlet {
 		//Only render status and navigation bars if the user has completed the wizard.
 		boolean renderBars = node.getClientCore().getToadletContainer().fproxyHasCompletedWizard();
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmExternalLinkTitle"), ctx, new RenderParameters().renderNavigationLinks(renderBars).renderStatus(renderBars));
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		HTMLNode warnboxContent = ctx.getPageMaker().getInfobox("infobox-warning",
 			l10n("confirmExternalLinkSubTitle"), contentNode, "confirm-external-link", true);
@@ -76,7 +75,7 @@ public class ExternalLinkToadlet extends Toadlet {
 			new String[]{"type", "name", "value"},
 			new String[]{"submit", "Go", l10n("goToExternalLink")});
 
-		this.writeHTMLReply(ctx, 200, "OK", null, pageNode.generate(), true);
+		this.writeHTMLReply(ctx, 200, "OK", null, page.generate(), true);
 	}
 
 	/**

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -177,7 +177,6 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			}
 			if(isSniffedAsFeed(data) && !(mimeType.startsWith("application/rss+xml"))) {
 				PageNode page = context.getPageMaker().getPageNode(l10n("dangerousRSSTitle"), context);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-alert");
@@ -222,7 +221,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				NodeL10n.getBase().addL10nSubstitution(option, "FProxyToadlet.backToFProxy", new String[] { "link" },
 						new HTMLNode[] { HTMLNode.link("/") });
 
-				byte[] pageBytes = pageNode.generate().getBytes(StandardCharsets.UTF_8);
+				byte[] pageBytes = page.generate().getBytes(StandardCharsets.UTF_8);
 				context.sendReplyHeaders(200, "OK", new MultiValueTable<String, String>(), "text/html; charset=utf-8", pageBytes.length);
 				context.writeData(pageBytes);
 				return;
@@ -567,7 +566,6 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			key = new FreenetURI(ks);
 		} catch (MalformedURLException e) {
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("invalidKeyTitle"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode errorInfobox = contentNode.addChild("div", "class", "infobox infobox-error");
@@ -580,7 +578,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			errorContent.addChild("br");
 			addHomepageLink(errorContent);
 
-			this.writeHTMLReply(ctx, 400, l10n("invalidKeyTitle"), pageNode.generate());
+			this.writeHTMLReply(ctx, 400, l10n("invalidKeyTitle"), page.generate());
 			return;
 		}
 
@@ -714,7 +712,6 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				boolean isJsEnabled=ctx.getContainer().isFProxyJavascriptEnabled() && ua != null && !ua.contains("AppleWebKit/");
 				boolean isWebPushingEnabled = false;
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("fetchingPageTitle"), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				String location = getLink(key, requestedMimeType, maxSize, httprequest.getParam("force", null), httprequest.isParameterSet("forcedownload"), maxRetries, overrideSize);
 				HTMLNode headNode=page.getHeadNode();
 				if(isJsEnabled){
@@ -761,7 +758,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
 				MultiValueTable<String, String> retHeaders = new MultiValueTable<>();
 				//retHeaders.put("Refresh", "2; url="+location);
-				writeHTMLReply(ctx, 200, "OK", retHeaders, pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", retHeaders, page.generate());
 				fr.close();
 				fetch.close();
 				return;
@@ -833,7 +830,6 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 					getLink(e.newURI, requestedMimeType, maxSize, httprequest.getParam("force", null), httprequest.isParameterSet("forcedownload"), maxRetries, overrideSize));
 			} else if(e.mode == FetchExceptionMode.TOO_BIG) {
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("fileInformationTitle"), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-information");
@@ -872,10 +868,9 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				//option = optionTable.addChild("tr").addChild("td", "colspan", "2");
 				optionList.addChild("li").addChild(ctx.getPageMaker().createBackLink(ctx, l10n("goBackToPrev")));
 
-				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", page.generate());
 			} else {
 				PageNode page = ctx.getPageMaker().getPageNode(e.getShortMessage(), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-error");
@@ -970,7 +965,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
 				optionList.addChild("li").addChild(ctx.getPageMaker().createBackLink(ctx, l10n("goBackToPrev")));
 				this.writeHTMLReply(ctx, (e.mode == FetchExceptionMode.NOT_IN_ARCHIVE) ? 404 : 500 /* close enough - FIXME probably should depend on status code */,
-						"Internal Error", pageNode.generate());
+						"Internal Error", page.generate());
 			}
 		} catch (SocketException e) {
 			// Probably irrelevant

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -177,8 +177,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			}
 			if(isSniffedAsFeed(data) && !(mimeType.startsWith("application/rss+xml"))) {
 				PageNode page = context.getPageMaker().getPageNode(l10n("dangerousRSSTitle"), context);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-alert");
 				infobox.addChild("div", "class", "infobox-header", l10n("dangerousRSSSubtitle"));
@@ -567,8 +567,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			key = new FreenetURI(ks);
 		} catch (MalformedURLException e) {
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("invalidKeyTitle"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode errorInfobox = contentNode.addChild("div", "class", "infobox infobox-error");
 			errorInfobox.addChild("div", "class", "infobox-header", NodeL10n.getBase().getString("FProxyToadlet.invalidKeyWithReason", new String[] { "reason" }, new String[] { e.toString() }));
@@ -714,7 +714,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				boolean isJsEnabled=ctx.getContainer().isFProxyJavascriptEnabled() && ua != null && !ua.contains("AppleWebKit/");
 				boolean isWebPushingEnabled = false;
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("fetchingPageTitle"), ctx);
-				HTMLNode pageNode = page.outer;
+				HTMLNode pageNode = page.getOuterNode();
 				String location = getLink(key, requestedMimeType, maxSize, httprequest.getParam("force", null), httprequest.isParameterSet("forcedownload"), maxRetries, overrideSize);
 				HTMLNode headNode=page.headNode;
 				if(isJsEnabled){
@@ -730,7 +730,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 					//If he disabled it, we just put the http refresh meta, without the noscript
 					headNode.addChild("meta", "http-equiv", "Refresh").addAttribute("content", "2;URL=" + location);
 				}
-				HTMLNode contentNode = page.content;
+				HTMLNode contentNode = page.getContentNode();
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-information");
 				infobox.addChild("div", "class", "infobox-header", l10n("fetchingPageBox"));
 				HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
@@ -833,8 +833,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 					getLink(e.newURI, requestedMimeType, maxSize, httprequest.getParam("force", null), httprequest.isParameterSet("forcedownload"), maxRetries, overrideSize));
 			} else if(e.mode == FetchExceptionMode.TOO_BIG) {
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("fileInformationTitle"), ctx);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-information");
 				infobox.addChild("div", "class", "infobox-header", l10n("largeFile"));
@@ -875,8 +875,8 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
 			} else {
 				PageNode page = ctx.getPageMaker().getPageNode(e.getShortMessage(), ctx);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-error");
 				infobox.addChild("div", "class", "infobox-header", l10n("errorWithReason", "error", e.getShortMessage()));

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -716,7 +716,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("fetchingPageTitle"), ctx);
 				HTMLNode pageNode = page.getOuterNode();
 				String location = getLink(key, requestedMimeType, maxSize, httprequest.getParam("force", null), httprequest.isParameterSet("forcedownload"), maxRetries, overrideSize);
-				HTMLNode headNode=page.headNode;
+				HTMLNode headNode=page.getHeadNode();
 				if(isJsEnabled){
 					//If the user has enabled javascript, we add a <noscript> http refresh(if he has disabled it in the browser)
 					headNode.addChild("noscript").addChild("meta", "http-equiv", "Refresh").addAttribute("content", "2;URL=" + location);

--- a/src/freenet/clients/http/FileInsertWizardToadlet.java
+++ b/src/freenet/clients/http/FileInsertWizardToadlet.java
@@ -65,8 +65,8 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 		final PageMaker pageMaker = ctx.getPageMaker();
 
 		PageNode page = pageMaker.getPageNode(l10n("pageTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		/* add alert summary box */
 		if (ctx.isAllowedFullAccess()) contentNode.addChild(ctx.getAlertManager().createSummary());
@@ -82,8 +82,8 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 		/* the insert file box */
 		InfoboxNode infobox = pageMaker.getInfobox(
 		        NodeL10n.getBase().getString("QueueToadlet.insertFile"), "insert-queue", true);
-		HTMLNode insertBox = infobox.outer;
-		HTMLNode insertContent = infobox.content;
+		HTMLNode insertBox = infobox.getOuterNode();
+		HTMLNode insertContent = infobox.getContentNode();
 		insertContent.addChild("p", l10n("insertIntro"));
 		NETWORK_THREAT_LEVEL seclevel = core.getNode().getSecurityLevels().getNetworkThreatLevel();
 		HTMLNode insertForm = ctx.addFormChild(insertContent, QueueToadlet.PATH_UPLOADS, "queueInsertForm");
@@ -193,8 +193,8 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 		/* the insert file box */
 		InfoboxNode infobox = pageMaker.getInfobox(
 		        l10n("previewFilterFile"), "insert-queue", true);
-		HTMLNode insertBox = infobox.outer;
-		HTMLNode insertContent = infobox.content;
+		HTMLNode insertBox = infobox.getOuterNode();
+		HTMLNode insertContent = infobox.getContentNode();
 		HTMLNode insertForm = ctx.addFormChild(insertContent, ContentFilterToadlet.PATH, "filterPreviewForm");
 	    insertForm.addChild("#", l10n("filterFileLabel"));
 	    insertForm.addChild("br");

--- a/src/freenet/clients/http/FileInsertWizardToadlet.java
+++ b/src/freenet/clients/http/FileInsertWizardToadlet.java
@@ -65,7 +65,6 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 		final PageMaker pageMaker = ctx.getPageMaker();
 
 		PageNode page = pageMaker.getPageNode(l10n("pageTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		/* add alert summary box */
@@ -75,7 +74,7 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 		if(ctx.isAdvancedModeEnabled())
 			contentNode.addChild(createFilterBox(pageMaker, ctx));
 		
-		writeHTMLReply(ctx, 200, "OK", null, pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", null, page.generate());
 	}
 	
 	private HTMLNode createInsertBox (PageMaker pageMaker, ToadletContext ctx, boolean isAdvancedModeEnabled) {

--- a/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
@@ -86,8 +86,8 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
         PageNode page = ctx.getPageMaker().getPageNode(l10n("homepageTitle"), ctx,
                 new PageMaker.RenderParameters().renderNavigationLinks(false).renderStatus(false));
         page.addCustomStyleSheet("/static/first-time-wizard.css");
-        addChild(page.content, "first-time-wizard", model, l10nPrefix);
-        this.writeHTMLReply(ctx, 200, "OK", page.outer.generate());
+        addChild(page.getContentNode(), "first-time-wizard", model, l10nPrefix);
+        this.writeHTMLReply(ctx, 200, "OK", page.getOuterNode().generate());
     }
 
     @Override

--- a/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
@@ -87,7 +87,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
                 new PageMaker.RenderParameters().renderNavigationLinks(false).renderStatus(false));
         page.addCustomStyleSheet("/static/first-time-wizard.css");
         addChild(page.getContentNode(), "first-time-wizard", model, l10nPrefix);
-        this.writeHTMLReply(ctx, 200, "OK", page.getOuterNode().generate());
+        this.writeHTMLReply(ctx, 200, "OK", page.generate());
     }
 
     @Override

--- a/src/freenet/clients/http/FirstTimeWizardToadlet.java
+++ b/src/freenet/clients/http/FirstTimeWizardToadlet.java
@@ -200,7 +200,7 @@ public class FirstTimeWizardToadlet extends Toadlet {
 		Step getStep = steps.get(currentStep);
 		PageHelper helper = new PageHelper(ctx, persistFields, currentStep);
 		getStep.getStep(request, helper);
-		writeHTMLReply(ctx, 200, "OK", helper.getPageOuter().generate());
+		writeHTMLReply(ctx, 200, "OK", helper.generate());
 	}
 
 	/**

--- a/src/freenet/clients/http/InfoboxNode.java
+++ b/src/freenet/clients/http/InfoboxNode.java
@@ -21,6 +21,14 @@ public class InfoboxNode {
 		this.content = content;
 	}
 
+	/**
+	 * Calls {@link HTMLNode#generate()} on the
+	 * {@link #getOuterNode() outer node} and returns the generated HTML.
+	 */
+	public String generate() {
+		return outer.generate();
+	}
+
 	public HTMLNode getOuterNode() {
 		return outer;
 	}

--- a/src/freenet/clients/http/InfoboxNode.java
+++ b/src/freenet/clients/http/InfoboxNode.java
@@ -21,4 +21,12 @@ public class InfoboxNode {
 		this.content = content;
 	}
 
+	public HTMLNode getOuterNode() {
+		return outer;
+	}
+
+	public HTMLNode getContentNode() {
+		return content;
+	}
+
 }

--- a/src/freenet/clients/http/InsertFreesiteToadlet.java
+++ b/src/freenet/clients/http/InsertFreesiteToadlet.java
@@ -17,8 +17,8 @@ public class InsertFreesiteToadlet extends Toadlet {
 
 	public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		
 		contentNode.addChild(ctx.getAlertManager().createSummary());
 		

--- a/src/freenet/clients/http/InsertFreesiteToadlet.java
+++ b/src/freenet/clients/http/InsertFreesiteToadlet.java
@@ -17,7 +17,6 @@ public class InsertFreesiteToadlet extends Toadlet {
 
 	public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		
 		contentNode.addChild(ctx.getAlertManager().createSummary());
@@ -50,7 +49,7 @@ public class InsertFreesiteToadlet extends Toadlet {
 		        new HTMLNode[] { HTMLNode.link(ExternalLinkToadlet.escape("http://downloads.freenetproject.org/alpha/thingamablog/thingamablog.zip")),
 		                HTMLNode.link("/CHK@o8j9T2Ghc9cfKMLvv9aLrHbvW5XiAMEGwGDqH2UANTk,sVxLdxoNL-UAsvrlXRZtI5KyKlp0zv3Ysk4EcO627V0,AAIC--8/thingamablog.zip") });
 		
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private static String l10n(String string) {

--- a/src/freenet/clients/http/LocalFileBrowserToadlet.java
+++ b/src/freenet/clients/http/LocalFileBrowserToadlet.java
@@ -291,7 +291,7 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
 
 		if (currentPath != null && !allowedDir(currentPath)) {
 			PageNode page = pageMaker.getPageNode(l10n("listingTitle", "path", attemptedPath), ctx);
-			pageMaker.getInfobox("infobox-error",  "Forbidden", page.content, "access-denied", true).
+			pageMaker.getInfobox("infobox-error",  "Forbidden", page.getContentNode(), "access-denied", true).
 			        addChild("#", l10n("dirAccessDenied"));
 
 			sendErrorPage(ctx, 403, "Forbidden", l10n("dirAccessDenied"));
@@ -303,8 +303,8 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
 		if (currentPath != null && currentPath.exists() && currentPath.isDirectory() && currentPath.canRead()) {
 			PageNode page = pageMaker.getPageNode(l10n("listingTitle", "path",
 			        currentPath.getAbsolutePath()), ctx);
-			pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 			if (ctx.isAllowedFullAccess()) contentNode.addChild(ctx.getAlertManager().createSummary());
 			
 			HTMLNode infoboxDiv = contentNode.addChild("div", "class", "infobox");
@@ -419,8 +419,8 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
 			}
 		} else {
 			PageNode page = pageMaker.getPageNode(l10n("listingTitle", "path", attemptedPath), ctx);
-			pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 			if (ctx.isAllowedFullAccess()) contentNode.addChild(ctx.getAlertManager().createSummary());
 			
 			HTMLNode infoboxDiv = contentNode.addChild("div", "class", "infobox");

--- a/src/freenet/clients/http/LocalFileBrowserToadlet.java
+++ b/src/freenet/clients/http/LocalFileBrowserToadlet.java
@@ -297,13 +297,12 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
 			sendErrorPage(ctx, 403, "Forbidden", l10n("dirAccessDenied"));
 			return;
 		}
-		
-		HTMLNode pageNode;
+
+		PageNode page;
 
 		if (currentPath != null && currentPath.exists() && currentPath.isDirectory() && currentPath.canRead()) {
-			PageNode page = pageMaker.getPageNode(l10n("listingTitle", "path",
+			page = pageMaker.getPageNode(l10n("listingTitle", "path",
 			        currentPath.getAbsolutePath()), ctx);
-			pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 			if (ctx.isAllowedFullAccess()) contentNode.addChild(ctx.getAlertManager().createSummary());
 			
@@ -418,8 +417,7 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
 				}
 			}
 		} else {
-			PageNode page = pageMaker.getPageNode(l10n("listingTitle", "path", attemptedPath), ctx);
-			pageNode = page.getOuterNode();
+			page = pageMaker.getPageNode(l10n("listingTitle", "path", attemptedPath), ctx);
 			HTMLNode contentNode = page.getContentNode();
 			if (ctx.isAllowedFullAccess()) contentNode.addChild(ctx.getAlertManager().createSummary());
 			
@@ -433,7 +431,7 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
 			ulNode.addChild("li", l10n("checkPathIsDir"));
 			ulNode.addChild("li", l10n("checkPathReadable"));
 		}
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private String l10n (String key, String pattern, String value) {

--- a/src/freenet/clients/http/N2NTMToadlet.java
+++ b/src/freenet/clients/http/N2NTMToadlet.java
@@ -75,7 +75,7 @@ public class N2NTMToadlet extends Toadlet {
 			}
 			HashMap<String, String> peers = new HashMap<String, String>();
 			peers.put(input_hashcode_string, peernode_name);
-			createN2NTMSendForm(page.getOuterNode(), ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
+			createN2NTMSendForm(ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
 			this.writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		}
@@ -266,7 +266,7 @@ public class N2NTMToadlet extends Toadlet {
 		node.addChild("p", message);
 	}
 
-	public static void createN2NTMSendForm(HTMLNode pageNode, boolean advancedMode,
+	public static void createN2NTMSendForm(boolean advancedMode,
 			HTMLNode contentNode, ToadletContext ctx, HashMap<String, String> peers)
 			throws ToadletContextClosedException, IOException {
 		HTMLNode infobox = contentNode.addChild("div", new String[] { "class",

--- a/src/freenet/clients/http/N2NTMToadlet.java
+++ b/src/freenet/clients/http/N2NTMToadlet.java
@@ -46,8 +46,8 @@ public class N2NTMToadlet extends Toadlet {
 
 		if (request.isParameterSet("peernode_hashcode")) {
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessage"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 
 			String peernode_name = null;
 			String input_hashcode_string = request.getParam("peernode_hashcode");
@@ -149,8 +149,8 @@ public class N2NTMToadlet extends Toadlet {
 				return;
 			}
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("processingSend"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 			HTMLNode peerTableInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
 			DarknetPeerNode[] peerNodes = node.getDarknetConnections();
 			if(request.isPartSet(LocalFileBrowserToadlet.selectFile)) {

--- a/src/freenet/clients/http/N2NTMToadlet.java
+++ b/src/freenet/clients/http/N2NTMToadlet.java
@@ -46,7 +46,6 @@ public class N2NTMToadlet extends Toadlet {
 
 		if (request.isParameterSet("peernode_hashcode")) {
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessage"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 
 			String peernode_name = null;
@@ -71,13 +70,13 @@ public class N2NTMToadlet extends Toadlet {
 				contentNode.addChild(createPeerInfobox("infobox-error",
 						l10n("peerNotFoundTitle"), l10n("peerNotFoundWithHash",
 								"hash", input_hashcode_string)));
-				this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				this.writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			}
 			HashMap<String, String> peers = new HashMap<String, String>();
 			peers.put(input_hashcode_string, peernode_name);
-			createN2NTMSendForm(pageNode, ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
-			this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+			createN2NTMSendForm(page.getOuterNode(), ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
+			this.writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		}
 		MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/friends/");
@@ -149,7 +148,6 @@ public class N2NTMToadlet extends Toadlet {
 				return;
 			}
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("processingSend"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 			HTMLNode peerTableInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
 			DarknetPeerNode[] peerNodes = node.getDarknetConnections();
@@ -160,7 +158,7 @@ public class N2NTMToadlet extends Toadlet {
 					if(!(filename.exists() && filename.canRead())) {
 						peerTableInfobox.addChild("#", l10n("noSuchFileOrCannotRead"));
 						Toadlet.addHomepageLink(peerTableInfobox);
-						this.writeHTMLReply(ctx, 400, "OK", pageNode.generate());
+						this.writeHTMLReply(ctx, 400, "OK", page.generate());
 						return;
 					}
 				}
@@ -181,7 +179,7 @@ public class N2NTMToadlet extends Toadlet {
 							peerTableInfobox.addChild("#", l10n("noSuchFileOrCannotRead"));
 							Toadlet.addHomepageLink(peerTableInfobox);
 							addUnsentMessageTextInfo(peerTableInfobox, message);
-							this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+							this.writeHTMLReply(ctx, 200, "OK", page.generate());
 							return;
 						}
 					} else if(request.isPartSet("n2nm-upload")) {
@@ -200,7 +198,7 @@ public class N2NTMToadlet extends Toadlet {
 												new String[] { "/friends/", l10n("returnToFriends") },
 												l10n("friends"));
 										addUnsentMessageTextInfo(peerTableInfobox, message);
-										this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+										this.writeHTMLReply(ctx, 200, "OK", page.generate());
 										return;
 									}
 									status = pn.sendFileOffer(request.getUploadedFile("n2nm-upload"), messageHead);
@@ -210,7 +208,7 @@ public class N2NTMToadlet extends Toadlet {
 							peerTableInfobox.addChild("#", l10n("uploadFailed"));
 							Toadlet.addHomepageLink(peerTableInfobox);
 							addUnsentMessageTextInfo(peerTableInfobox, message);
-							this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+							this.writeHTMLReply(ctx, 200, "OK", page.generate());
 							return;
 						}
 					}
@@ -256,7 +254,7 @@ public class N2NTMToadlet extends Toadlet {
 			list.addChild("li").addChild("a", new String[] { "href", "title" },
 					new String[] { "/friends/", l10n("returnToFriends") },
 					l10n("friends"));
-			this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+			this.writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		}
 		MultiValueTable<String, String> headers = MultiValueTable.from("Location", "/friends/");

--- a/src/freenet/clients/http/PageMaker.java
+++ b/src/freenet/clients/http/PageMaker.java
@@ -686,8 +686,8 @@ public final class PageMaker {
 	/** Create an infobox, attach it to the given parent, and return the content node. */
 	public HTMLNode getInfobox(String category, String header, HTMLNode parent, String title, boolean isUnique) {
 		InfoboxNode node = getInfobox(category, header, title, isUnique);
-		parent.addChild(node.outer);
-		return node.content;
+		parent.addChild(node.getOuterNode());
+		return node.getContentNode();
 	}
 
 	/**

--- a/src/freenet/clients/http/PageNode.java
+++ b/src/freenet/clients/http/PageNode.java
@@ -15,7 +15,11 @@ public class PageNode extends InfoboxNode {
 		super(page, content);
 		this.headNode = head;
 	}
-	
+
+	public HTMLNode getHeadNode() {
+		return headNode;
+	}
+
 	/**
 	 * Adds a custom style sheet to the header of the page.
 	 *

--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -193,8 +193,8 @@ public class PproxyToadlet extends Toadlet {
 					pm.removeCachedCopy(pluginSpecification);
 				}
 				PageNode page = pageMaker.getPageNode(l10n("plugins"), ctx);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-success");
 				infobox.addChild("div", "class", "infobox-header", l10n("pluginUnloaded"));
 				HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
@@ -208,8 +208,8 @@ public class PproxyToadlet extends Toadlet {
 				return;
 			}if (!request.getPartAsStringFailsafe("unload", MAX_PLUGIN_NAME_LENGTH).isEmpty()) {
 				PageNode page = pageMaker.getPageNode(l10n("plugins"), ctx);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-query");
 				infobox.addChild("div", "class", "infobox-header", l10n("unloadPluginTitle"));
 				HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
@@ -228,8 +228,8 @@ public class PproxyToadlet extends Toadlet {
 				return;
 			} else if (!request.getPartAsStringFailsafe("reload", MAX_PLUGIN_NAME_LENGTH).isEmpty()) {
 				PageNode page = pageMaker.getPageNode(l10n("plugins"), ctx);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 				HTMLNode reloadContent = pageMaker.getInfobox("infobox infobox-query", l10n("reloadPluginTitle"), contentNode, "plugin-reload", true);
 				reloadContent.addChild("p", l10n("reloadExplanation"));
 				reloadContent.addChild("p", l10n("reloadWarning"));
@@ -363,12 +363,12 @@ public class PproxyToadlet extends Toadlet {
 
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("plugins"), ctx);
 				boolean advancedModeEnabled = ctx.isAdvancedModeEnabled();
-				HTMLNode pageNode = page.outer;
+				HTMLNode pageNode = page.getOuterNode();
 				if (loadingPlugins.hasNext()) {
 					/* okay, add a refresh. */
 					page.headNode.addChild("meta", new String[] { "http-equiv", "content" }, new String[] { "refresh", "10; url=" });
 				}
-				HTMLNode contentNode = page.content;
+				HTMLNode contentNode = page.getContentNode();
 
 				contentNode.addChild(ctx.getAlertManager().createSummary());
 

--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -366,7 +366,7 @@ public class PproxyToadlet extends Toadlet {
 				HTMLNode pageNode = page.getOuterNode();
 				if (loadingPlugins.hasNext()) {
 					/* okay, add a refresh. */
-					page.headNode.addChild("meta", new String[] { "http-equiv", "content" }, new String[] { "refresh", "10; url=" });
+					page.getHeadNode().addChild("meta", new String[] { "http-equiv", "content" }, new String[] { "refresh", "10; url=" });
 				}
 				HTMLNode contentNode = page.getContentNode();
 

--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -193,7 +193,6 @@ public class PproxyToadlet extends Toadlet {
 					pm.removeCachedCopy(pluginSpecification);
 				}
 				PageNode page = pageMaker.getPageNode(l10n("plugins"), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-success");
 				infobox.addChild("div", "class", "infobox-header", l10n("pluginUnloaded"));
@@ -204,11 +203,10 @@ public class PproxyToadlet extends Toadlet {
                                 infoboxContent.addChild("br");
                                 infoboxContent.addChild("br");
 				infoboxContent.addChild("a", "href", "/plugins/", l10n("returnToPluginPage"));
-				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			}if (!request.getPartAsStringFailsafe("unload", MAX_PLUGIN_NAME_LENGTH).isEmpty()) {
 				PageNode page = pageMaker.getPageNode(l10n("plugins"), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 				HTMLNode infobox = contentNode.addChild("div", "class", "infobox infobox-query");
 				infobox.addChild("div", "class", "infobox-header", l10n("unloadPluginTitle"));
@@ -224,11 +222,10 @@ public class PproxyToadlet extends Toadlet {
 				tempNode.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "confirm", l10n("unload") });
 				tempNode.addChild("#", " ");
 				tempNode.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel") });
-				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			} else if (!request.getPartAsStringFailsafe("reload", MAX_PLUGIN_NAME_LENGTH).isEmpty()) {
 				PageNode page = pageMaker.getPageNode(l10n("plugins"), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 				HTMLNode reloadContent = pageMaker.getInfobox("infobox infobox-query", l10n("reloadPluginTitle"), contentNode, "plugin-reload", true);
 				reloadContent.addChild("p", l10n("reloadExplanation"));
@@ -246,7 +243,7 @@ public class PproxyToadlet extends Toadlet {
 				tempNode.addChild("#", " ");
 				tempNode.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel") });
 				
-				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			} else if (!request.getPartAsStringFailsafe("update", MAX_PLUGIN_NAME_LENGTH).isEmpty()) {
 				// Deploy the plugin update
@@ -363,7 +360,6 @@ public class PproxyToadlet extends Toadlet {
 
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("plugins"), ctx);
 				boolean advancedModeEnabled = ctx.isAdvancedModeEnabled();
-				HTMLNode pageNode = page.getOuterNode();
 				if (loadingPlugins.hasNext()) {
 					/* okay, add a refresh. */
 					page.getHeadNode().addChild("meta", new String[] { "http-equiv", "content" }, new String[] { "refresh", "10; url=" });
@@ -422,7 +418,7 @@ public class PproxyToadlet extends Toadlet {
 				showUnofficialPluginLoader(ctx, contentNode);
 				showFreenetPluginLoader(ctx, contentNode);
 
-				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", page.generate());
 			} else {
 				// split path into plugin class name and 'data' path for plugin
 				int to = path.indexOf('/');

--- a/src/freenet/clients/http/QueueToadlet.java
+++ b/src/freenet/clients/http/QueueToadlet.java
@@ -235,7 +235,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 			if(request.isPartSet("delete_request") && !request.getPartAsStringFailsafe("delete_request", 128).isEmpty()) {
 				// Confirm box
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmDeleteTitle"), ctx);
-				HTMLNode inner = page.content;
+				HTMLNode inner = page.getContentNode();
 				HTMLNode content = ctx.getPageMaker().getInfobox("infobox-warning", l10n("confirmDeleteTitle"), inner, "confirm-delete-title", true);
 				
 				HTMLNode deleteNode = new HTMLNode("p");
@@ -286,7 +286,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 					new String[] { "type", "name", "value" },
 					new String[] { "submit", "cancel", NodeL10n.getBase().getString("Toadlet.no") });
 
-				this.writeHTMLReply(ctx, 200, "OK", page.outer.generate());
+				this.writeHTMLReply(ctx, 200, "OK", page.getOuterNode().generate());
 				return;
 			} else if(request.isPartSet("remove_request") && !request.getPartAsStringFailsafe("remove_request", 128).isEmpty()) {
 				// Remove all requested (i.e. selected) requests from the queue, regardless of
@@ -504,8 +504,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				boolean displaySuccessBox = !success.isEmpty();
 
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("downloadFiles"), ctx);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode alertContent = ctx.getPageMaker().getInfobox(
 					(displayFailureBox ? "infobox-warning" : "infobox-info"),
@@ -868,8 +868,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				return;
 			} else if (request.isPartSet("recommend_request")) {
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("recommendAFileToFriends"), ctx);
-				HTMLNode pageNode = page.outer;
-				HTMLNode contentNode = page.content;
+				HTMLNode pageNode = page.getOuterNode();
+				HTMLNode contentNode = page.getContentNode();
 				HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("#", l10n("recommendAFileToFriends"), contentNode, "recommend-file", true);
 				HTMLNode form = ctx.addFormChild(infoboxContent, path(), "recommendForm2");
 				
@@ -970,8 +970,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 	private void downloadDisallowedPage (NotAllowedException e, String downloadPath, ToadletContext ctx)
 		throws IOException, ToadletContextClosedException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("downloadFiles"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		Logger.warning(this, e.toString());
 		HTMLNode alert = ctx.getPageMaker().getInfobox("infobox-alert",
 			l10n("downloadFiles"), contentNode, "grouped-downloads", true);
@@ -997,8 +997,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 
 	private void sendConfirmPanicPage(ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmPanicButtonPageTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
 			l10n("confirmPanicButtonPageTitle"), contentNode, "confirm-panic", true).
@@ -1026,8 +1026,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 		String title = l10n("awaitingPasswordTitle"+(uploads ? "Uploads" : "Downloads"));
 		if(core.getNode().awaitingPassword()) {
 			PageNode page = ctx.getPageMaker().getPageNode(title, ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", title, contentNode, null, true);
 
@@ -1059,8 +1059,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 	private void writeError(String header, String message, ToadletContext context, boolean returnToQueuePage, boolean returnToInsertPage) throws ToadletContextClosedException, IOException {
 		PageMaker pageMaker = context.getPageMaker();
 		PageNode page = pageMaker.getPageNode(header, context);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		if(context.isAllowedFullAccess())
 			contentNode.addChild(context.getAlertManager().createSummary());
 		HTMLNode infoboxContent = pageMaker.getInfobox("infobox-error", header, contentNode, "queue-error", false);
@@ -1143,8 +1143,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 							long reallyQueued = core.getRequestStarters().chkFetchSchedulerBulk.countQueuedRequests() + core.getRequestStarters().chkFetchSchedulerRT.countQueuedRequests();
 							Logger.minor(this, "Total queued CHK requests (including transient): "+reallyQueued);
 							PageNode page = pageMaker.getPageNode(l10n("title"), ctx);
-							pageNode = page.outer;
-							HTMLNode contentNode = page.content;
+							pageNode = page.getOuterNode();
+							HTMLNode contentNode = page.getContentNode();
 							/* add alert summary box */
 							if(ctx.isAllowedFullAccess())
 								contentNode.addChild(ctx.getAlertManager().createSummary());
@@ -1449,8 +1449,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				") "+l10n("titleDownloads");
 
 		PageNode page = pageMaker.getPageNode(pageName, ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		/* add alert summary box */
 		if(ctx.isAllowedFullAccess())
@@ -1458,8 +1458,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 
 		/* navigation bar */
 		InfoboxNode infobox = pageMaker.getInfobox("navbar", l10n("requestNavigation"), null, false);
-		HTMLNode navigationBar = infobox.outer;
-		HTMLNode navigationContent = infobox.content.addChild("ul");
+		HTMLNode navigationBar = infobox.getOuterNode();
+		HTMLNode navigationContent = infobox.getContentNode().addChild("ul");
 		boolean includeNavigationBar = false;
 		if (!completedDownloadToTemp.isEmpty()) {
 			navigationContent.addChild("li").addChild("a", "href", "#completedDownloadToTemp", l10n("completedDtoTemp", new String[]{ "size" }, new String[]{ String.valueOf(completedDownloadToTemp.size()) }));
@@ -1783,8 +1783,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 
 	private HTMLNode sendEmptyQueuePage(ToadletContext ctx, PageMaker pageMaker) {
 	PageNode page = pageMaker.getPageNode(l10n("title"+(uploads?"Uploads":"Downloads")), ctx);
-	HTMLNode pageNode = page.outer;
-	HTMLNode contentNode = page.content;
+	HTMLNode pageNode = page.getOuterNode();
+	HTMLNode contentNode = page.getContentNode();
 	/* add alert summary box */
 	if(ctx.isAllowedFullAccess())
 	    contentNode.addChild(ctx.getAlertManager().createSummary());
@@ -1933,8 +1933,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 
 	private HTMLNode createPanicBox(PageMaker pageMaker, ToadletContext ctx) {
 		InfoboxNode infobox = pageMaker.getInfobox("infobox-alert", l10n("panicButtonTitle"), "panic-button", true);
-		HTMLNode panicBox = infobox.outer;
-		HTMLNode panicForm = ctx.addFormChild(infobox.content, path(), "queuePanicForm");
+		HTMLNode panicBox = infobox.getOuterNode();
+		HTMLNode panicForm = ctx.addFormChild(infobox.getContentNode(), path(), "queuePanicForm");
 		panicForm.addChild("#", (SimpleToadletServer.noConfirmPanic ? l10n("panicButtonNoConfirmation") : l10n("panicButtonWithConfirmation")) + ' ');
 		panicForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "panic", l10n("panicButton") });
 		return panicBox;
@@ -1995,8 +1995,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 	private HTMLNode createBulkDownloadForm(ToadletContext ctx, PageMaker pageMaker) {
 		InfoboxNode infobox = pageMaker.getInfobox(
 			l10n("downloadFiles"), "grouped-downloads", true);
-		HTMLNode downloadBox = infobox.outer;
-		HTMLNode downloadBoxContent = infobox.content;
+		HTMLNode downloadBox = infobox.getOuterNode();
+		HTMLNode downloadBoxContent = infobox.getContentNode();
 		HTMLNode downloadForm = ctx.addFormChild(downloadBoxContent, path(), "queueDownloadForm");
 		downloadForm.addChild("#", l10n("downloadFilesInstructions"));
 		downloadForm.addChild("br");

--- a/src/freenet/clients/http/QueueToadlet.java
+++ b/src/freenet/clients/http/QueueToadlet.java
@@ -286,7 +286,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 					new String[] { "type", "name", "value" },
 					new String[] { "submit", "cancel", NodeL10n.getBase().getString("Toadlet.no") });
 
-				this.writeHTMLReply(ctx, 200, "OK", page.getOuterNode().generate());
+				this.writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			} else if(request.isPartSet("remove_request") && !request.getPartAsStringFailsafe("remove_request", 128).isEmpty()) {
 				// Remove all requested (i.e. selected) requests from the queue, regardless of
@@ -504,7 +504,6 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				boolean displaySuccessBox = !success.isEmpty();
 
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("downloadFiles"), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 
 				HTMLNode alertContent = ctx.getPageMaker().getInfobox(
@@ -534,7 +533,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				}
 				alertContent.addChild("a", "href", path(),
 					NodeL10n.getBase().getString("Toadlet.returnToQueuepage"));
-				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			} else if (request.isPartSet("change_priority_top")) {
 				handleChangePriority(request, ctx, "_top");
@@ -868,7 +867,6 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				return;
 			} else if (request.isPartSet("recommend_request")) {
 				PageNode page = ctx.getPageMaker().getPageNode(l10n("recommendAFileToFriends"), ctx);
-				HTMLNode pageNode = page.getOuterNode();
 				HTMLNode contentNode = page.getContentNode();
 				HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("#", l10n("recommendAFileToFriends"), contentNode, "recommend-file", true);
 				HTMLNode form = ctx.addFormChild(infoboxContent, path(), "recommendForm2");
@@ -917,7 +915,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 					new String[]{"type", "name", "value"},
 					new String[]{"submit", "recommend_uri", l10n("recommend")});
 
-				this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+				this.writeHTMLReply(ctx, 200, "OK", page.generate());
 				return;
 			} else if(request.isPartSet("recommend_uri")) {
 				String description = request.getPartAsStringFailsafe("description", 32768);
@@ -970,7 +968,6 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 	private void downloadDisallowedPage (NotAllowedException e, String downloadPath, ToadletContext ctx)
 		throws IOException, ToadletContextClosedException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("downloadFiles"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		Logger.warning(this, e.toString());
 		HTMLNode alert = ctx.getPageMaker().getInfobox("infobox-alert",
@@ -978,7 +975,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 		alert.addChild("ul", l10n("downloadDisallowed", "directory", downloadPath));
 		alert.addChild("a", "href", path(),
 			NodeL10n.getBase().getString("Toadlet.returnToQueuepage"));
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private File getDownloadsDir (String downloadPath) throws NotAllowedException {
@@ -997,7 +994,6 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 
 	private void sendConfirmPanicPage(ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmPanicButtonPageTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
@@ -1019,14 +1015,13 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 		else
 			content.addChild("p").addChild("a", "href", path(), l10n("backToDownloadsPage"));
 
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private void sendPersistenceDisabledError(ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		String title = l10n("awaitingPasswordTitle"+(uploads ? "Uploads" : "Downloads"));
 		if(core.getNode().awaitingPassword()) {
 			PageNode page = ctx.getPageMaker().getPageNode(title, ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", title, contentNode, null, true);
@@ -1035,7 +1030,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 
 			addHomepageLink(infoboxContent);
 
-			writeHTMLReply(ctx, 500, "Internal Server Error", pageNode.generate());
+			writeHTMLReply(ctx, 500, "Internal Server Error", page.generate());
 			return;
 
 		}
@@ -1059,7 +1054,6 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 	private void writeError(String header, String message, ToadletContext context, boolean returnToQueuePage, boolean returnToInsertPage) throws ToadletContextClosedException, IOException {
 		PageMaker pageMaker = context.getPageMaker();
 		PageNode page = pageMaker.getPageNode(header, context);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		if(context.isAllowedFullAccess())
 			contentNode.addChild(context.getAlertManager().createSummary());
@@ -1069,7 +1063,7 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 			NodeL10n.getBase().addL10nSubstitution(infoboxContent.addChild("div"), "QueueToadlet.returnToQueuePage", new String[] { "link" }, new HTMLNode[] { HTMLNode.link(path()) });
 		else if(returnToInsertPage)
 			NodeL10n.getBase().addL10nSubstitution(infoboxContent.addChild("div"), "QueueToadlet.tryAgainUploadFilePage", new String[] { "link" }, new HTMLNode[] { HTMLNode.link(FileInsertWizardToadlet.PATH) });
-		writeHTMLReply(context, 400, "Bad request", pageNode.generate());
+		writeHTMLReply(context, 400, "Bad request", page.generate());
 	}
 
 	public void handleMethodGET(URI uri, final HTTPRequest request, final ToadletContext ctx)

--- a/src/freenet/clients/http/SecurityLevelsToadlet.java
+++ b/src/freenet/clients/http/SecurityLevelsToadlet.java
@@ -79,8 +79,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 						HTMLNode warning = node.getSecurityLevels().getConfirmWarning(newThreatLevel, confirm);
 						if(warning != null) {
 							PageNode page = ctx.getPageMaker().getPageNode(NodeL10n.getBase().getString("ConfigToadlet.fullTitle"), ctx);
-							pageNode = page.outer;
-							content = page.content;
+							pageNode = page.getOuterNode();
+							content = page.getContentNode();
 							formNode = ctx.addFormChild(content, ".", "configFormSecLevels");
 							ul = formNode.addChild("ul", "class", "config");
 							HTMLNode seclevelGroup = ul.addChild("li");
@@ -158,8 +158,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 							} catch (MasterKeysWrongPasswordException e) {
 								System.err.println("Wrong password!");
 								PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
-								pageNode = page.outer;
-								HTMLNode contentNode = page.content;
+								pageNode = page.getOuterNode();
+								HTMLNode contentNode = page.getContentNode();
 
 								content = ctx.getPageMaker().getInfobox("infobox-error",
 										l10nSec("passwordWrongTitle"), contentNode, "wrong-password", true).
@@ -217,8 +217,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 							} catch (MasterKeysWrongPasswordException e) {
 								System.err.println("Wrong password!");
 								PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordForDecryptTitle"), ctx);
-								pageNode = page.outer;
-								HTMLNode contentNode = page.content;
+								pageNode = page.getOuterNode();
+								HTMLNode contentNode = page.getContentNode();
 
 								content = ctx.getPageMaker().getInfobox("infobox-error",
 										l10nSec("passwordWrongTitle"), contentNode, "wrong-password", true).
@@ -246,8 +246,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 						} else if(core.getNode().getMasterPasswordFile().exists()) {
 							// We need the old password
 							PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordForDecryptTitle"), ctx);
-							pageNode = page.outer;
-							HTMLNode contentNode = page.content;
+							pageNode = page.getOuterNode();
+							HTMLNode contentNode = page.getContentNode();
 
 							content = ctx.getPageMaker().getInfobox("infobox-error",
 									l10nSec("passwordForDecryptTitle"), contentNode, "password-prompt", false).
@@ -361,8 +361,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 	public static HTMLNode sendCantDeleteMasterKeysFileInner(ToadletContext ctx, String filename, boolean forFirstTimeWizard, String physicalSecurityLevel, Node node) {
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("cantDeletePasswordFileTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
 				l10nSec("cantDeletePasswordFileTitle"), contentNode, "password-error", true).
@@ -397,8 +397,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 		// Must set a password!
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("changePasswordTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
 				l10nSec("changePasswordTitle"), contentNode, "password-change", true).
@@ -430,8 +430,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 		// Must set a password!
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("setPasswordTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
 				l10nSec("setPasswordTitle"), contentNode, "password-prompt", false).
@@ -457,8 +457,8 @@ public class SecurityLevelsToadlet extends Toadlet {
             return;
 
 		PageNode page = ctx.getPageMaker().getPageNode(NodeL10n.getBase().getString("SecurityLevelsToadlet.fullTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		contentNode.addChild(ctx.getAlertManager().createSummary());
 
@@ -658,8 +658,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 	public static HTMLNode sendPasswordFileCorruptedPageInner(boolean tooBig, ToadletContext ctx, boolean forSecLevels, boolean forFirstTimeWizard, String masterPasswordFile, Node node) {
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordFileCorruptedTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		HTMLNode infoBox = ctx.getPageMaker().getInfobox("infobox-error",
 		        l10nSec("passwordFileCorruptedTitle"), contentNode, "password-error", false).
 		        addChild("div", "class", "infobox-content");
@@ -687,8 +687,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 	 */
 	private void sendPasswordFormPage(boolean wasWrong, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
 				wasWrong ? l10nSec("passwordWrongTitle") : l10nSec("enterPasswordTitle"), contentNode, "password-error", false).
@@ -708,8 +708,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 	*/
 	private void sendPasswordPageMismatch(ToadletContext ctx, String threatLevel) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
 				l10nSec("setPasswordTitle"), contentNode, "password-error", false).addChild("div", "class", "infobox-content");
 		content.addChild("p", l10nSec("passwordsDoNotMatch"));

--- a/src/freenet/clients/http/SecurityLevelsToadlet.java
+++ b/src/freenet/clients/http/SecurityLevelsToadlet.java
@@ -158,7 +158,6 @@ public class SecurityLevelsToadlet extends Toadlet {
 							} catch (MasterKeysWrongPasswordException e) {
 								System.err.println("Wrong password!");
 								PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
-								pageNode = page.getOuterNode();
 								HTMLNode contentNode = page.getContentNode();
 
 								content = ctx.getPageMaker().getInfobox("infobox-error",
@@ -166,7 +165,7 @@ public class SecurityLevelsToadlet extends Toadlet {
 										addChild("div", "class", "infobox-content");
 								SecurityLevelsToadlet.generatePasswordFormPage(true, ctx.getContainer(), content, false, false, true, newPhysicalLevel.name(), null);
 								addBackToSeclevelsLink(content);
-								writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+								writeHTMLReply(ctx, 200, "OK", page.generate());
 								if(changedAnything)
 									core.storeConfig();
 								return;
@@ -217,7 +216,6 @@ public class SecurityLevelsToadlet extends Toadlet {
 							} catch (MasterKeysWrongPasswordException e) {
 								System.err.println("Wrong password!");
 								PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordForDecryptTitle"), ctx);
-								pageNode = page.getOuterNode();
 								HTMLNode contentNode = page.getContentNode();
 
 								content = ctx.getPageMaker().getInfobox("infobox-error",
@@ -228,7 +226,7 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 								addBackToSeclevelsLink(content);
 
-								writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+								writeHTMLReply(ctx, 200, "OK", page.generate());
 								if(changedAnything)
 									core.storeConfig();
 								return;
@@ -246,7 +244,6 @@ public class SecurityLevelsToadlet extends Toadlet {
 						} else if(core.getNode().getMasterPasswordFile().exists()) {
 							// We need the old password
 							PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordForDecryptTitle"), ctx);
-							pageNode = page.getOuterNode();
 							HTMLNode contentNode = page.getContentNode();
 
 							content = ctx.getPageMaker().getInfobox("infobox-error",
@@ -261,7 +258,7 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 							addBackToSeclevelsLink(content);
 
-							writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+							writeHTMLReply(ctx, 200, "OK", page.generate());
 							if(changedAnything)
 								core.storeConfig();
 							return;
@@ -397,7 +394,6 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 		// Must set a password!
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("changePasswordTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
@@ -422,7 +418,7 @@ public class SecurityLevelsToadlet extends Toadlet {
 		}
 		addBackToSeclevelsLink(content);
 
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 
 	}
 
@@ -430,7 +426,6 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 		// Must set a password!
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("setPasswordTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
@@ -445,7 +440,7 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 		addBackToSeclevelsLink(content);
 
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private static void addBackToSeclevelsLink(HTMLNode content) {
@@ -457,14 +452,13 @@ public class SecurityLevelsToadlet extends Toadlet {
             return;
 
 		PageNode page = ctx.getPageMaker().getPageNode(NodeL10n.getBase().getString("SecurityLevelsToadlet.fullTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		contentNode.addChild(ctx.getAlertManager().createSummary());
 
 		drawSecurityLevelsPage(contentNode, ctx);
 
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private void drawSecurityLevelsPage(HTMLNode contentNode, ToadletContext ctx) {
@@ -687,7 +681,6 @@ public class SecurityLevelsToadlet extends Toadlet {
 	 */
 	private void sendPasswordFormPage(boolean wasWrong, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
@@ -698,7 +691,7 @@ public class SecurityLevelsToadlet extends Toadlet {
 
 		addHomepageLink(content);
 
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	/** Send a page asking for the master password.
@@ -708,14 +701,13 @@ public class SecurityLevelsToadlet extends Toadlet {
 	*/
 	private void sendPasswordPageMismatch(ToadletContext ctx, String threatLevel) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10nSec("passwordPageTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		HTMLNode content = ctx.getPageMaker().getInfobox("infobox-error",
 				l10nSec("setPasswordTitle"), contentNode, "password-error", false).addChild("div", "class", "infobox-content");
 		content.addChild("p", l10nSec("passwordsDoNotMatch"));
 		generatePasswordFormPage(false, ctx.getContainer(), content, false, false, true, threatLevel, null);
 		addBackToSeclevelsLink(content);
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	/**

--- a/src/freenet/clients/http/SimpleHelpToadlet.java
+++ b/src/freenet/clients/http/SimpleHelpToadlet.java
@@ -29,7 +29,6 @@ public class SimpleHelpToadlet extends Toadlet {
 
 		
 		PageNode page = ctx.getPageMaker().getPageNode("Freenet " + NodeL10n.getBase().getString("FProxyToadlet.help"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		
 		if(ctx.isAllowedFullAccess())
@@ -58,7 +57,7 @@ public class SimpleHelpToadlet extends Toadlet {
 		helpScreenContent3.addChild("#", NodeL10n.getBase().getString("SimpleHelpToadlet.connectivityText"));
 		
 		
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 		
 	}
 

--- a/src/freenet/clients/http/SimpleHelpToadlet.java
+++ b/src/freenet/clients/http/SimpleHelpToadlet.java
@@ -29,8 +29,8 @@ public class SimpleHelpToadlet extends Toadlet {
 
 		
 		PageNode page = ctx.getPageMaker().getPageNode("Freenet " + NodeL10n.getBase().getString("FProxyToadlet.help"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		
 		if(ctx.isAllowedFullAccess())
 			contentNode.addChild(ctx.getAlertManager().createSummary());

--- a/src/freenet/clients/http/StartupToadlet.java
+++ b/src/freenet/clients/http/StartupToadlet.java
@@ -31,7 +31,6 @@ public class StartupToadlet extends Toadlet {
 		else {
 			String desc = NodeL10n.getBase().getString("StartupToadlet.title");
 			PageNode page = ctx.getPageMaker().getPageNode(desc, ctx, new RenderParameters().renderStatus(false).renderNavigationLinks(false).renderModeSwitch(false));
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode headNode = page.getHeadNode();
 			headNode.addChild("meta", new String[]{"http-equiv", "content"}, new String[]{"refresh", "1; url="});
 			HTMLNode contentNode = page.getContentNode();
@@ -47,7 +46,7 @@ public class StartupToadlet extends Toadlet {
 			WelcomeToadlet.maybeDisplayWrapperLogfile(ctx, contentNode);
 
 			//TODO: send a Retry-After header ?
-			writeHTMLReply(ctx, 503, desc, pageNode.generate());
+			writeHTMLReply(ctx, 503, desc, page.generate());
 		}
 	}
 

--- a/src/freenet/clients/http/StartupToadlet.java
+++ b/src/freenet/clients/http/StartupToadlet.java
@@ -32,7 +32,7 @@ public class StartupToadlet extends Toadlet {
 			String desc = NodeL10n.getBase().getString("StartupToadlet.title");
 			PageNode page = ctx.getPageMaker().getPageNode(desc, ctx, new RenderParameters().renderStatus(false).renderNavigationLinks(false).renderModeSwitch(false));
 			HTMLNode pageNode = page.getOuterNode();
-			HTMLNode headNode = page.headNode;
+			HTMLNode headNode = page.getHeadNode();
 			headNode.addChild("meta", new String[]{"http-equiv", "content"}, new String[]{"refresh", "1; url="});
 			HTMLNode contentNode = page.getContentNode();
 

--- a/src/freenet/clients/http/StartupToadlet.java
+++ b/src/freenet/clients/http/StartupToadlet.java
@@ -31,10 +31,10 @@ public class StartupToadlet extends Toadlet {
 		else {
 			String desc = NodeL10n.getBase().getString("StartupToadlet.title");
 			PageNode page = ctx.getPageMaker().getPageNode(desc, ctx, new RenderParameters().renderStatus(false).renderNavigationLinks(false).renderModeSwitch(false));
-			HTMLNode pageNode = page.outer;
+			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode headNode = page.headNode;
 			headNode.addChild("meta", new String[]{"http-equiv", "content"}, new String[]{"refresh", "1; url="});
-			HTMLNode contentNode = page.content;
+			HTMLNode contentNode = page.getContentNode();
 
 			if(!isPRNGReady) {
 				HTMLNode prngInfoboxContent = ctx.getPageMaker().getInfobox("infobox-error", NodeL10n.getBase().getString("StartupToadlet.entropyErrorTitle"), contentNode, null, true);

--- a/src/freenet/clients/http/StatisticsToadlet.java
+++ b/src/freenet/clients/http/StatisticsToadlet.java
@@ -173,8 +173,8 @@ public class StatisticsToadlet extends Toadlet {
 
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("fullTitle"), ctx);
 		boolean advancedMode = ctx.isAdvancedModeEnabled();
-		pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		// FIXME! We need some nice images
 		final long now = System.currentTimeMillis();
@@ -533,8 +533,8 @@ public class StatisticsToadlet extends Toadlet {
 
 	private void showRequesters(HTTPRequest request, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("fullTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		drawClientRequestersBox(contentNode);
 		writeHTMLReply(ctx, 200, "OK", pageNode.generate());

--- a/src/freenet/clients/http/StatisticsToadlet.java
+++ b/src/freenet/clients/http/StatisticsToadlet.java
@@ -135,8 +135,8 @@ public class StatisticsToadlet extends Toadlet {
 
 		node.getClientCore().getBandwidthStatsPutter().updateData(node);
 
-		HTMLNode pageNode;
-		
+		PageNode page = ctx.getPageMaker().getPageNode(l10n("fullTitle"), ctx);
+
 		// Synchronize to avoid problems with DecimalFormat.
 		synchronized(this) {
 		
@@ -171,9 +171,7 @@ public class StatisticsToadlet extends Toadlet {
 		int numberOfDisconnecting = PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING);
 		int numberOfNoLoadStats = PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS);
 
-		PageNode page = ctx.getPageMaker().getPageNode(l10n("fullTitle"), ctx);
 		boolean advancedMode = ctx.isAdvancedModeEnabled();
-		pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		// FIXME! We need some nice images
@@ -528,16 +526,15 @@ public class StatisticsToadlet extends Toadlet {
 		
 		}
 
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private void showRequesters(HTTPRequest request, ToadletContext ctx) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("fullTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		drawClientRequestersBox(contentNode);
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	private void drawLoadBalancingBox(HTMLNode loadStatsInfobox, boolean realTime) {

--- a/src/freenet/clients/http/Toadlet.java
+++ b/src/freenet/clients/http/Toadlet.java
@@ -399,8 +399,8 @@ public abstract class Toadlet {
 	 */
 	protected void sendErrorPage(ToadletContext ctx, int code, String desc, HTMLNode message) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(desc, ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", desc, contentNode, null, true);
 		infoboxContent.addChild(message);
@@ -423,8 +423,8 @@ public abstract class Toadlet {
 	 */
 	protected void sendErrorPage(ToadletContext ctx, String desc, String message, Throwable t) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(desc, ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", desc, contentNode, null, true);
 		infoboxContent.addChild("#", message);

--- a/src/freenet/clients/http/Toadlet.java
+++ b/src/freenet/clients/http/Toadlet.java
@@ -399,7 +399,6 @@ public abstract class Toadlet {
 	 */
 	protected void sendErrorPage(ToadletContext ctx, int code, String desc, HTMLNode message) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(desc, ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", desc, contentNode, null, true);
@@ -409,7 +408,7 @@ public abstract class Toadlet {
 		infoboxContent.addChild("br");
 		addHomepageLink(infoboxContent);
 
-		writeHTMLReply(ctx, code, desc, pageNode.generate());
+		writeHTMLReply(ctx, code, desc, page.generate());
 	}
 
 	/**
@@ -423,7 +422,6 @@ public abstract class Toadlet {
 	 */
 	protected void sendErrorPage(ToadletContext ctx, String desc, String message, Throwable t) throws ToadletContextClosedException, IOException {
 		PageNode page = ctx.getPageMaker().getPageNode(desc, ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("infobox-error", desc, contentNode, null, true);
@@ -440,7 +438,7 @@ public abstract class Toadlet {
 		infoboxContent.addChild("a", "href", ".", l10n("returnToPrevPage"));
 		addHomepageLink(infoboxContent);
 
-		writeHTMLReply(ctx, 500, desc, pageNode.generate());
+		writeHTMLReply(ctx, 500, desc, page.generate());
 	}
 
 	/**

--- a/src/freenet/clients/http/TranslationToadlet.java
+++ b/src/freenet/clients/http/TranslationToadlet.java
@@ -65,7 +65,6 @@ public class TranslationToadlet extends Toadlet {
 		} else if (request.isParameterSet("translation_updated")) {
 			String key = request.getParam("translation_updated");
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("translationUpdatedTitle"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode translationNode = contentNode.addChild("div", "class", "translation");
@@ -94,13 +93,12 @@ public class TranslationToadlet extends Toadlet {
 			footer.addChild("%", "&nbsp;&nbsp;");
 			footer.addChild("a", "href", TOADLET_URL + (showEverything ? "" : "?toTranslateOnly")).addChild("#", l10n("returnToTranslations"));
 
-			this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+			this.writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;				
 		} else if (request.isParameterSet("translate")) {
 			boolean gotoNext = request.isParameterSet("gotoNext");
 			String key = request.getParam("translate");
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("translationUpdateTitle"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode translationNode = contentNode.addChild("div", "class", "translation");
@@ -140,12 +138,11 @@ public class TranslationToadlet extends Toadlet {
 				updateForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "hidden", "toTranslateOnly", key });
 			
 			updateForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel") });
-			this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+			this.writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		} else if (request.isParameterSet("remove")) {
 			String key = request.getParam("remove");
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("removeOverrideTitle"), ctx);
-			HTMLNode pageNode = page.getOuterNode();
 			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode content = ctx.getPageMaker().getInfobox("infobox-warning", l10n("removeOverrideWarningTitle"), contentNode, "translation-override", true);
@@ -159,12 +156,11 @@ public class TranslationToadlet extends Toadlet {
 			removeForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "remove_confirmed", l10n("remove") });
 			removeForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel") });
 			
-			this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+			this.writeHTMLReply(ctx, 200, "OK", page.generate());
 			return;
 		}
 
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("translationUpdateTitle"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 
 		final HTMLNode translatingForBox = ctx.getPageMaker().getInfobox(null, l10n("selectTranslation"), contentNode);
@@ -221,7 +217,7 @@ public class TranslationToadlet extends Toadlet {
 			contentRow.addChild("td", "class", "translation-new").addChild(_setOrRemoveOverride(key, isOverriden, showEverything));
 		}
 		
-		this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		this.writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx) throws ToadletContextClosedException, IOException {

--- a/src/freenet/clients/http/TranslationToadlet.java
+++ b/src/freenet/clients/http/TranslationToadlet.java
@@ -65,8 +65,8 @@ public class TranslationToadlet extends Toadlet {
 		} else if (request.isParameterSet("translation_updated")) {
 			String key = request.getParam("translation_updated");
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("translationUpdatedTitle"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode translationNode = contentNode.addChild("div", "class", "translation");
 			HTMLNode legendTable = translationNode.addChild("table", "class", "translation");
@@ -100,8 +100,8 @@ public class TranslationToadlet extends Toadlet {
 			boolean gotoNext = request.isParameterSet("gotoNext");
 			String key = request.getParam("translate");
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("translationUpdateTitle"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode translationNode = contentNode.addChild("div", "class", "translation");
 			HTMLNode updateForm =  ctx.addFormChild(translationNode, TOADLET_URL, "trans_update");
@@ -145,8 +145,8 @@ public class TranslationToadlet extends Toadlet {
 		} else if (request.isParameterSet("remove")) {
 			String key = request.getParam("remove");
 			PageNode page = ctx.getPageMaker().getPageNode(l10n("removeOverrideTitle"), ctx);
-			HTMLNode pageNode = page.outer;
-			HTMLNode contentNode = page.content;
+			HTMLNode pageNode = page.getOuterNode();
+			HTMLNode contentNode = page.getContentNode();
 
 			HTMLNode content = ctx.getPageMaker().getInfobox("infobox-warning", l10n("removeOverrideWarningTitle"), contentNode, "translation-override", true);
 			content.addChild("p").addChild("#",
@@ -164,8 +164,8 @@ public class TranslationToadlet extends Toadlet {
 		}
 
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("translationUpdateTitle"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 
 		final HTMLNode translatingForBox = ctx.getPageMaker().getInfobox(null, l10n("selectTranslation"), contentNode);
 		ArrayList<String> elementsToTranslate = new ArrayList<String>();

--- a/src/freenet/clients/http/UserAlertsToadlet.java
+++ b/src/freenet/clients/http/UserAlertsToadlet.java
@@ -30,8 +30,8 @@ public class UserAlertsToadlet extends Toadlet {
             return;
 
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.outer;
-		HTMLNode contentNode = page.content;
+		HTMLNode pageNode = page.getOuterNode();
+		HTMLNode contentNode = page.getContentNode();
 		HTMLNode alertsNode = ctx.getAlertManager().createAlerts(false);
 		if (alertsNode.getFirstTag() == null) {
 			alertsNode = new HTMLNode("div", "class", "infobox");

--- a/src/freenet/clients/http/UserAlertsToadlet.java
+++ b/src/freenet/clients/http/UserAlertsToadlet.java
@@ -30,7 +30,6 @@ public class UserAlertsToadlet extends Toadlet {
             return;
 
 		PageNode page = ctx.getPageMaker().getPageNode(l10n("title"), ctx);
-		HTMLNode pageNode = page.getOuterNode();
 		HTMLNode contentNode = page.getContentNode();
 		HTMLNode alertsNode = ctx.getAlertManager().createAlerts(false);
 		if (alertsNode.getFirstTag() == null) {
@@ -39,7 +38,7 @@ public class UserAlertsToadlet extends Toadlet {
 		}
 		contentNode.addChild(alertsNode);
 
-		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+		writeHTMLReply(ctx, 200, "OK", page.generate());
 	}
 
 	public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx) throws ToadletContextClosedException, IOException {

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -169,28 +169,25 @@ public class WelcomeToadlet extends Toadlet {
         	if(!ctx.checkFormPassword(request)) return;
             // false for no navigation bars, because that would be very silly
             PageNode page = ctx.getPageMaker().getPageNode(l10n("updatingTitle"), ctx);
-            HTMLNode pageNode = page.getOuterNode();
             HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-information", l10n("updatingTitle"), contentNode, null, true);
             content.addChild("p").addChild("#", l10n("updating"));
             content.addChild("p").addChild("#", l10n("thanks"));
-            writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+            writeHTMLReply(ctx, 200, "OK", page.generate());
             Logger.normal(this, "Node is updating/restarting");
             node.getNodeUpdater().arm();
         } else if (!request.getPartAsStringFailsafe("update", 32).isEmpty()) {
         	PageNode page = ctx.getPageMaker().getPageNode(l10n("nodeUpdateConfirmTitle"), ctx);
-            HTMLNode pageNode = page.getOuterNode();
             HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-query", l10n("nodeUpdateConfirmTitle"), contentNode, "update-node-confirm", true);
             content.addChild("p").addChild("#", l10n("nodeUpdateConfirm"));
             HTMLNode updateForm = ctx.addFormChild(content, "/", "updateConfirmForm");
             updateForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel")});
             updateForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "updateconfirm", l10n("update")});
-            writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+            writeHTMLReply(ctx, 200, "OK", page.generate());
 	} else if (request.isPartSet("getThreadDump")) {
     	if(!ctx.checkFormPassword(request)) return;
             PageNode page = ctx.getPageMaker().getPageNode(l10n("threadDumpTitle"), ctx);
-            HTMLNode pageNode = page.getOuterNode();
             HTMLNode contentNode = page.getContentNode();
             if (node.isUsingWrapper()) {
             	ctx.getPageMaker().getInfobox("#", l10n("threadDumpSubTitle"), contentNode, "thread-dump-generation", true).
@@ -201,7 +198,7 @@ public class WelcomeToadlet extends Toadlet {
             	ctx.getPageMaker().getInfobox("infobox-error", l10n("threadDumpSubTitle"), contentNode, "thread-dump-generation", true).
             		addChild("#", l10n("threadDumpNotUsingWrapper"));
             }
-            this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+            this.writeHTMLReply(ctx, 200, "OK", page.generate());
         } else if (request.isPartSet("disable")) {
         	if(!ctx.checkFormPassword(request)) return;
 	    int validAlertsRemaining = 0;
@@ -237,7 +234,6 @@ public class WelcomeToadlet extends Toadlet {
             RandomAccessBucket bucket = request.getPart("filename");
 
             PageNode page = ctx.getPageMaker().getPageNode(l10n("insertedTitle"), ctx);
-            HTMLNode pageNode = page.getOuterNode();
             HTMLNode contentNode = page.getContentNode();
             HTMLNode content;
             String filenameHint = null;
@@ -273,7 +269,7 @@ public class WelcomeToadlet extends Toadlet {
             content.addChild("br");
             addHomepageLink(content);
 
-            writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+            writeHTMLReply(ctx, 200, "OK", page.generate());
             request.freeParts();
             bucket.free();
             return;
@@ -290,14 +286,13 @@ public class WelcomeToadlet extends Toadlet {
             return;
         } else if (request.isPartSet("exit")) {
         	PageNode page = ctx.getPageMaker().getPageNode(l10n("shutdownConfirmTitle"), ctx);
-            HTMLNode pageNode = page.getOuterNode();
             HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-query", l10n("shutdownConfirmTitle"), contentNode, "shutdown-confirm", true);
             content.addChild("p").addChild("#", l10n("shutdownConfirm"));
             HTMLNode shutdownForm = ctx.addFormChild(content.addChild("p"), "/", "confirmShutdownForm");
             shutdownForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel")});
             shutdownForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "shutdownconfirm", l10n("shutdown")});
-            writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+            writeHTMLReply(ctx, 200, "OK", page.generate());
             return;
         } else if (request.isPartSet("shutdownconfirm")) {
         	if(!ctx.checkFormPassword(request)) return;
@@ -316,14 +311,13 @@ public class WelcomeToadlet extends Toadlet {
             return;
         } else if (request.isPartSet("restart")) {
         	PageNode page = ctx.getPageMaker().getPageNode(l10n("restartConfirmTitle"), ctx);
-            HTMLNode pageNode = page.getOuterNode();
             HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-query", l10n("restartConfirmTitle"), contentNode, "restart-confirm", true);
             content.addChild("p").addChild("#", l10n("restartConfirm"));
             HTMLNode restartForm = ctx.addFormChild(content.addChild("p"), "/", "confirmRestartForm");
             restartForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel")});
             restartForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "restartconfirm", l10n("restart")});
-            writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+            writeHTMLReply(ctx, 200, "OK", page.generate());
             return;
         } else if (request.isPartSet("restartconfirm")) {
         	if(!ctx.checkFormPassword(request)) return;
@@ -428,14 +422,13 @@ public class WelcomeToadlet extends Toadlet {
                 }
                 // Tell the user that the node is shutting down
                 PageNode page = ctx.getPageMaker().getPageNode("Node Shutdown", ctx, new RenderParameters().renderNavigationLinks(false));
-                HTMLNode pageNode = page.getOuterNode();
                 HTMLNode contentNode = page.getContentNode();
                 ctx.getPageMaker().getInfobox("infobox-information", l10n("shutdownDone"), contentNode, "shutdown-progressing", true).
                 	addChild("#", l10n("thanks"));
 
                 WelcomeToadlet.maybeDisplayWrapperLogfile(ctx, contentNode);
 
-                this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+                this.writeHTMLReply(ctx, 200, "OK", page.generate());
                 return;
             } else if (request.isParameterSet("restarted")) {
                 if ((!request.isParameterSet("formPassword")) || !request.getParam("formPassword").equals(ctx.getFormPassword())) {
@@ -446,7 +439,6 @@ public class WelcomeToadlet extends Toadlet {
                 return;
             } else if (!request.getParam("newbookmark").isEmpty()) {
             	PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmAddBookmarkTitle"), ctx);
-                HTMLNode pageNode = page.getOuterNode();
                 HTMLNode contentNode = page.getContentNode();
                 HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("#", l10n("confirmAddBookmarkSubTitle"), contentNode, "add-bookmark-confirm", true);
                 HTMLNode addForm = ctx.addFormChild(infoboxContent, "/bookmarkEditor/", "editBookmarkForm");
@@ -494,7 +486,7 @@ public class WelcomeToadlet extends Toadlet {
 
                 addForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "addbookmark", NodeL10n.getBase().getString("BookmarkEditorToadlet.addBookmark")});
 
-                this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+                this.writeHTMLReply(ctx, 200, "OK", page.generate());
                 return;
         } else if (uri.getQuery() != null && uri.getQuery().startsWith("_CHECKED_HTTP_=")) {
 		//Redirect requests for escaped URLs using the old destination to ExternalLinkToadlet.
@@ -504,7 +496,6 @@ public class WelcomeToadlet extends Toadlet {
         }
 
         PageNode page = ctx.getPageMaker().getPageNode(l10n("homepageFullTitle"), ctx);
-        HTMLNode pageNode = page.getOuterNode();
         HTMLNode contentNode = page.getContentNode();
 
         String useragent = ctx.getHeaders().getFirst("user-agent");
@@ -579,7 +570,7 @@ public class WelcomeToadlet extends Toadlet {
             }
         }
 
-        this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
+        this.writeHTMLReply(ctx, 200, "OK", page.generate());
     }
 
 	private void putFetchKeyBox(ToadletContext ctx, HTMLNode contentNode) {

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -601,7 +601,7 @@ public class WelcomeToadlet extends Toadlet {
         // Tell the user that the node is restarting
         PageNode page = ctx.getPageMaker().getPageNode("Node Restart", ctx, new RenderParameters().renderNavigationLinks(false));
         HTMLNode pageNode = page.getOuterNode();
-        HTMLNode headNode = page.headNode;
+        HTMLNode headNode = page.getHeadNode();
         headNode.addChild("meta", new String[]{"http-equiv", "content"}, new String[]{"refresh", "20; url="});
         HTMLNode contentNode = page.getContentNode();
         ctx.getPageMaker().getInfobox("infobox-information", l10n("restartingTitle"), contentNode, "shutdown-progressing", true).

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -169,8 +169,8 @@ public class WelcomeToadlet extends Toadlet {
         	if(!ctx.checkFormPassword(request)) return;
             // false for no navigation bars, because that would be very silly
             PageNode page = ctx.getPageMaker().getPageNode(l10n("updatingTitle"), ctx);
-            HTMLNode pageNode = page.outer;
-            HTMLNode contentNode = page.content;
+            HTMLNode pageNode = page.getOuterNode();
+            HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-information", l10n("updatingTitle"), contentNode, null, true);
             content.addChild("p").addChild("#", l10n("updating"));
             content.addChild("p").addChild("#", l10n("thanks"));
@@ -179,8 +179,8 @@ public class WelcomeToadlet extends Toadlet {
             node.getNodeUpdater().arm();
         } else if (!request.getPartAsStringFailsafe("update", 32).isEmpty()) {
         	PageNode page = ctx.getPageMaker().getPageNode(l10n("nodeUpdateConfirmTitle"), ctx);
-            HTMLNode pageNode = page.outer;
-            HTMLNode contentNode = page.content;
+            HTMLNode pageNode = page.getOuterNode();
+            HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-query", l10n("nodeUpdateConfirmTitle"), contentNode, "update-node-confirm", true);
             content.addChild("p").addChild("#", l10n("nodeUpdateConfirm"));
             HTMLNode updateForm = ctx.addFormChild(content, "/", "updateConfirmForm");
@@ -190,8 +190,8 @@ public class WelcomeToadlet extends Toadlet {
 	} else if (request.isPartSet("getThreadDump")) {
     	if(!ctx.checkFormPassword(request)) return;
             PageNode page = ctx.getPageMaker().getPageNode(l10n("threadDumpTitle"), ctx);
-            HTMLNode pageNode = page.outer;
-            HTMLNode contentNode = page.content;
+            HTMLNode pageNode = page.getOuterNode();
+            HTMLNode contentNode = page.getContentNode();
             if (node.isUsingWrapper()) {
             	ctx.getPageMaker().getInfobox("#", l10n("threadDumpSubTitle"), contentNode, "thread-dump-generation", true).
             		addChild("#", l10n("threadDumpWithFilename", "filename", WrapperManager.getProperties().getProperty("wrapper.logfile")));
@@ -237,8 +237,8 @@ public class WelcomeToadlet extends Toadlet {
             RandomAccessBucket bucket = request.getPart("filename");
 
             PageNode page = ctx.getPageMaker().getPageNode(l10n("insertedTitle"), ctx);
-            HTMLNode pageNode = page.outer;
-            HTMLNode contentNode = page.content;
+            HTMLNode pageNode = page.getOuterNode();
+            HTMLNode contentNode = page.getContentNode();
             HTMLNode content;
             String filenameHint = null;
             if (key.getKeyType().equals("CHK")) {
@@ -290,8 +290,8 @@ public class WelcomeToadlet extends Toadlet {
             return;
         } else if (request.isPartSet("exit")) {
         	PageNode page = ctx.getPageMaker().getPageNode(l10n("shutdownConfirmTitle"), ctx);
-            HTMLNode pageNode = page.outer;
-            HTMLNode contentNode = page.content;
+            HTMLNode pageNode = page.getOuterNode();
+            HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-query", l10n("shutdownConfirmTitle"), contentNode, "shutdown-confirm", true);
             content.addChild("p").addChild("#", l10n("shutdownConfirm"));
             HTMLNode shutdownForm = ctx.addFormChild(content.addChild("p"), "/", "confirmShutdownForm");
@@ -316,8 +316,8 @@ public class WelcomeToadlet extends Toadlet {
             return;
         } else if (request.isPartSet("restart")) {
         	PageNode page = ctx.getPageMaker().getPageNode(l10n("restartConfirmTitle"), ctx);
-            HTMLNode pageNode = page.outer;
-            HTMLNode contentNode = page.content;
+            HTMLNode pageNode = page.getOuterNode();
+            HTMLNode contentNode = page.getContentNode();
             HTMLNode content = ctx.getPageMaker().getInfobox("infobox-query", l10n("restartConfirmTitle"), contentNode, "restart-confirm", true);
             content.addChild("p").addChild("#", l10n("restartConfirm"));
             HTMLNode restartForm = ctx.addFormChild(content.addChild("p"), "/", "confirmRestartForm");
@@ -428,8 +428,8 @@ public class WelcomeToadlet extends Toadlet {
                 }
                 // Tell the user that the node is shutting down
                 PageNode page = ctx.getPageMaker().getPageNode("Node Shutdown", ctx, new RenderParameters().renderNavigationLinks(false));
-                HTMLNode pageNode = page.outer;
-                HTMLNode contentNode = page.content;
+                HTMLNode pageNode = page.getOuterNode();
+                HTMLNode contentNode = page.getContentNode();
                 ctx.getPageMaker().getInfobox("infobox-information", l10n("shutdownDone"), contentNode, "shutdown-progressing", true).
                 	addChild("#", l10n("thanks"));
 
@@ -446,8 +446,8 @@ public class WelcomeToadlet extends Toadlet {
                 return;
             } else if (!request.getParam("newbookmark").isEmpty()) {
             	PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmAddBookmarkTitle"), ctx);
-                HTMLNode pageNode = page.outer;
-                HTMLNode contentNode = page.content;
+                HTMLNode pageNode = page.getOuterNode();
+                HTMLNode contentNode = page.getContentNode();
                 HTMLNode infoboxContent = ctx.getPageMaker().getInfobox("#", l10n("confirmAddBookmarkSubTitle"), contentNode, "add-bookmark-confirm", true);
                 HTMLNode addForm = ctx.addFormChild(infoboxContent, "/bookmarkEditor/", "editBookmarkForm");
                 addForm.addChild("#", l10n("confirmAddBookmarkWithKey", "key", request.getParam("newbookmark")));
@@ -504,8 +504,8 @@ public class WelcomeToadlet extends Toadlet {
         }
 
         PageNode page = ctx.getPageMaker().getPageNode(l10n("homepageFullTitle"), ctx);
-        HTMLNode pageNode = page.outer;
-        HTMLNode contentNode = page.content;
+        HTMLNode pageNode = page.getOuterNode();
+        HTMLNode contentNode = page.getContentNode();
 
         String useragent = ctx.getHeaders().getFirst("user-agent");
 
@@ -600,10 +600,10 @@ public class WelcomeToadlet extends Toadlet {
     static HTMLNode sendRestartingPageInner(ToadletContext ctx) {
         // Tell the user that the node is restarting
         PageNode page = ctx.getPageMaker().getPageNode("Node Restart", ctx, new RenderParameters().renderNavigationLinks(false));
-        HTMLNode pageNode = page.outer;
+        HTMLNode pageNode = page.getOuterNode();
         HTMLNode headNode = page.headNode;
         headNode.addChild("meta", new String[]{"http-equiv", "content"}, new String[]{"refresh", "20; url="});
-        HTMLNode contentNode = page.content;
+        HTMLNode contentNode = page.getContentNode();
         ctx.getPageMaker().getInfobox("infobox-information", l10n("restartingTitle"), contentNode, "shutdown-progressing", true).
         	addChild("#", l10n("restarting"));
         Logger.normal(WelcomeToadlet.class, "Node is restarting");

--- a/src/freenet/clients/http/ajaxpush/PushTesterToadlet.java
+++ b/src/freenet/clients/http/ajaxpush/PushTesterToadlet.java
@@ -25,7 +25,7 @@ public class PushTesterToadlet extends Toadlet {
 		for (int i = 0; i < 600; i++) {
 			pageNode.getContentNode().addChild(new TesterElement(ctx, String.valueOf(i), 100));
 		}
-		writeHTMLReply(ctx, 200, "OK", pageNode.getOuterNode().generate());
+		writeHTMLReply(ctx, 200, "OK", pageNode.generate());
 	}
 
 	@Override

--- a/src/freenet/clients/http/ajaxpush/PushTesterToadlet.java
+++ b/src/freenet/clients/http/ajaxpush/PushTesterToadlet.java
@@ -23,9 +23,9 @@ public class PushTesterToadlet extends Toadlet {
 	public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx) throws ToadletContextClosedException, IOException, RedirectException {
 		PageNode pageNode = ctx.getPageMaker().getPageNode("Push tester", ctx, new RenderParameters().renderNavigationLinks(false));
 		for (int i = 0; i < 600; i++) {
-			pageNode.content.addChild(new TesterElement(ctx, String.valueOf(i), 100));
+			pageNode.getContentNode().addChild(new TesterElement(ctx, String.valueOf(i), 100));
 		}
-		writeHTMLReply(ctx, 200, "OK", pageNode.outer.generate());
+		writeHTMLReply(ctx, 200, "OK", pageNode.getOuterNode().generate());
 	}
 
 	@Override

--- a/src/freenet/clients/http/wizardsteps/PageHelper.java
+++ b/src/freenet/clients/http/wizardsteps/PageHelper.java
@@ -37,6 +37,10 @@ public class PageHelper {
 
 	/**
 	 * After getPageContent has been called, returns page outer HTMLNode.
+	 * <p>
+	 * If you are getting the outer node with the sole purpose of generating
+	 * its HTML, use {@link #generate()} instead.
+	 *
 	 * @return page outer node used to render entire page.
 	 */
 	public HTMLNode getPageOuter() {
@@ -44,6 +48,20 @@ public class PageHelper {
 			throw new NullPointerException("pageNode was not initialized. getPageContent must be called first.");
 		}
 		return pageNode.getOuterNode();
+	}
+
+	/**
+	 * Generates the page’s HTML.
+	 * <p>
+	 * {@link #getPageContent(String)} must be called before this method.
+	 *
+	 * @return The page’s HTML
+	 */
+	public String generate() {
+		if (pageNode == null) {
+			throw new NullPointerException("pageNode was not initialized. getPageContent must be called first.");
+		}
+		return pageNode.generate();
 	}
 
 	public HTMLNode getInfobox(String category, String header, HTMLNode parent, String title, boolean isUnique) {

--- a/src/freenet/clients/http/wizardsteps/PageHelper.java
+++ b/src/freenet/clients/http/wizardsteps/PageHelper.java
@@ -32,7 +32,7 @@ public class PageHelper {
 	 */
 	public HTMLNode getPageContent(String title) {
 		pageNode = toadletContext.getPageMaker().getPageNode(title, toadletContext, new RenderParameters().renderNavigationLinks(false).renderStatus(false));
-		return pageNode.content;
+		return pageNode.getContentNode();
 	}
 
 	/**
@@ -43,7 +43,7 @@ public class PageHelper {
 		if (pageNode == null) {
 			throw new NullPointerException("pageNode was not initialized. getPageContent must be called first.");
 		}
-		return pageNode.outer;
+		return pageNode.getOuterNode();
 	}
 
 	public HTMLNode getInfobox(String category, String header, HTMLNode parent, String title, boolean isUnique) {

--- a/src/freenet/support/plugins/helpers1/WebInterfaceToadlet.java
+++ b/src/freenet/support/plugins/helpers1/WebInterfaceToadlet.java
@@ -80,7 +80,7 @@ public abstract class WebInterfaceToadlet extends Toadlet implements LinkEnabled
 
 	public HTMLNode createErrorBox(List<String> errors, String path, FreenetURI retryUri, String extraParams) {
 		InfoboxNode box = pluginContext.pageMaker.getInfobox("infobox-alert", "ERROR");
-		HTMLNode errorBox = box.content;
+		HTMLNode errorBox = box.getContentNode();
 		for (String error : errors) {
 			errorBox.addChild("#", error);
 			errorBox.addChild("br");
@@ -90,6 +90,6 @@ public abstract class WebInterfaceToadlet extends Toadlet implements LinkEnabled
 			errorBox.addChild(new HTMLNode("a", "href", path + "?key="
 					+ ((extraParams == null) ? retryUri : (retryUri + extraParams)), retryUri.toString(false, false)));
 		}
-		return box.outer;
+		return box.getOuterNode();
 	}
 }


### PR DESCRIPTION
The `outer` and `content` member variables have been a pain in my ass for a while now, especially when trying to get any tests around our toadlets done. This pull request adds accessors, and it adds a `generate()` convenience method (both to `PageNode` and to `PageHelper`) to alleviate the need of even calling `getOuterNode()`.