### PR TITLE
BlockTransmitter: delay BlockSenderJob asynchronously on the Ticker (improved)

### DIFF
--- a/src/freenet/io/xfer/BlockTransmitter.java
+++ b/src/freenet/io/xfer/BlockTransmitter.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import freenet.io.comm.AsyncMessageCallback;
 import freenet.io.comm.AsyncMessageFilterCallback;
@@ -36,6 +37,7 @@ import freenet.io.comm.NotConnectedException;
 import freenet.io.comm.PeerContext;
 import freenet.io.comm.RetrievalException;
 import freenet.io.comm.SlowAsyncMessageFilterCallback;
+import freenet.node.FastRunnable;
 import freenet.node.HighHtlAware;
 import freenet.node.MessageItem;
 import freenet.node.Node;
@@ -92,7 +94,7 @@ public class BlockTransmitter {
 	private final boolean realTime;
 	final PartiallyReceivedBlock _prb;
 	private Deque<Integer> _unsent;
-	private BlockSenderJob _senderThread = new BlockSenderJob();
+	private final BlockSenderJob _senderThread = new BlockSenderJob();
 	private BitArray _sentPackets;
 	private long timeAllSent = -1;
 	final ByteCounter _ctr;
@@ -123,18 +125,20 @@ public class BlockTransmitter {
 	static int runningBlockTransmits = 0;
 	
 	class BlockSenderJob implements PrioRunnable {
-		
-		private boolean running = false;
+		private static final int STATE_IDLE = 0; // not running
+		private static final int STATE_RUNNING = 1; // currently running
+		private static final int STATE_WAITING = 2; // waiting for a scheduled delay
+
+		private final AtomicInteger state = new AtomicInteger();
 		private int count = 0;
 		
 		@Override
 		public void run() {
-			synchronized(this) {
-				if(running) return;
-				running = true;
+			if (!state.compareAndSet(STATE_IDLE, STATE_RUNNING)) {
+				return;
 			}
 			try {
-				while(true) {
+				while(state.get() == STATE_RUNNING) {
 					int packetNo = -1;
 					BitArray copy;
 					synchronized(_senderThread) {
@@ -156,24 +160,21 @@ public class BlockTransmitter {
 						// the variable count is used to count which message is being processed now
 						// the HTL is taken into consideration when adding delay too
 						count++;
-						if (isHighHtl() && count >= (Node.PACKETS_IN_BLOCK - 1)) {
-							try {
-								wait((int) (Math.random() * MAX_ARTIFICIAL_FINAL_PACKETS_DELAY));
-							} catch (InterruptedException e) {
-								// intentionally left blank: can continue
-							}
+						if (isHighHtl() && count >= (Node.PACKETS_IN_BLOCK - 2)) {
+							state.set(STATE_WAITING);
+							long delayMillis = (long) (Math.random() * MAX_ARTIFICIAL_FINAL_PACKETS_DELAY);
+							_ticker.queueTimedJob((FastRunnable) this::schedule, delayMillis);
 						}
 					}
 					if(!innerRun(packetNo, copy)) return;
 				}
 			} finally {
-				synchronized(this) {
-					running = false;
-				}
+				state.compareAndSet(STATE_RUNNING, STATE_IDLE);
 			}
 		}
-		
-		public void schedule() {
+
+		void schedule() {
+			state.compareAndSet(STATE_WAITING, STATE_IDLE);
 			if(_failed || _receivedSendCompletion || _completed) {
 				if(logMINOR) Logger.minor(this, "Not scheduling for "+_uid+" to "+_destination+" :"+
 						(_failed ? "(failed) " : "") + (_receivedSendCompletion ? "(receivedSendCompletion) " : "") + (_completed ? "(completed) " : ""));
@@ -314,7 +315,7 @@ public class BlockTransmitter {
 			timeAllSent = System.currentTimeMillis();
 			if(logMINOR)
 				Logger.minor(this, "Sent all blocks, none unsent on "+this);
-			_senderThread.notifyAll();
+			_senderThread.schedule();
 			return true;
 		}
 		if(blockSendsPending == 0 && _failed) {
@@ -613,7 +614,7 @@ public class BlockTransmitter {
 		synchronized(_senderThread) {
 			timeAllSent = -1;
 			_failed = true;
-			_senderThread.notifyAll();
+			_senderThread.schedule();
 			fail = maybeFail(reason, description);
 		}
 		fail.execute();


### PR DESCRIPTION
The current delay logic blocks the thread for the block transmitter, of which there can be many (roughly 1 per 32 KiB sent), leading to an increased thread count depending on the level of traffic.

Replace wait() with a Ticker-based rescheduling approach to delay the transmission in a non-blocking way.

This is a second iteration of #1087 which was incorrect.
See also #1086 for a simpler but slightly less effective approach.
Please review and test carefully.