### PR TITLE
contributing.md: Clarify that all functional changes must be reviewed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,11 @@ If you don't hear anything for a while feel free to bring it to the attention of
 people in [IRC](https://www.hyphanet.org/pages/help.html#chat-with-us) or the [mailing list](https://www.hyphanet.org/pages/help.html#mailing-lists) - we may
 have missed it.
 
+All commits with functional changes must be reviewed, also those from
+maintainers. An exception are plugins: updates to official plugins
+must include the commit id from the the plugin-repo in the commit
+description (the review in the plugin-repo doubles as review in fred).
+
 Code review helps improve code quality, ensures that multiple people know the
 codebase, serves as a defense against introducing malicious code, and makes it
 infeasible to pressure people into contributing malicious code. Its goal is


### PR DESCRIPTION
The goal is to ensure that changes to the repository can always be verified by everyone without requiring knowledge of the code: either there’s a review with approval (in fred or in a referenced plugin-repo), or the change is trivial and causes no functional changes.