### PR TITLE
Allow freesite to set robots, googlebot and referrer=no-referrer meta tag

### DIFF
--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -3020,14 +3020,10 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 					} else if (name.equalsIgnoreCase("Viewport")) {
 						hn.put("name", name);
 						hn.put("content", content);
-					} else if (name.equalsIgnoreCase("referrer")) {
-						hn.put("name", name);
-						hn.put("content", "no-referrer"); // Only no-referrer is allowed in freesites for privacy
 					} else if (name.equalsIgnoreCase("robots") || name.equalsIgnoreCase("googlebot")) {
-						StringTokenizer tokenizer = new StringTokenizer(content, ",");
+						String[] tokens = content.split(",");
 						StringBuilder sb = new StringBuilder(content.length());
-						while (tokenizer.hasMoreTokens()) {
-							String token = tokenizer.nextToken();
+						for (String token : tokens) {
 							if(!validRobotsValues.contains(token.trim().toLowerCase()))
 								continue;
 							if(sb.length() != 0)

--- a/test/freenet/client/filter/TagVerifierTest.java
+++ b/test/freenet/client/filter/TagVerifierTest.java
@@ -104,6 +104,27 @@ public class TagVerifierTest {
 	}
 
 	@Test
+	public void testMetaTagSpider() throws DataFilterException {
+		tagname = "meta";
+		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
+
+		attributes.put("name","robots");
+		attributes.put("content","none, noindex, nofollow, noarchive, nosnippet, nocache");
+		htmlTag = new ParsedTag(tagname, attributes);
+
+		assertEquals("Meta tag controlling spiders - valid value", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
+
+		attributes.put("name","robots");
+		attributes.put("content","noindex,invalid");
+		htmlTag = new ParsedTag(tagname, attributes);
+
+		ParsedTag htmlTagFiltered;
+		attributes.put("content","noindex");
+		htmlTagFiltered = new ParsedTag(tagname, attributes);
+		assertEquals("Meta tag controlling spiders - invalid value", htmlTagFiltered.toString(), verifier.sanitize(htmlTag, pc).toString());
+	}
+
+	@Test
 	public void testMetaTagUnknownContentType() {
 		tagname = "meta";
 		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);


### PR DESCRIPTION
Freesites should be able to set the robots tag to tell spiders on freenet to stop publishing them. Invalid robots value is filtered.
Freesites can also set referrer, and no-referrer is the only value supported.