### PR TITLE
Add HTML elements meter,progress,input type=email,number,search,tel,url

### DIFF
--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -2981,8 +2981,8 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 			HTMLParseContext pc) throws DataFilterException {
 			Map<String, Object> hn = super.sanitizeHash(h, p, pc);
 
-			// We drop the whole <input> if type isn't allowed
-			if(!allowedTypes.contains(hn.get("type"))){
+			// We drop the whole <input> if type isn't allowed (case-insensitive)
+			if(!allowedTypes.contains(hn.get("type").toString().toLowerCase())){
 				return null;
 			}
 

--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -1440,7 +1440,8 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 					"alt",
 					"ismap",
 					"accept",
-					"align" },
+					"align",
+					"form" },
 				new String[] { "usemap" },
 				new String[] { "src" },
 				new String[] { "onfocus", "onblur", "onselect", "onchange" }));
@@ -1507,6 +1508,33 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 				emptyStringArray,
 				new String[] { "onfocus", "onblur", "onselect", "onchange" },
 				emptyStringArray));
+		allowedTagsVerifiers.put(
+				"meter",
+				new CoreTagVerifier(
+						"meter",
+						new String[] {
+								"form",
+								"high",
+								"low",
+								"max",
+								"min",
+								"optimum",
+								"value" },
+						emptyStringArray,
+						emptyStringArray,
+						emptyStringArray,
+						emptyStringArray));
+		allowedTagsVerifiers.put(
+				"progress",
+				new CoreTagVerifier(
+						"progress",
+						new String[] {
+								"max",
+								"value" },
+						emptyStringArray,
+						emptyStringArray,
+						emptyStringArray,
+						emptyStringArray));
 		allowedTagsVerifiers.put(
 			"isindex",
 			new BaseCoreTagVerifier(
@@ -2924,7 +2952,12 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 			// no ! file
 			"hidden",
 			"image",
-			"button"
+			"button",
+			"email",
+			"number",
+			"search",
+			"tel",
+			"url"
 		};
 
 		InputTagVerifier(

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -115,6 +115,7 @@ public class ContentFilterTest {
 
     private static final String SPAN_WITH_STYLE = "<span style=\"font-family: verdana, sans-serif; color: red;\">";
 
+    private static final String HTML_METER_PROGRESS_TAG = "<meter min=\"0\" max=\"100\" low=\"20\" high=\"80\" optimum=\"80\" value=\"50\">alt text</meter><progress max=\"100\" value=\"0\">alt text</progress>";
 	private static final String HTML5_TAGS = "<main><article><details><summary><mark>TLDR</mark></summary><center>Too Long Di<wbr />dn&rsquo;t Read</center></details><section><figure><figcaption>Fig.1</figcaption></figure></article></main>";
 	private static final String HTML5_BDI_RUBY = "<small dir=\"auto\"><bdi>&#x0627;&#x06CC;&#x0631;&#x0627;&#x0646;</bdi>, <bdo><ruby>&#xBD81;<rt>North</rt>&#xD55C;<rt>Korea</rt></ruby><rp>North Korea</rp></ruby></bdo></small>";
 
@@ -201,6 +202,7 @@ public class ContentFilterTest {
         testOneHTMLFilter(CSS_SPEC_EXAMPLE1);
 
         testOneHTMLFilter(SPAN_WITH_STYLE);
+        testOneHTMLFilter(HTML_METER_PROGRESS_TAG);
         testOneHTMLFilter(HTML5_TAGS);
         testOneHTMLFilter(HTML5_BDI_RUBY);
 

--- a/test/freenet/client/filter/TagVerifierTest.java
+++ b/test/freenet/client/filter/TagVerifierTest.java
@@ -166,25 +166,54 @@ public class TagVerifierTest {
 
 	@Test
 	public void testValidInputTag() throws DataFilterException {
-		tagname = "input";
-		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
+		String[] types = new String[]{
+			"TEXT",
+			"password",
+			"Checkbox",
+			"radio",
+			"SUBMIT",
+			"rEsEt",
+			// no ! file
+			"hidden",
+			"image",
+			"button",
+			"email",
+			"number",
+			"search",
+			"tel",
+			"url"
+		};
 
-		attributes.put("type", "text");
+		for(String t : types) {
+			tagname = "input";
 
-		htmlTag = new ParsedTag(tagname, attributes);
+			verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
 
-		assertEquals("Input tag with a valid type", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
+			attributes.put("type", t);
+
+			htmlTag = new ParsedTag(tagname, attributes);
+
+			assertEquals("Input tag with a valid type", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
+		}
 	}
 
 	@Test
 	public void testInvalidInputTag() throws DataFilterException {
-		tagname = "input";
-		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
+		String[] types = new String[]{
+			"file",
+			"FILE",
+			"INVALID_TYPE",
+		};
 
-		attributes.put("type", "INVALID_TYPE");
+		for(String t : types) {
+			tagname = "input";
+			verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
 
-		htmlTag = new ParsedTag(tagname, attributes);
+			attributes.put("type", "INVALID_TYPE");
 
-		assertNull("Input tag with an invalid type", verifier.sanitize(htmlTag, pc));
+			htmlTag = new ParsedTag(tagname, attributes);
+
+			assertNull("Input tag with an invalid type", verifier.sanitize(htmlTag, pc));
+		}
 	}
 }

--- a/test/freenet/client/filter/TagVerifierTest.java
+++ b/test/freenet/client/filter/TagVerifierTest.java
@@ -184,15 +184,12 @@ public class TagVerifierTest {
 			"url"
 		};
 
+		tagname = "input";
+		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
+
 		for(String t : types) {
-			tagname = "input";
-
-			verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
-
 			attributes.put("type", t);
-
 			htmlTag = new ParsedTag(tagname, attributes);
-
 			assertEquals("Input tag with a valid type", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
 		}
 	}
@@ -205,14 +202,12 @@ public class TagVerifierTest {
 			"INVALID_TYPE",
 		};
 
+		tagname = "input";
+		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
+
 		for(String t : types) {
-			tagname = "input";
-			verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
-
-			attributes.put("type", "INVALID_TYPE");
-
+			attributes.put("type", t);
 			htmlTag = new ParsedTag(tagname, attributes);
-
 			assertNull("Input tag with an invalid type", verifier.sanitize(htmlTag, pc));
 		}
 	}


### PR DESCRIPTION
New elements [`<meter>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meter), [`<progress>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress), `<input type="email">`, `<input type="number">`, `<input type="search">`, `<input type="tel">`, `<input type="url">`

Some of the input elements on Freenet may better use `<input type="search">` or `<input type="number">` than `<input type="text">`, so we should first support them.