### PR TITLE
Cleanup build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ sourceSets {
 }
 
 def gitrev
-task buildInfo {
+tasks.register('buildInfo') {
     try {
         def cmd = "git describe --always --abbrev=4 --dirty"
         def proc = cmd.execute([], project.rootDir)
@@ -92,7 +92,7 @@ tasks.withType(Javadoc) {
     options.encoding = "UTF-8"
 }
 
-task generateVersionSource(type: Copy) {
+tasks.register('generateVersionSource', Copy) {
     dependsOn buildInfo
     from(sourceSets.main.java.srcDirs) {
         include version_src
@@ -103,7 +103,7 @@ task generateVersionSource(type: Copy) {
     into version_buildir
 }
 
-task compileVersion (type: JavaCompile) {
+tasks.register('compileVersion', JavaCompile) {
     dependsOn generateVersionSource, compileJava
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -113,7 +113,7 @@ task compileVersion (type: JavaCompile) {
     destinationDirectory.set(layout.buildDirectory.dir("java/version/").get())
 }
 
-task buildJar(type: Jar) {
+tasks.register('buildJar', Jar) {
     dependsOn compileVersion, processResources
     from(processResources)
     from(compileJava.destinationDirectory) {
@@ -145,7 +145,7 @@ task buildJar(type: Jar) {
 jar.enabled = false
 jar.dependsOn buildJar
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     dependsOn generateVersionSource
     archiveClassifier = 'sources'
     preserveFileTimestamps = false
@@ -180,7 +180,7 @@ gradle.addBuildListener(new BuildAdapter() {
     }
 })
 
-task copyResourcesToClasses2 {
+tasks.register('copyResourcesToClasses2') {
     inputs.files sourceSets.main.allSource
     outputs.dir layout.buildDirectory.dir("classes/java/main/")
     doLast {
@@ -203,7 +203,7 @@ task copyResourcesToClasses2 {
 processResources.dependsOn copyResourcesToClasses2
 compileVersion.dependsOn copyResourcesToClasses2
 
-task copyTestResourcesToClasses2 {
+tasks.register('copyTestResourcesToClasses2') {
     inputs.files sourceSets.test.allSource
     outputs.dir layout.buildDirectory.dir("classes/java/test/")
     doLast {
@@ -244,14 +244,14 @@ tasks.withType(Test) {
     enableAssertions = false
 }
 
-task copyRuntimeLibs(type: Copy) {
+tasks.register('copyRuntimeLibs', Copy) {
     into "${buildDir}/output/"
     from configurations.runtimeClasspath
     from jar
 }
 copyRuntimeLibs.dependsOn jar
 
-task tar(type: Tar) {
+tasks.register('tar', Tar) {
   description = "Build a source release, specifically excluding the build directories and gradle wrapper files"
   compression = Compression.BZIP2
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,10 +67,7 @@ sourceSets {
         }
         resources {
             srcDirs 'src'
-            include 'freenet/l10n/*properties'
-            include 'freenet/l10n/iso-*.tab'
-            include 'freenet/clients/http/staticfiles/**'
-            include 'freenet/clients/http/templates/**'
+            exclude '**/*.java'
         }
     }
     test {
@@ -80,10 +77,7 @@ sourceSets {
         }
         resources {
             srcDirs 'test'
-            include 'freenet/client/filter/*/**'
-            include 'freenet/crypt/ciphers/rijndael-gladman-test-data/**'
-            include 'freenet/l10n/*properties'
-            include 'freenet/clients/http/templates/**'
+            exclude '**/*.java'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,6 @@ plugins {
     id 'maven-publish'
 }
 
-configurations {
-    provided
-    compile
-}
-
 repositories {
     flatDir { dirs uri("${projectDir}/lib") }
     maven {
@@ -19,11 +14,6 @@ repositories {
         }
     }
     mavenCentral()
-}
-
-sourceSets {
-    main.compileClasspath += configurations.provided
-    test.compileClasspath += configurations.provided
 }
 
 def version_buildir = file("$projectDir/build/tmp/compileVersion/")

--- a/build.gradle
+++ b/build.gradle
@@ -178,13 +178,17 @@ sourcesJar {
 }
 
 tasks.register('copyRuntimeLibs', Copy) {
+    description = 'Collect all runtime artifacts and dependencies.'
+    group = 'Build'
+
     into layout.buildDirectory.dir('output')
     from configurations.runtimeClasspath
     from jar
 }
 
 tasks.register('tar', Tar) {
-    description = "Build a source release, specifically excluding the build directories and gradle wrapper files"
+    description = 'Build a source release, specifically excluding the build directories and gradle wrapper files.'
+    group = 'Build'
 
     from(project.rootDir) {
         exclude '**/build'

--- a/build.gradle
+++ b/build.gradle
@@ -189,29 +189,9 @@ tasks.register('copyRuntimeLibs', Copy) {
 }
 
 assemble {
-    // Add copyRuntimeLibs so `gradlew assemble` collects all build artifacts (except tar).
+    // Add copyRuntimeLibs so `gradlew assemble` collects all build artifacts.
     // Note: jar, sourcesJar, javadocJar are added as dependency by default.
     dependsOn copyRuntimeLibs
-}
-
-tasks.register('tar', Tar) {
-    description = 'Build a source release, specifically excluding the build directories and gradle wrapper files.'
-    group = 'Build'
-
-    from(project.rootDir) {
-        exclude '**/build'
-        exclude 'build'
-        exclude '.gradle'
-    }
-    into 'freenet-sources'
-
-    compression = Compression.BZIP2
-    destinationDirectory = layout.buildDirectory
-    archiveFileName = 'freenet-sources.tgz'
-
-    doLast { // generate md5 checksum
-        ant.checksum file: file(archiveFile)
-    }
 }
 
 tasks.register('archiveDigests') {

--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,29 @@ def versionJavaFile = 'freenet/node/Version.java'
 sourceSets {
     main {
         java {
-            srcDir 'src/'
+            srcDirs 'src'
+            include '**/*.java'
+            exclude versionJavaFile
+        }
+        resources {
+            srcDirs 'src'
+            include 'freenet/l10n/*properties'
+            include 'freenet/l10n/iso-*.tab'
+            include 'freenet/clients/http/staticfiles/**'
+            include 'freenet/clients/http/templates/**'
         }
     }
     test {
         java {
-            srcDir 'test/'
+            srcDirs 'test'
+            include '**/*.java'
+        }
+        resources {
+            srcDirs 'test'
+            include 'freenet/client/filter/*/**'
+            include 'freenet/crypt/ciphers/rijndael-gladman-test-data/**'
+            include 'freenet/l10n/*properties'
+            include 'freenet/clients/http/templates/**'
         }
     }
 }
@@ -74,10 +91,7 @@ sourceSets {
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
+    withSourcesJar()
 }
 
 tasks.withType(Javadoc) {
@@ -96,90 +110,25 @@ tasks.register('versionSource', Copy) {
     into temporaryDir
 }
 
+extendSourceDirectorySet(sourceSets.main.java, 'version') {
+    // Add the generated version file
+    srcDirs versionSource
+    include versionJavaFile
+}
+
+extendSourceDirectorySet(sourceSets.main.resources, 'dependencies') {
+    // Add `dependencies.properties` from the project root
+    srcDirs projectDir
+    include 'dependencies.properties'
+}
+
 compileJava {
-    // Include generated Version.java in compilation
-    source versionSource
+    options.encoding = 'UTF-8'
 }
 
-tasks.register('buildJar', Jar) {
-    dependsOn processResources
-    from(processResources)
-    from(compileJava.destinationDirectory) {
-        exclude 'freenet/node/Version.class'
-        exclude 'freenet/node/Version$1.class'
-    }
-    preserveFileTimestamps = false
-    reproducibleFileOrder = true
-    duplicatesStrategy = DuplicatesStrategy.FAIL
-    archivesBaseName = "freenet"
-    manifest {
-        attributes("Permissions": "all-permissions")
-        attributes("Application-Name": "Freenet REference Daemon")
-        attributes("Required-Ext-Version": 29)
-        attributes("Recommended-Ext-Version": 29)
-        attributes("Compiled-With": "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})")
-        attributes([
-                       "Specification-Title": "Freenet",
-                       "Specification-Version": "0.7.5",
-                       "Specification-Vendor": "freenetproject.org",
-                       "Implementation-Title": "Freenet",
-                       "Implementation-Version": "0.7.5 ${version}",
-                       "Implementation-Vendor": "freenetproject.org",
-                   ], "common")
-    }
+compileTestJava {
+    options.encoding = 'UTF-8'
 }
-
-jar.enabled = false
-jar.dependsOn buildJar
-
-tasks.register('sourcesJar', Jar) {
-    archiveClassifier = 'sources'
-    preserveFileTimestamps = false
-    reproducibleFileOrder = true
-    from(sourceSets.main.allSource) {
-        exclude 'freenet/node/Version.java'
-    }
-    from(versionSource)
-}
-
-tasks.register('copyResourcesToClasses2') {
-    inputs.files sourceSets.main.allSource
-    outputs.dir layout.buildDirectory.dir("classes/java/main/")
-    doLast {
-        copy {
-            from sourceSets.main.allSource
-            into layout.buildDirectory.dir("classes/java/main/")
-            include 'freenet/l10n/*properties'
-            include 'freenet/l10n/iso-*.tab'
-            include 'freenet/clients/http/staticfiles/**'
-            include 'freenet/clients/http/templates/**'
-            include '../dependencies.properties'
-        }
-        copy {
-            from "${projectDir}/"
-            into layout.buildDirectory.dir("classes/java/main/")
-            include 'dependencies.properties'
-        }
-    }
-}
-processResources.dependsOn copyResourcesToClasses2
-
-tasks.register('copyTestResourcesToClasses2') {
-    inputs.files sourceSets.test.allSource
-    outputs.dir layout.buildDirectory.dir("classes/java/test/")
-    doLast {
-        copy {
-            from sourceSets.test.allSource
-            into layout.buildDirectory.dir("classes/java/test/")
-            include 'freenet/client/filter/*/**'
-            include 'freenet/crypt/ciphers/rijndael-gladman-test-data/**'
-            include 'freenet/l10n/*properties'
-            include 'freenet/clients/http/templates/**'
-        }
-    }
-}
-compileTestJava.dependsOn copyResourcesToClasses2
-compileTestJava.dependsOn copyTestResourcesToClasses2
 
 test {
     if(JavaVersion.current() >= JavaVersion.VERSION_1_9) {
@@ -205,12 +154,34 @@ tasks.withType(Test) {
     enableAssertions = false
 }
 
+jar {
+    archiveFileName = 'freenet.jar'
+    manifest {
+        attributes 'Permissions': 'all-permissions'
+        attributes 'Application-Name': 'Freenet REference Daemon'
+        attributes 'Required-Ext-Version': 29
+        attributes 'Recommended-Ext-Version': 29
+        attributes 'Compiled-With': "${System.getProperty('java.version')} (${System.getProperty('java.vendor')})"
+        attributes([
+                'Specification-Title'   : 'Freenet',
+                'Specification-Version' : '0.7.5',
+                'Specification-Vendor'  : 'freenetproject.org',
+                'Implementation-Title'  : 'Freenet',
+                'Implementation-Version': "0.7.5 ${version}",
+                'Implementation-Vendor' : 'freenetproject.org',
+        ], 'common')
+    }
+}
+
+sourcesJar {
+    archiveFileName = 'freenet-sources.jar'
+}
+
 tasks.register('copyRuntimeLibs', Copy) {
     into layout.buildDirectory.dir('output')
     from configurations.runtimeClasspath
     from jar
 }
-copyRuntimeLibs.dependsOn jar
 
 tasks.register('tar', Tar) {
     description = "Build a source release, specifically excluding the build directories and gradle wrapper files"
@@ -260,6 +231,13 @@ tasks.register('archiveDigests') {
 }
 
 tasks.withType(AbstractArchiveTask).configureEach {
+    // Ensure reproducible archives
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+
+    // Fail the build if any file would be overwritten due to duplicates
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+
     // Register the archive for displaying digests at the end of the build
     artifacts.archives archiveFile
     finalizedBy archiveDigests
@@ -279,4 +257,14 @@ String getVersionFromGit() {
         logger.warn('Cannot determine version from git: {}', e.message)
         return '@unknown@'
     }
+}
+
+/**
+ * Add additional sources to a existing source directory. The additional sources can specify their own inclusion/
+ * exclusion patterns independently from the existing sources.
+ */
+void extendSourceDirectorySet(SourceDirectorySet parent, String name, @DelegatesTo(value = SourceDirectorySet) Closure cl) {
+    def child = objects.sourceDirectorySet(name, parent.name)
+    cl.rehydrate(child, cl.owner, cl.thisObject).call()
+    parent.source child
 }

--- a/build.gradle
+++ b/build.gradle
@@ -245,36 +245,29 @@ tasks.withType(Test) {
 }
 
 tasks.register('copyRuntimeLibs', Copy) {
-    into "${buildDir}/output/"
+    into layout.buildDirectory.dir('output')
     from configurations.runtimeClasspath
     from jar
 }
 copyRuntimeLibs.dependsOn jar
 
 tasks.register('tar', Tar) {
-  description = "Build a source release, specifically excluding the build directories and gradle wrapper files"
-  compression = Compression.BZIP2
+    description = "Build a source release, specifically excluding the build directories and gradle wrapper files"
 
-  archiveBaseName = "freenet-sources"
+    from(project.rootDir) {
+        exclude '**/build'
+        exclude 'build'
+        exclude '.gradle'
+    }
+    into 'freenet-sources'
 
-  from(project.rootDir) {
-    exclude '**/build'
-    exclude 'build'
-    exclude '.gradle'
-  }
+    compression = Compression.BZIP2
+    destinationDirectory = layout.buildDirectory
+    archiveFileName = 'freenet-sources.tgz'
 
-  into(archiveBaseName)
-
-  preserveFileTimestamps = true
-  reproducibleFileOrder = true
-
-  // Set destination directory.
-  destinationDirectory = file("${project.buildDir}")
-
-  archiveFileName = "${archiveBaseName}.tgz"
-  doLast { // generate md5 checksum
-    ant.checksum file:"$destinationDirectory/$archiveFileName"
-  }
+    doLast { // generate md5 checksum
+        ant.checksum file: file(archiveFile)
+    }
 }
 
 javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,11 @@ plugins {
     id 'maven-publish'
 }
 
+// Use version from Git if no version is provided
+if (version == DEFAULT_VERSION) {
+    version = versionFromGit
+}
+
 repositories {
     flatDir { dirs uri("${projectDir}/lib") }
     maven {
@@ -37,7 +42,6 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'org.freenetproject'
             artifactId = 'fred'
-            version = gitrev
             from components.java
         }
     }
@@ -52,8 +56,7 @@ publishing {
     }
 }
 
-def version_buildir = file("$projectDir/build/tmp/compileVersion/")
-def version_src = 'freenet/node/Version.java'
+def versionJavaFile = 'freenet/node/Version.java'
 
 sourceSets {
     main {
@@ -65,17 +68,6 @@ sourceSets {
         java {
             srcDir 'test/'
         }
-    }
-}
-
-def gitrev
-tasks.register('buildInfo') {
-    try {
-        def cmd = "git describe --always --abbrev=4 --dirty"
-        def proc = cmd.execute([], project.rootDir)
-        gitrev = proc.text.trim()
-    } catch (IOException ignored) {
-        gitrev = "@unknown@"
     }
 }
 
@@ -92,35 +84,30 @@ tasks.withType(Javadoc) {
     options.encoding = "UTF-8"
 }
 
-tasks.register('generateVersionSource', Copy) {
-    dependsOn buildInfo
+tasks.register('versionSource', Copy) {
+    inputs.property('version', version)
     from(sourceSets.main.java.srcDirs) {
-        include version_src
-        filter {
-            String line -> line.replaceAll('@custom@', gitrev)
-        }
+        include versionJavaFile
     }
-    into version_buildir
+    filteringCharset = 'UTF-8'
+    filter {
+        line -> line.replaceAll('@custom@', inputs.properties.version as String)
+    }
+    into temporaryDir
 }
 
-tasks.register('compileVersion', JavaCompile) {
-    dependsOn generateVersionSource, compileJava
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
-    source = version_buildir
-    include version_src
-    classpath = files(sourceSets.main.compileClasspath, sourceSets.main.output.classesDirs)
-    destinationDirectory.set(layout.buildDirectory.dir("java/version/").get())
+compileJava {
+    // Include generated Version.java in compilation
+    source versionSource
 }
 
 tasks.register('buildJar', Jar) {
-    dependsOn compileVersion, processResources
+    dependsOn processResources
     from(processResources)
     from(compileJava.destinationDirectory) {
         exclude 'freenet/node/Version.class'
         exclude 'freenet/node/Version$1.class'
     }
-    from(compileVersion.destinationDirectory)
     preserveFileTimestamps = false
     reproducibleFileOrder = true
     duplicatesStrategy = DuplicatesStrategy.FAIL
@@ -136,7 +123,7 @@ tasks.register('buildJar', Jar) {
                        "Specification-Version": "0.7.5",
                        "Specification-Vendor": "freenetproject.org",
                        "Implementation-Title": "Freenet",
-                       "Implementation-Version": "0.7.5 ${gitrev}",
+                       "Implementation-Version": "0.7.5 ${version}",
                        "Implementation-Vendor": "freenetproject.org",
                    ], "common")
     }
@@ -146,14 +133,13 @@ jar.enabled = false
 jar.dependsOn buildJar
 
 tasks.register('sourcesJar', Jar) {
-    dependsOn generateVersionSource
     archiveClassifier = 'sources'
     preserveFileTimestamps = false
     reproducibleFileOrder = true
     from(sourceSets.main.allSource) {
         exclude 'freenet/node/Version.java'
     }
-    from(compileVersion.source)
+    from(versionSource)
 }
 
 tasks.register('copyResourcesToClasses2') {
@@ -177,7 +163,6 @@ tasks.register('copyResourcesToClasses2') {
     }
 }
 processResources.dependsOn copyResourcesToClasses2
-compileVersion.dependsOn copyResourcesToClasses2
 
 tasks.register('copyTestResourcesToClasses2') {
     inputs.files sourceSets.test.allSource
@@ -278,4 +263,20 @@ tasks.withType(AbstractArchiveTask).configureEach {
     // Register the archive for displaying digests at the end of the build
     artifacts.archives archiveFile
     finalizedBy archiveDigests
+}
+
+/**
+ * Try to obtain the version description from `git describe`.
+ */
+String getVersionFromGit() {
+    try {
+        def process = 'git describe --always --abbrev=4 --dirty'.execute([], project.rootDir)
+        if (process.waitFor() != 0) {
+            throw new IOException("exit code ${process.exitValue()}")
+        }
+        return process.text.trim()
+    } catch (IOException e) {
+        logger.warn('Cannot determine version from git: {}', e.message)
+        return '@unknown@'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 repositories {
     flatDir { dirs uri("${projectDir}/lib") }
     maven {
-        url 'https://mvn.freenetproject.org'
+        url = 'https://mvn.freenetproject.org'
         metadataSources {
             artifact()
         }
@@ -35,18 +35,18 @@ dependencies {
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId 'org.freenetproject'
-            artifactId 'fred'
-            version gitrev
+            groupId = 'org.freenetproject'
+            artifactId = 'fred'
+            version = gitrev
             from components.java
         }
     }
     repositories {
         maven {
-            url 's3://mvn.freenetproject.org/'
+            url = 's3://mvn.freenetproject.org/'
             credentials(AwsCredentials) {
-                accessKey System.getenv('AWS_ACCESS_KEY_ID')
-                secretKey System.getenv('AWS_SECRET_ACCESS_KEY')
+                accessKey = System.getenv('AWS_ACCESS_KEY_ID')
+                secretKey = System.getenv('AWS_SECRET_ACCESS_KEY')
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,42 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.59'
+    implementation 'net.java.dev.jna:jna:4.5.2'
+    implementation 'net.java.dev.jna:jna-platform:4.5.2'
+    implementation 'org.freenetproject:freenet-ext:29'
+    implementation 'io.pebbletemplates:pebble:3.1.5'
+    // dependencies of pebble
+    implementation 'org.unbescape:unbescape:1.1.6.RELEASE'
+    implementation 'org.slf4j:slf4j-api:1.7.25'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:1.9.5'
+    testImplementation 'org.hamcrest:hamcrest:3.0'
+    testImplementation 'org.objenesis:objenesis:1.0'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId 'org.freenetproject'
+            artifactId 'fred'
+            version gitrev
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url 's3://mvn.freenetproject.org/'
+            credentials(AwsCredentials) {
+                accessKey System.getenv('AWS_ACCESS_KEY_ID')
+                secretKey System.getenv('AWS_SECRET_ACCESS_KEY')
+            }
+        }
+    }
+}
+
 def version_buildir = file("$projectDir/build/tmp/compileVersion/")
 def version_src = 'freenet/node/Version.java'
 
@@ -208,49 +244,12 @@ tasks.withType(Test) {
     enableAssertions = false
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            groupId 'org.freenetproject'
-            artifactId "fred"
-            version gitrev
-            from components.java
-        }
-    }
-    repositories {
-        maven {
-            url "s3://mvn.freenetproject.org/"
-            credentials(AwsCredentials) {
-                accessKey System.getenv('AWS_ACCESS_KEY_ID')
-                secretKey System.getenv('AWS_SECRET_ACCESS_KEY')
-            }
-        }
-    }
-}
-
 task copyRuntimeLibs(type: Copy) {
     into "${buildDir}/output/"
     from configurations.runtimeClasspath
     from jar
 }
 copyRuntimeLibs.dependsOn jar
-
-// In this section you declare the dependencies for your production and test code
-dependencies {
-    implementation "org.bouncycastle:bcprov-jdk15on:1.59"
-    implementation "net.java.dev.jna:jna:4.5.2"
-    implementation "net.java.dev.jna:jna-platform:4.5.2"
-    implementation "org.freenetproject:freenet-ext:29"
-    implementation "io.pebbletemplates:pebble:3.1.5"
-    // dependencies of pebble
-    implementation "org.unbescape:unbescape:1.1.6.RELEASE"
-    implementation "org.slf4j:slf4j-api:1.7.25"
-
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.mockito:mockito-core:1.9.5"
-    testImplementation "org.hamcrest:hamcrest:3.0"
-    testImplementation "org.objenesis:objenesis:1.0"
-}
 
 task tar(type: Tar) {
   description = "Build a source release, specifically excluding the build directories and gradle wrapper files"

--- a/build.gradle
+++ b/build.gradle
@@ -156,30 +156,6 @@ tasks.register('sourcesJar', Jar) {
     from(compileVersion.source)
 }
 
-def jars = []
-gradle.addListener(new TaskExecutionListener() {
-void afterExecute(Task task, TaskState state) {
-    if(task in AbstractArchiveTask && task.enabled) {
-        jars << task.outputs.files.singleFile
-    }
-}
-
-void beforeExecute(Task task) { }
-})
-gradle.addBuildListener(new BuildAdapter() {
-    void buildFinished(BuildResult result) {
-        if(jars) {
-            def hash = {
-                File file -> def sha256 = MessageDigest.getInstance('SHA-256')
-                file.eachByte(1024 * 4) { buffer, len -> sha256.update(buffer, 0, len) }
-                println "SHA-256 of ${file.name}: ${sha256.digest().encodeHex().toString()}"
-            }
-
-            jars.each { hash(it) }
-        }
-    }
-})
-
 tasks.register('copyResourcesToClasses2') {
     inputs.files sourceSets.main.allSource
     outputs.dir layout.buildDirectory.dir("classes/java/main/")
@@ -208,8 +184,8 @@ tasks.register('copyTestResourcesToClasses2') {
     outputs.dir layout.buildDirectory.dir("classes/java/test/")
     doLast {
         copy {
-	    from sourceSets.test.allSource
-	    into layout.buildDirectory.dir("classes/java/test/")
+            from sourceSets.test.allSource
+            into layout.buildDirectory.dir("classes/java/test/")
             include 'freenet/client/filter/*/**'
             include 'freenet/crypt/ciphers/rijndael-gladman-test-data/**'
             include 'freenet/l10n/*properties'
@@ -274,4 +250,32 @@ javadoc {
     doLast {
         failOnError false
     }
+}
+
+tasks.register('archiveDigests') {
+    description = 'Display SHA-256 digests of all archives that were created.'
+    group = 'Help'
+
+    // Do not declare dependencies, we'll print whatever is available
+    def artifacts = configurations.archives.artifacts
+
+    // Run this task at the end of the build
+    shouldRunAfter tasks
+
+    // Print SHA256 digests of all available archive artifacts
+    doLast {
+        def sha256 = MessageDigest.getInstance('SHA-256')
+        artifacts.files.files.findAll {
+            it.canRead()
+        }.each { file ->
+            file.eachByte(1024 * 4) { buffer, len -> sha256.update(buffer, 0, len) }
+            logger.lifecycle('SHA-256 of {}: {}', file.name, sha256.digest().encodeHex())
+        }
+    }
+}
+
+tasks.withType(AbstractArchiveTask).configureEach {
+    // Register the archive for displaying digests at the end of the build
+    artifacts.archives archiveFile
+    finalizedBy archiveDigests
 }

--- a/build.gradle
+++ b/build.gradle
@@ -92,10 +92,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     withSourcesJar()
-}
-
-tasks.withType(Javadoc) {
-    options.encoding = "UTF-8"
+    withJavadocJar()
 }
 
 tasks.register('versionSource', Copy) {
@@ -154,6 +151,16 @@ tasks.withType(Test) {
     enableAssertions = false
 }
 
+javadoc {
+    title = "Freenet REference Daemon ${version}"
+    options {
+        encoding = 'UTF-8'
+        source = java.sourceCompatibility
+        // Ignore Javadoc linting errors
+        addBooleanOption('Xdoclint:none', true)
+    }
+}
+
 jar {
     archiveFileName = 'freenet.jar'
     manifest {
@@ -175,6 +182,10 @@ jar {
 
 sourcesJar {
     archiveFileName = 'freenet-sources.jar'
+}
+
+javadocJar {
+    archiveFileName = 'freenet-javadoc.jar'
 }
 
 tasks.register('copyRuntimeLibs', Copy) {
@@ -209,12 +220,6 @@ tasks.register('tar', Tar) {
 
     doLast { // generate md5 checksum
         ant.checksum file: file(archiveFile)
-    }
-}
-
-javadoc {
-    doLast {
-        failOnError false
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,14 @@
 import java.security.MessageDigest
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
-    }
+plugins {
+    id 'java'
+    id 'maven-publish'
 }
 
 configurations {
     provided
     compile
 }
-
-apply plugin: 'java'
-apply plugin: 'maven-publish'
 
 repositories {
     flatDir { dirs uri("${projectDir}/lib") }

--- a/build.gradle
+++ b/build.gradle
@@ -128,27 +128,19 @@ compileTestJava {
 }
 
 test {
-    if(JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
         jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/java.io=ALL-UNNAMED'
         jvmArgs '--add-opens=java.base/java.util.zip=ALL-UNNAMED'
     }
-    minHeapSize = "128m"
-    maxHeapSize = "512m"
-    // no inner class
+    useJUnit()
+    minHeapSize = '128m'
+    maxHeapSize = '512m'
+    // Do not run inner classes, they are registered as part of a Suite
     include 'freenet/**/*Test.class'
     exclude 'freenet/**/*$*Test.class'
     scanForTestClasses = false
-    systemProperties += [
-//	"test.extensive":
-//	"test.verbose":
-//	"test.benchmark":
-    ]
-}
-
-tasks.withType(Test) {
-    enableAssertions = false
 }
 
 javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
 }
 
-// Use version from Git if no version is provided
+// Use version from Git if no version is provided (using `-Pversion=buildXXXXX`)
 if (version == DEFAULT_VERSION) {
     version = versionFromGit
 }
@@ -121,6 +121,11 @@ extendSourceDirectorySet(sourceSets.main.resources, 'dependencies') {
 
 compileJava {
     options.encoding = 'UTF-8'
+    if (!version.endsWith('-dirty')) {
+        // Make sure incremental compilation is disabled on release builds due to reproducibility issues.
+        logger.lifecycle('Potential release build (project version not dirty). Incremental compilation disabled.')
+        options.incremental = false
+    }
 }
 
 compileTestJava {

--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,12 @@ tasks.register('copyRuntimeLibs', Copy) {
     from jar
 }
 
+assemble {
+    // Add copyRuntimeLibs so `gradlew assemble` collects all build artifacts (except tar).
+    // Note: jar, sourcesJar, javadocJar are added as dependency by default.
+    dependsOn copyRuntimeLibs
+}
+
 tasks.register('tar', Tar) {
     description = 'Build a source release, specifically excluding the build directories and gradle wrapper files.'
     group = 'Build'

--- a/debian/rules
+++ b/debian/rules
@@ -32,7 +32,6 @@ clean:
 	rm -rf .gradle gradle/wrapper/dists debian/freenet
 
 override_dh_auto_build: build_seed_file
-	./gradlew jar; \
 	./gradlew copyRuntimeLibs
 
 	sed -e 's/@version@/$(FREENET_VERSION)/' -e 's/@build@/$(FREENET_BUILD)/' $(CURDIR)/debian/freenet.service.params | \


### PR DESCRIPTION
Our Gradle build is using various deprecated options and features (syntax, conventions and properties), and has various custom tasks for what is supposed to be standard Gradle functionality (such as dealing with sources, compilation, resources copying, and JARs). Additionally, the source version (in Version.java) was not always updated appropriately unless a `clean` build was done.

Overhaul the `build.gradle` configuration to get rid of deprecation warnings & make it more maintainable.
Additionally, improve the following:
* Always update the Version.java when the Git version changes.
* Allow overriding the build version using the version Gradle parameter (`-PbuildXXXXX`)
* Disable incremental builds when for non-dirty builds. Those could be release builds, and incremental builds are not reproducible.
* Generate a sources JAR and Javadoc JAR on `gradlew assemble`.

@ArneBab could you please check that this did not break your release manager workflow?