### PR TITLE
BlockTransmitter: prevent 0.2% of jobs from stalling

### DIFF
--- a/src/freenet/io/xfer/BlockTransmitter.java
+++ b/src/freenet/io/xfer/BlockTransmitter.java
@@ -158,7 +158,7 @@ public class BlockTransmitter {
 						count++;
 						if (isHighHtl() && count >= (Node.PACKETS_IN_BLOCK - 1)) {
 							try {
-								wait((int) (Math.random() * MAX_ARTIFICIAL_FINAL_PACKETS_DELAY));
+								wait((int) (Math.random() * MAX_ARTIFICIAL_FINAL_PACKETS_DELAY), 1);
 							} catch (InterruptedException e) {
 								// intentionally left blank: can continue
 							}


### PR DESCRIPTION
The timed wait(int) method behaves like an untimed wait() when its argument is zero, effectively stalling the thread until they are waken up for other reasons. Since the MAX_ARTIFICIAL_FINAL_PACKETS_DELAY is 1000 millis and a delay is used for the last two packets this will impact 0.2% of the jobs, causing a thread leak.

Use wait(int, long) to pass an additional nanosecond of waiting time to prevent the wait time from ever being zero.

Please review and test carefully. There is also #1087 that removes the blocking wait altogether, but that one is somewhat more complex.