### PR TITLE
Fix NullPointerException in input tag filter

### DIFF
--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -2987,6 +2987,9 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 			HTMLParseContext pc) throws DataFilterException {
 			Map<String, Object> hn = super.sanitizeHash(h, p, pc);
 
+			// We drop the whole <input> if type is null
+			if(hn.get("type") == null)
+				return null;
 			// We drop the whole <input> if type isn't allowed (case-insensitive)
 			if(!allowedTypes.contains(hn.get("type").toString().toLowerCase())){
 				return null;

--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -2987,11 +2987,8 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 			HTMLParseContext pc) throws DataFilterException {
 			Map<String, Object> hn = super.sanitizeHash(h, p, pc);
 
-			// We drop the whole <input> if type is null
-			if(hn.get("type") == null)
-				return null;
 			// We drop the whole <input> if type isn't allowed (case-insensitive)
-			if(!allowedTypes.contains(hn.get("type").toString().toLowerCase())){
+			if(hn.get("type") != null && !allowedTypes.contains(hn.get("type").toString().toLowerCase())){
 				return null;
 			}
 

--- a/test/freenet/client/filter/TagVerifierTest.java
+++ b/test/freenet/client/filter/TagVerifierTest.java
@@ -226,6 +226,9 @@ public class TagVerifierTest {
 		tagname = "input";
 		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
 
+		htmlTag = new ParsedTag(tagname, attributes);
+		assertNull("Input tag without type", verifier.sanitize(htmlTag, pc));
+
 		for(String t : types) {
 			attributes.put("type", t);
 			htmlTag = new ParsedTag(tagname, attributes);

--- a/test/freenet/client/filter/TagVerifierTest.java
+++ b/test/freenet/client/filter/TagVerifierTest.java
@@ -208,6 +208,9 @@ public class TagVerifierTest {
 		tagname = "input";
 		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
 
+		htmlTag = new ParsedTag(tagname, attributes);
+		assertEquals("Input tag without type", htmlTag.toString(), verifier.sanitize(htmlTag, pc).toString());
+
 		for(String t : types) {
 			attributes.put("type", t);
 			htmlTag = new ParsedTag(tagname, attributes);
@@ -225,9 +228,6 @@ public class TagVerifierTest {
 
 		tagname = "input";
 		verifier = HTMLFilter.allowedTagsVerifiers.get(tagname);
-
-		htmlTag = new ParsedTag(tagname, attributes);
-		assertNull("Input tag without type", verifier.sanitize(htmlTag, pc));
 
 		for(String t : types) {
 			attributes.put("type", t);


### PR DESCRIPTION
I'm so sorry this bug was introduced, and the tests are completely unable to catch it.