### PR TITLE
Build the Atom XML correctly

### DIFF
--- a/src/freenet/client/ArchiveManager.java
+++ b/src/freenet/client/ArchiveManager.java
@@ -314,7 +314,7 @@ public class ArchiveManager {
 				pis.connect(pos);
 				final OutputStream os = new BufferedOutputStream(pos);
 				wrapper = new ExceptionWrapper();
-				context.mainExecutor.execute(new Runnable() {
+				context.getMainExecutor().execute(new Runnable() {
 
 					@Override
 					public void run() {

--- a/src/freenet/client/async/ClientContext.java
+++ b/src/freenet/client/async/ClientContext.java
@@ -50,8 +50,15 @@ public class ClientContext {
 	private transient ClientRequestScheduler sskInsertSchedulerRT;
 	private transient ClientRequestScheduler chkInsertSchedulerRT;
 	private transient UserAlertManager alerts;
-	/** The main Executor for the node. Jobs for transient requests run here. */
+
+	/**
+	 * The main Executor for the node. Jobs for transient requests run here.
+	 *
+	 * @deprecated Use {@link #getMainExecutor()} instead
+	 */
+	@Deprecated
 	public transient final Executor mainExecutor;
+
 	/** We need to be able to suspend execution of jobs changing persistent state in order to write
 	 * it to disk consistently. Also, some jobs may want to request immediate serialization. */
 	public transient final PersistentJobRunner jobRunner;
@@ -317,4 +324,9 @@ public class ClientContext {
 	public Config getConfig() {
 		return config;
 	}
+
+	public Executor getMainExecutor() {
+		return mainExecutor;
+	}
+
 }

--- a/src/freenet/client/async/ClientRequestScheduler.java
+++ b/src/freenet/client/async/ClientRequestScheduler.java
@@ -289,7 +289,7 @@ public class ClientRequestScheduler implements RequestScheduler {
 		}
 		final Key key = block.getKey();
 		if(schedTransient.anyProbablyWantKey(key, clientContext)) {
-			this.clientContext.mainExecutor.execute(new PrioRunnable() {
+			this.clientContext.getMainExecutor().execute(new PrioRunnable() {
 
 				@Override
 				public void run() {

--- a/src/freenet/client/async/ClientRequestSelector.java
+++ b/src/freenet/client/async/ClientRequestSelector.java
@@ -760,7 +760,7 @@ outer:	for(;choosenPriorityClass <= RequestStarter.MINIMUM_FETCHABLE_PRIORITY_CL
     
     public void wakeUp(ClientContext context) {
         // Break out of locks. Can be called within RGAs etc!
-        context.mainExecutor.execute(new Runnable() {
+        context.getMainExecutor().execute(new Runnable() {
 
             @Override
             public void run() {

--- a/src/freenet/client/async/InsertCompressor.java
+++ b/src/freenet/client/async/InsertCompressor.java
@@ -226,7 +226,7 @@ public class InsertCompressor implements CompressJob {
 				}, NativeThread.NORM_PRIORITY+1);
 			} else {
 				// We do it off thread so that RealCompressor can release the semaphore
-				context.mainExecutor.execute(new PrioRunnable() {
+				context.getMainExecutor().execute(new PrioRunnable() {
 
 					@Override
 					public int getPriority() {

--- a/src/freenet/client/async/SingleBlockInserter.java
+++ b/src/freenet/client/async/SingleBlockInserter.java
@@ -192,7 +192,7 @@ public class SingleBlockInserter extends SendableInsert implements ClientPutStat
 			resultingKey = key;
 		}
 		if(!persistent) {
-			context.mainExecutor.execute(new Runnable() {
+			context.getMainExecutor().execute(new Runnable() {
 				
 				@Override
 				public void run() {

--- a/src/freenet/client/async/USKManager.java
+++ b/src/freenet/client/async/USKManager.java
@@ -454,7 +454,7 @@ public class USKManager {
 					final USK usk = origUSK.copy(number);
 					final boolean newSlotToo = newSlot;
 					for(final USKCallback callback : callbacks)
-						context.mainExecutor.execute(new Runnable() {
+						context.getMainExecutor().execute(new Runnable() {
 							@Override
 							public void run() {
 								callback.onFoundEdition(number, usk, // non-persistent
@@ -488,7 +488,7 @@ public class USKManager {
 			// Run off-thread, because of locking, and because client callbacks may take some time
 					final USK usk = origUSK.copy(number);
 					for(final USKCallback callback : callbacks)
-						context.mainExecutor.execute(new Runnable() {
+						context.getMainExecutor().execute(new Runnable() {
 							@Override
 							public void run() {
 								callback.onFoundEdition(number, usk, // non-persistent

--- a/src/freenet/client/async/USKRetriever.java
+++ b/src/freenet/client/async/USKRetriever.java
@@ -158,7 +158,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
 
 		final FetchResult result = new FetchResult(clientMetadata, finalResult);
 		context.uskManager.updateKnownGood(origUSK, state.getToken(), context);
-		context.mainExecutor.execute(new PrioRunnable() {
+		context.getMainExecutor().execute(new PrioRunnable() {
 
 			@Override
 			public void run() {

--- a/src/freenet/node/useralerts/UserAlertManager.java
+++ b/src/freenet/node/useralerts/UserAlertManager.java
@@ -3,6 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node.useralerts;
 
+import static java.util.Arrays.stream;
+
+import java.io.IOException;
+import java.io.StringWriter;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -13,7 +17,23 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.sun.org.apache.xml.internal.serializer.OutputPropertiesFactory;
 import freenet.clients.fcp.FCPConnectionHandler;
 import freenet.l10n.NodeL10n;
 import freenet.node.NodeClientCore;
@@ -414,32 +434,115 @@ public class UserAlertManager implements Comparator<UserAlert> {
 		String messagesURI = startURI + "/alerts/";
 		String feedURI = startURI + "/feed/";
 
-		StringBuilder sb = new StringBuilder();
-		sb.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
-		sb.append("<feed xmlns=\"http://www.w3.org/2005/Atom\">\n");
-		sb.append("\n");
-		sb.append("  <title>").append(l10n("feedTitle")).append("</title>\n");
-		sb.append("  <link href=\"").append(feedURI).append("\" rel=\"self\"/>\n");
-		sb.append("  <link href=\"").append(startURI).append("\"/>\n");
-		sb.append("  <updated>").append(formatTime(lastUpdated)).append("</updated>\n");
-		sb.append("  <id>urn:node:").append(Base64.encode(core.getNode().getDarknetPubKeyHash())).append("</id>\n");
-		sb.append("  <logo>").append("/favicon.ico").append("</logo>\n");
-		UserAlert[] alerts = getAlerts();
-		for(int i = alerts.length - 1; i >= 0; i--) {
-			UserAlert alert = alerts[i];
-			if (alert.isValid()) {
-				sb.append("\n");
-				sb.append("  <entry>\n");
-				sb.append("    <title>").append(alert.getTitle()).append("</title>\n");
-				sb.append("    <link href=\"").append(messagesURI).append("#").append(alert.anchor()).append("\"/>\n");
-				sb.append("    <summary>").append(alert.getShortText()).append("</summary>\n");
-				sb.append("    <content type=\"text\">").append(alert.getText()).append("</content>\n");
-				sb.append("    <id>urn:feed:").append(alert.anchor()).append("</id>\n");
-				sb.append("    <updated>").append(formatTime(alert.getUpdatedTime())).append("</updated>\n");
-				sb.append("  </entry>\n");
+		XmlBuilder xmlBuilder = new XmlBuilder();
+		xmlBuilder.addNamespaceElement("http://www.w3.org/2005/Atom", "feed", feed -> {
+			feed.addElement("title", l10n("feedTitle"));
+			feed.addElement("link", link -> {
+				link.setAttribute("rel", "self");
+				link.setAttribute("href", feedURI);
+			});
+			feed.addElement("link", link -> link.setAttribute("href", startURI));
+			feed.addElement("id", "urn:node:" + Base64.encode(core.getNode().getDarknetPubKeyHash()));
+			feed.addElement("updated", formatTime(lastUpdated));
+			feed.addElement("logo", "/favicon.ico");
+
+			stream(getAlerts())
+					.filter(UserAlert::isValid)
+					.forEach(alert -> {
+						feed.addElement("entry", entry -> {
+							entry.addElement("id", "urn:feed:" + alert.anchor());
+							entry.addElement("link", link -> link.setAttribute("href", messagesURI + "#" + alert.anchor()));
+							entry.addElement("updated", formatTime(alert.getUpdatedTime()));
+							entry.addElement("title", alert.getTitle());
+							entry.addElement("summary", alert.getShortText());
+							entry.addElement("content", alert.getText(), content -> content.setAttribute("type", "text"));
+						});
+					});
+		});
+		return xmlBuilder.generate();
+	}
+
+	private interface ElementBuilder {
+
+		void addElement(String name, Consumer<ElementBuilder> elementBuilder);
+		void addElement(String name, String content, Consumer<ElementBuilder> elementBuilder);
+		void addNamespaceElement(String namespace, String name, Consumer<ElementBuilder> elementBuilder);
+		void setAttribute(String name, String value);
+
+		default void addElement(String name, String content) {
+			addElement(name, content, elementBuilder -> {});
+		}
+
+	}
+
+	private static class XmlBuilder implements ElementBuilder {
+
+		@Override
+		public void addElement(String name, Consumer<ElementBuilder> elementBuilder) {
+			Element element = document.createElement(name);
+			elementBuilder.accept(new XmlBuilder(document, element));
+			((this.element == null) ? document : this.element).appendChild(element);
+		}
+
+		@Override
+		public void addElement(String name, String content, Consumer<ElementBuilder> elementBuilder) {
+			Element element = document.createElement(name);
+			element.setTextContent(content);
+			elementBuilder.accept(new XmlBuilder(document, element));
+			((this.element == null) ? document : this.element).appendChild(element);
+		}
+
+		@Override
+		public void addNamespaceElement(String namespace, String name, Consumer<ElementBuilder> elementBuilder) {
+			Element element = document.createElementNS(namespace, name);
+			elementBuilder.accept(new XmlBuilder(document, element));
+			((this.element == null) ? document : this.element).appendChild(element);
+		}
+
+		@Override
+		public void setAttribute(String name, String value) {
+			if (element != null) {
+				element.setAttribute(name, value);
 			}
 		}
-		sb.append("\n</feed>\n");
-		return sb.toString();
+
+		public String generate() {
+			DOMSource source = new DOMSource(document);
+			try (StringWriter stringWriter = new StringWriter()) {
+				StreamResult result = new StreamResult(stringWriter);
+				transformer.transform(source, result);
+				return stringWriter.toString();
+			} catch (TransformerException | IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		public XmlBuilder() {
+			this(documentBuilder.newDocument(), null);
+		}
+
+		private XmlBuilder(Document document, Element element) {
+			this.document = document;
+			this.element = element;
+		}
+
+		private final Document document;
+		private final Element element;
+		private static DocumentBuilder documentBuilder;
+		private static final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+		private static final Transformer transformer;
+
+		static {
+			try {
+				documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+				transformer = transformerFactory.newTransformer();
+				transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+				transformer.setOutputProperty(OutputPropertiesFactory.S_KEY_INDENT_AMOUNT, "2");
+			} catch (ParserConfigurationException | TransformerConfigurationException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
 	}
+
 }

--- a/src/freenet/node/useralerts/UserAlertManager.java
+++ b/src/freenet/node/useralerts/UserAlertManager.java
@@ -77,7 +77,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
 	private void notifySubscribers(final UserAlert alert) {
 		// Run off-thread, because of locking, and because client
 		// callbacks may take some time
-		core.getClientContext().mainExecutor.execute(new Runnable() {
+		core.getClientContext().getMainExecutor().execute(new Runnable() {
 			@Override
 			public void run() {
 				for (FCPConnectionHandler subscriber : subscribers)
@@ -387,7 +387,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
 		subscribers.add(subscriber);
 		// Run off-thread, because of locking, and because client
 		// callbacks may take some time
-		core.getClientContext().mainExecutor.execute(new Runnable() {
+		core.getClientContext().getMainExecutor().execute(new Runnable() {
 			@Override
 			public void run() {
 				for (UserAlert alert : getAlerts())

--- a/test/freenet/node/useralerts/UserAlertManagerTest.java
+++ b/test/freenet/node/useralerts/UserAlertManagerTest.java
@@ -1,0 +1,203 @@
+package freenet.node.useralerts;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.TimeZone;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import freenet.node.NodeClientCore;
+
+public class UserAlertManagerTest {
+
+	@Test
+	public void generatedAtomContainsTitle() throws Exception {
+		verifyStringPropertyInGeneratedAtom("/feed/title", equalTo("UserAlertManager.feedTitle"));
+	}
+
+	@Test
+	public void generatedAtomContainsLinkToItself() throws Exception {
+		verifyStringPropertyInGeneratedAtom("/feed/link[@rel='self']/@href", equalTo("http://test/feed/"));
+	}
+
+	@Test
+	public void generatedAtomContainsLinkToContext() throws Exception {
+		verifyStringPropertyInGeneratedAtom("/feed/link[count(@rel)=0]/@href", equalTo("http://test"));
+	}
+
+	@Test
+	public void generatedAtomContainsLastUpdateTime() throws Exception {
+		verifyStringPropertyInGeneratedAtom("/feed/updated", matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}[+-]\\d{2}:\\d{2}"));
+	}
+
+	@Test
+	public void generatedAtomContainsNodeId() throws Exception {
+		verifyStringPropertyInGeneratedAtom("/feed/id", equalTo("urn:node:AQIDBA"));
+	}
+
+	@Test
+	public void generatedAtomContainsLogoUrl() throws Exception {
+		verifyStringPropertyInGeneratedAtom("/feed/logo", equalTo("/favicon.ico"));
+	}
+
+	@Test
+	public void generatedAtomContainsUserAlerts() throws Exception {
+		SimpleUserAlert alert = new SimpleUserAlert(true, "Alert Title", "This is an alert!", "It’s an alert!", (short) 0);
+		userAlertManager.register(alert);
+		List<Node> nodes = getEntryNodes(createAtomXml());
+		assertThat(nodes, contains(representsUserAlert(alert)));
+	}
+
+	@Test
+	public void generatedAtomContainsUserAlertWithCharactersThatAreNotValidInXml() throws Exception {
+		SimpleUserAlert userAlert = new SimpleUserAlert(true, "Alert <", "Contains a <.", "It’s <!", (short) 0);
+		userAlertManager.register(userAlert);
+		List<Node> nodes = getEntryNodes(createAtomXml());
+		assertThat(nodes, contains(representsUserAlert(userAlert)));
+	}
+
+	@Test
+	public void generatedAtomContainsMultipleUserAlerts() throws Exception {
+		SimpleUserAlert firstAlert = new SimpleUserAlert(true, "Alert 1", "Text 1", "Short 1", (short) 0);
+		SimpleUserAlert secondAlert = new SimpleUserAlert(true, "Alert 2", "Text 2", "Short 2", (short) 0);
+		userAlertManager.register(secondAlert);
+		userAlertManager.register(firstAlert);
+		List<Node> entryNodes = getEntryNodes(createAtomXml());
+		assertThat(entryNodes, containsInAnyOrder(
+				representsUserAlert(firstAlert),
+				representsUserAlert(secondAlert)
+		));
+	}
+
+	@Test
+	public void generatedAtomDoesNotContainInvalidUserAlerts() throws Exception {
+		SimpleUserAlert firstAlert = new SimpleUserAlert(true, "Alert 1", "Text 1", "Short 1", (short) 0);
+		SimpleUserAlert secondAlert = new SimpleUserAlert(true, "Alert 2", "Text 2", "Short 2", (short) 0) {
+			@Override
+			public boolean isValid() {
+				return false;
+			}
+		};
+		userAlertManager.register(secondAlert);
+		userAlertManager.register(firstAlert);
+		List<Node> entryNodes = getEntryNodes(createAtomXml());
+		assertThat(entryNodes, containsInAnyOrder(representsUserAlert(firstAlert)));
+	}
+
+	@Test
+	public void generatedAtomEntriesUseAnchorForId() throws Exception {
+		SimpleUserAlert userAlert = new SimpleUserAlert(true, "Alert 1", "Text 1", "Short 1", (short) 0) {
+			@Override
+			public String anchor() {
+				return "test-anchor";
+			}
+		};
+		userAlertManager.register(userAlert);
+		Node node = getEntryNodes(createAtomXml()).get(0);
+		assertThat(xPath.evaluate("id", node), equalTo("urn:feed:test-anchor"));
+	}
+
+	private List<Node> getEntryNodes(Document atomXml) throws Exception {
+		List<Node> nodes = new ArrayList<>();
+		NodeList nodeList = (NodeList) xPath.evaluate("/feed/entry", atomXml, XPathConstants.NODESET);
+		for (int index = 0; index < nodeList.getLength(); index++) {
+			nodes.add(nodeList.item(index));
+		}
+		return nodes;
+	}
+
+	private Matcher<Node> representsUserAlert(UserAlert userAlert) {
+		return new TypeSafeDiagnosingMatcher<Node>() {
+			@Override
+			protected boolean matchesSafely(Node node, Description mismatchDescription) {
+				try {
+					if (!Objects.equals(xPath.evaluate("id", node), "urn:feed:" + userAlert.anchor())) {
+						mismatchDescription.appendText("id was ").appendValue(xPath.evaluate("id", node));
+						return false;
+					}
+					if (!Objects.equals(xPath.evaluate("link/@href", node), "http://test/alerts/#" + userAlert.anchor())) {
+						mismatchDescription.appendText("link was ").appendValue(xPath.evaluate("link/@href", node));
+						return false;
+					}
+					if (!Objects.equals(xPath.evaluate("updated", node), formatTime(userAlert.getUpdatedTime()))) {
+						mismatchDescription.appendText("updated was ").appendValue(xPath.evaluate("updated", node));
+						return false;
+					}
+					if (!Objects.equals(xPath.evaluate("title", node), userAlert.getTitle())) {
+						mismatchDescription.appendText("title was ").appendValue(xPath.evaluate("title", node));
+						return false;
+					}
+					if (!Objects.equals(xPath.evaluate("summary", node), userAlert.getShortText())) {
+						mismatchDescription.appendText("summary was ").appendValue(xPath.evaluate("summary", node));
+						return false;
+					}
+					if (!Objects.equals(xPath.evaluate("content[@type='text']", node), userAlert.getText())) {
+						mismatchDescription.appendText("content was ").appendValue(xPath.evaluate("content[@type='text']", node));
+						return false;
+					}
+				} catch (XPathExpressionException e) {
+					throw new RuntimeException(e);
+				}
+				return true;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("is user alert ").appendValue(userAlert);
+			}
+		};
+	}
+
+	private static String formatTime(long time) {
+		return String.format("%tY-%<tm-%<tdT%<tH:%<tM:%<tS%0+3d:%02d", time, MILLISECONDS.toHours(TimeZone.getDefault().getOffset(time)), MILLISECONDS.toMinutes(TimeZone.getDefault().getOffset(time)) % 60);
+	}
+
+	private void verifyStringPropertyInGeneratedAtom(String xpathExpression, Matcher<String> valueMatcher) throws Exception {
+		verifyStringPropertyInAtom(createAtomXml(), xpathExpression, valueMatcher);
+	}
+
+	private void verifyStringPropertyInAtom(Document atomXml, String xpathExpression, Matcher<String> valueMatcher) throws Exception {
+		String value = xPath.evaluate(xpathExpression, atomXml);
+		assertThat(value, valueMatcher);
+	}
+
+	private Document createAtomXml() throws Exception {
+		String atom = userAlertManager.getAtom("http://test");
+		return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(atom)));
+	}
+
+	private final NodeClientCore nodeClientCore = mock(NodeClientCore.class, RETURNS_DEEP_STUBS);
+
+	{
+		when(nodeClientCore.getNode().getDarknetPubKeyHash()).thenReturn(new byte[] { 1, 2, 3, 4 });
+	}
+
+	private final UserAlertManager userAlertManager = new UserAlertManager(nodeClientCore);
+	private static final XPath xPath = XPathFactory.newInstance().newXPath();
+
+}


### PR DESCRIPTION
As the XML is currently being hand-built using a `StringBuilder`, it should come as no surprise that it breaks as soon as a user alert contains e.g. a `<` character.

This branch builds upon #1079.