### PR TITLE
Fix UserAlertManager Test

### DIFF
--- a/src/freenet/l10n/NodeL10n.java
+++ b/src/freenet/l10n/NodeL10n.java
@@ -51,4 +51,16 @@ public class NodeL10n {
 		}
 		return b;
 	}
+
+	/**
+	 * Sets the {@link BaseL10n} used to localize the node.
+	 * <p>
+	 * This method should only be used in tests, via {@code BaseL10nTest#useTestTranslation()}!
+	 *
+	 * @param baseL10n The {@link BaseL10n} object used for localization
+	 */
+	static void setBase(BaseL10n baseL10n) {
+		b = baseL10n;
+	}
+
 }

--- a/test/freenet/l10n/BaseL10nTest.java
+++ b/test/freenet/l10n/BaseL10nTest.java
@@ -260,4 +260,14 @@ public class BaseL10nTest {
         return new BaseL10n("freenet/l10n/", "freenet.l10n.${lang}.test.properties",
                 overrideFile.getPath(), lang);
     }
+
+    /**
+     * Installs a {@link #createTestL10n(LANGUAGE) BaseL10n} with
+     * translations read from the test classpath into the global
+     * {@link NodeL10n}, allowing tests for translation keys.
+     */
+    public static void useTestTranslation() {
+        NodeL10n.setBase(createTestL10n(LANGUAGE.ENGLISH));
+    }
+
 }

--- a/test/freenet/node/useralerts/UserAlertManagerTest.java
+++ b/test/freenet/node/useralerts/UserAlertManagerTest.java
@@ -31,12 +31,14 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import freenet.l10n.BaseL10nTest;
 import freenet.node.NodeClientCore;
 
 public class UserAlertManagerTest {
 
 	@Test
 	public void generatedAtomContainsTitle() throws Exception {
+		BaseL10nTest.useTestTranslation();
 		verifyStringPropertyInGeneratedAtom("/feed/title", equalTo("UserAlertManager.feedTitle"));
 	}
 


### PR DESCRIPTION
The test was using the wrong translation file, i.e. the production translation. By forcing it to use the translation file used in tests of the translation system, any key that does not exist in that file (which is pretty much every key outside of tests) will return the key as translation, making it trivial to test that the correct key is requested.